### PR TITLE
Remove final `@clients` from `client_id` parameter of JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/*
 **/*.h5
 **/*.csv.gz
 .env
+.ds_store

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install:
 	pip install -e .[dev]
 
 debug:
-	FLASK_APP=policyengine_household_api.api FLASK_DEBUG=1 flask run --without-threads -p 5050
+	FLASK_APP=policyengine_household_api.api FLASK_DEBUG=1 flask run --without-threads
 
 test:
 	pytest -vv --timeout=150 -rP tests

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Removed the '@clients' parameter from the client_id portion of the JWT

--- a/policyengine_household_api/decorators/analytics.py
+++ b/policyengine_household_api/decorators/analytics.py
@@ -20,6 +20,9 @@ def log_analytics(func):
         token = auth_header.split(" ")[1]
         decoded_token = jwt.decode(token, options={"verify_signature": False})
         client_id = decoded_token["sub"]
+        suffix_to_slice = "@clients"
+        if client_id[-len(suffix_to_slice):] == suffix_to_slice:
+            client_id = client_id[:-len(suffix_to_slice)]
         new_visit.client_id = client_id
 
         # Set API version

--- a/policyengine_household_api/decorators/analytics.py
+++ b/policyengine_household_api/decorators/analytics.py
@@ -21,7 +21,10 @@ def log_analytics(func):
         decoded_token = jwt.decode(token, options={"verify_signature": False})
         client_id = decoded_token["sub"]
         suffix_to_slice = "@clients"
-        if len(client_id) >= len(suffix_to_slice) and client_id[-len(suffix_to_slice) :] == suffix_to_slice:
+        if (
+            len(client_id) >= len(suffix_to_slice)
+            and client_id[-len(suffix_to_slice) :] == suffix_to_slice
+        ):
             client_id = client_id[: -len(suffix_to_slice)]
         new_visit.client_id = client_id
 

--- a/policyengine_household_api/decorators/analytics.py
+++ b/policyengine_household_api/decorators/analytics.py
@@ -21,7 +21,7 @@ def log_analytics(func):
         decoded_token = jwt.decode(token, options={"verify_signature": False})
         client_id = decoded_token["sub"]
         suffix_to_slice = "@clients"
-        if client_id[-len(suffix_to_slice) :] == suffix_to_slice:
+        if len(client_id) >= len(suffix_to_slice) and client_id[-len(suffix_to_slice) :] == suffix_to_slice:
             client_id = client_id[: -len(suffix_to_slice)]
         new_visit.client_id = client_id
 

--- a/policyengine_household_api/decorators/analytics.py
+++ b/policyengine_household_api/decorators/analytics.py
@@ -21,8 +21,8 @@ def log_analytics(func):
         decoded_token = jwt.decode(token, options={"verify_signature": False})
         client_id = decoded_token["sub"]
         suffix_to_slice = "@clients"
-        if client_id[-len(suffix_to_slice):] == suffix_to_slice:
-            client_id = client_id[:-len(suffix_to_slice)]
+        if client_id[-len(suffix_to_slice) :] == suffix_to_slice:
+            client_id = client_id[: -len(suffix_to_slice)]
         new_visit.client_id = client_id
 
         # Set API version


### PR DESCRIPTION
This PR removes the trailing `@clients` added to the client_id parameter taken from the decoded JWT whenever an authenticated user visits the API. This value creates challenges for later analysis and is not expected to be a portion of the `client_id` value, as it's merely tacked on by either auth0 upon JWT formation or Flask upon request decoding.