### PR TITLE
Update PolicyEngine UK to 2.18.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update PolicyEngine UK to 2.18.0


### PR DESCRIPTION
Update PolicyEngine UK to 2.18.0