### PR TITLE
Update Docker image path

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Updated Docker image path

--- a/gcp/policyengine_household_api/Dockerfile
+++ b/gcp/policyengine_household_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM anthvolk/policyengine-household-api:latest
+FROM policyengine/policyengine-household-api:latest
 ENV GOOGLE_APPLICATION_CREDENTIALS .gac.json
 ENV AUTH0_ADDRESS_NO_DOMAIN .address
 ENV AUTH0_AUDIENCE_NO_DOMAIN .audience


### PR DESCRIPTION
Fixes #233 

PR updates Docker image path within the Dockerfile that builds on top of the template Docker image