### PR TITLE
Allow GH Actions to use earlier version of glibc

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,9 @@ name: Pull request
 
 on: pull_request
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   Lint:
     runs-on: ubuntu-latest

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Allow GitHub Actions to use earlier version of glibc


### PR DESCRIPTION
Fixes #146.

PR allows GitHub Actions to use earlier versions of `glibc`, a dependency for almost every LTS version of Ubuntu (of which, we launch off 22.04), standard support for which was removed within GitHub Actions runs that don't include an environment variable to enable them.