### PR TITLE
Fix reference to main branch in bump_country_package

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Fixed main branch reference in bump_country_package

--- a/gcp/bump_country_package.py
+++ b/gcp/bump_country_package.py
@@ -73,7 +73,7 @@ def bump_country_package(country, version):
     os.system(f"git push -u origin {branch_name} -f")
     # Create a pull request using the GitHub CLI
     os.system(
-        f"gh pr create --title 'Update {country_package_full_name} to {version}' --body 'Update {country_package_full_name} to {version}' --base master --head {branch_name}"
+        f"gh pr create --title 'Update {country_package_full_name} to {version}' --body 'Update {country_package_full_name} to {version}' --base main --head {branch_name}"
     )
 
 


### PR DESCRIPTION
This repairs automatic country package deployment by fixing the `bump_country_package` file's reference to the `main` branch. This script was originally taken from the API package, the default branch of which is `master`, and this value was not changed upon addition to the household API.