### PR TITLE
Added calculate_demo endpoint for use on API documentation page

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Added calculate_demo endpoint for use on API documentation page

--- a/policyengine_household_api/api.py
+++ b/policyengine_household_api/api.py
@@ -12,6 +12,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import DeclarativeBase
 from dotenv import load_dotenv
 from authlib.integrations.flask_oauth2 import ResourceProtector
+from ratelimiter import RateLimiter
 
 # Internal imports
 from .auth.validation import Auth0JWTBearerTokenValidator
@@ -90,6 +91,12 @@ def readiness_check():
     return flask.Response(
         "OK", status=200, headers={"Content-Type": "text/plain"}
     )
+
+
+@app.route("/<country_id>/calculate_demo", methods=["POST"])
+@RateLimiter(max_calls=1, period=1)
+def calculate_demo(country_id):
+    return get_calculate(country_id)
 
 
 print("API initialised.")

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "python-dotenv",
         "pymysql",
         "black==22.12.0",  # This is because policyengine_canada uses black<23
-        "ratelimiter"
+        "ratelimiter",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "python-dotenv",
         "pymysql",
         "black==22.12.0",  # This is because policyengine_canada uses black<23
+        "ratelimiter"
     ],
     extras_require={
         "dev": [

--- a/tests/python/test_calculate_demo.py
+++ b/tests/python/test_calculate_demo.py
@@ -1,0 +1,29 @@
+import pytest
+import os
+from .utils import client
+from policyengine_household_api.api import app
+
+
+class TestCalculateDemo:
+    def test_calc_demo():
+        """
+        Ensure that calculate_demo properly calculates;
+        the rate limiter does not return a 4xx, but instead
+        waits until the rate limit has ended, preventing the
+        need for a further test
+        """
+
+        response = client.post(
+            "/us/calculate",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer "
+                + os.getenv("AUTH0_TEST_TOKEN_NO_DOMAIN"),
+            },
+            data=open(
+                "./tests/python/data/calculate_us_1_data.json",
+                "r",
+                encoding="utf-8",
+            ),
+        )
+        assert response.status_code == 200, response.text

--- a/tests/python/test_calculate_demo.py
+++ b/tests/python/test_calculate_demo.py
@@ -1,29 +1,25 @@
 import pytest
 import os
-from .utils import client
+from tests.python.utils import client
 from policyengine_household_api.api import app
 
+def test_calc_demo(client):
+    """
+    Ensure that calculate_demo properly calculates;
+    the rate limiter does not return a 4xx, but instead
+    waits until the rate limit has ended, preventing the
+    need for a further test
+    """
 
-class TestCalculateDemo:
-    def test_calc_demo():
-        """
-        Ensure that calculate_demo properly calculates;
-        the rate limiter does not return a 4xx, but instead
-        waits until the rate limit has ended, preventing the
-        need for a further test
-        """
-
-        response = client.post(
-            "/us/calculate",
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": "Bearer "
-                + os.getenv("AUTH0_TEST_TOKEN_NO_DOMAIN"),
-            },
-            data=open(
-                "./tests/python/data/calculate_us_1_data.json",
-                "r",
-                encoding="utf-8",
-            ),
-        )
-        assert response.status_code == 200, response.text
+    response = client.post(
+        "/us/calculate_demo",
+        headers={
+            "Content-Type": "application/json",
+        },
+        data=open(
+            "./tests/python/data/calculate_us_1_data.json",
+            "r",
+            encoding="utf-8",
+        ),
+    )
+    assert response.status_code == 200, response.text

--- a/tests/python/test_calculate_demo.py
+++ b/tests/python/test_calculate_demo.py
@@ -3,6 +3,7 @@ import os
 from tests.python.utils import client
 from policyengine_household_api.api import app
 
+
 def test_calc_demo(client):
     """
     Ensure that calculate_demo properly calculates;


### PR DESCRIPTION
Fixes #73. This adds the `calculate_demo` endpoint, rate limited at 1 total request among all users per second, to allow for the easy display and demonstration of the standard `calculate` endpoint within API documenation.