### PR TITLE
Fix empty call to ENV in Dockerfile

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,3 +1,4 @@
 - bump: patch
   changes:
     changed:
+    - Removed empty ENV call in Dockerfile

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,3 @@
+- bump: patch
+  changes:
+    changed:

--- a/gcp/policyengine_household_api/Dockerfile
+++ b/gcp/policyengine_household_api/Dockerfile
@@ -1,7 +1,6 @@
 FROM policyengine/policyengine-household-api:latest
 
 ENV GOOGLE_APPLICATION_CREDENTIALS .gac.json
-ENV 
 ENV AUTH0_ADDRESS_NO_DOMAIN .address
 ENV AUTH0_AUDIENCE_NO_DOMAIN .audience
 ENV AUTH0_TEST_TOKEN_NO_DOMAIN .test-token


### PR DESCRIPTION
Fixes #241 by removing the erroneous empty call to ENV in the Dockerfile
