### PR TITLE
Update GCP Dockerfile

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.repository == 'PolicyEngine/policyengine-uk')
-      && (github.event.head_commit.message == 'Update PolicyEngine API')
+      && (github.event.head_commit.message == 'Update PolicyEngine Household API')
     steps:
       - uses: actions/checkout@v3
       - name: Check formatting
@@ -24,7 +24,7 @@ jobs:
     name: Update versioning
     if: |
       (github.repository == 'PolicyEngine/policyengine-household-api')
-      && !(github.event.head_commit.message == 'Update PolicyEngine API')
+      && !(github.event.head_commit.message == 'Update PolicyEngine Household API')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -47,13 +47,13 @@ jobs:
           add: "."
           committer_name: Github Actions[bot]
           author_name: Github Actions[bot]
-          message: Update PolicyEngine API
+          message: Update PolicyEngine Household API
   deploy:
     name: Deploy API
     runs-on: ubuntu-latest
     if: |
       (github.repository == 'PolicyEngine/policyengine-household-api')
-      && (github.event.head_commit.message == 'Update PolicyEngine API')
+      && (github.event.head_commit.message == 'Update PolicyEngine Household API')
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Updated GCP Dockerfile to properly support launching off of start.sh

--- a/gcp/policyengine_household_api/Dockerfile
+++ b/gcp/policyengine_household_api/Dockerfile
@@ -1,11 +1,23 @@
 FROM policyengine/policyengine-household-api:latest
+
 ENV GOOGLE_APPLICATION_CREDENTIALS .gac.json
+ENV 
 ENV AUTH0_ADDRESS_NO_DOMAIN .address
 ENV AUTH0_AUDIENCE_NO_DOMAIN .audience
 ENV AUTH0_TEST_TOKEN_NO_DOMAIN .test-token
-ENV USER_ANALYTICS_DB_PASSWORD .dbpw
 ENV USER_ANALYTICS_DB_USERNAME .dbuser
+ENV USER_ANALYTICS_DB_PASSWORD .dbpw
 ENV USER_ANALYTICS_DB_CONNECTION_NAME .dbconn
+
+WORKDIR /app
+
+# Copy application
 ADD . /app
+
+# Make start.sh executable
+RUN chmod +x /app/start.sh
+
 RUN cd /app && make install && make test
-CMD ./start.sh 
+
+# Use full path to start.sh
+CMD ["/bin/sh", "/app/start.sh"]


### PR DESCRIPTION
Fixes #235 
Fixes #237 

Updates GCP launch Dockerfile to properly execute `start.sh`.