### PR TITLE
Fix Black version in GitHub actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
-      - uses: psf/black@22
+      - uses: psf/black@v22.12.0
         with:
           options: ". -l 79 --check"
   check-version:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
-      - uses: psf/black@v22.12.0
+      - uses: psf/black@22.12.0
         with:
           options: ". -l 79 --check"
   check-version:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
-      - uses: psf/black@stable
+      - uses: psf/black@22
         with:
           options: ". -l 79 --check"
   check-version:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Fix Black version

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Flask-Caching==2.0.2",
         "urllib3<1.27,>=1.21.1",
         "python-dotenv",
-        "black@22.12.0",  # This is because policyengine_canada uses black<23
+        "black==22.12.0",  # This is because policyengine_canada uses black<23
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Flask-Caching==2.0.2",
         "urllib3<1.27,>=1.21.1",
         "python-dotenv",
-        "black<23",  # This is because policyengine_canada uses black<23
+        "black@22.12.0",  # This is because policyengine_canada uses black<23
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "Flask-Caching==2.0.2",
         "urllib3<1.27,>=1.21.1",
         "python-dotenv",
+        "black<23",  # This is because policyengine_canada uses black<23
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Fixes #66. Pins Black at <23 to avoid dependency conflict and ensure proper linting in GitHub actions.