### PR TITLE
Update PolicyEngine US to 1.96.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update PolicyEngine US to 1.96.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "policyengine-ng==0.5.1",
         "policyengine-il==0.1.0",
         "policyengine_uk==1.8.0",
-        "policyengine_us==1.85.4",
+        "policyengine_us==1.96.0",
         "pyjwt",
         "Flask-Caching==2.0.2",
         "urllib3<1.27,>=1.21.1",


### PR DESCRIPTION
Update PolicyEngine US to 1.96.0