### PR TITLE
Loosen country household entities, change year to period in variable filter

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,7 @@
+- bump: patch
+  changes:
+    added:
+    - Customer test for Benefits Navigator
+    changed:
+    - Loosened schema requirements for US- and UK-specific entities
+    - Changed "year" to string-based "period" for filtering variables from household

--- a/policyengine_household_api/models/household.py
+++ b/policyengine_household_api/models/household.py
@@ -49,14 +49,14 @@ class HouseholdModelGeneric(BaseModel):
 
 
 class HouseholdModelUS(HouseholdModelGeneric):
-    families: dict[str, HouseholdEntity]
-    spm_units: dict[str, HouseholdEntity]
-    tax_units: dict[str, HouseholdEntity]
-    marital_units: dict[str, HouseholdEntity]
+    families: Optional[dict[str, HouseholdEntity]] = {}
+    spm_units: Optional[dict[str, HouseholdEntity]] = {}
+    tax_units: Optional[dict[str, HouseholdEntity]] = {}
+    marital_units: Optional[dict[str, HouseholdEntity]] = {}
 
 
 class HouseholdModelUK(HouseholdModelGeneric):
-    benunits: dict[str, HouseholdEntity]
+    benunits: Optional[dict[str, HouseholdEntity]] = {}
 
 
 # Typing alias for all three possible household models

--- a/policyengine_household_api/utils/household.py
+++ b/policyengine_household_api/utils/household.py
@@ -12,13 +12,13 @@ class FlattenedVariable(BaseModel):
     entity_group: str
     entity: str
     variable: str
-    year: int
+    period: int | str
     value: Any
 
 
 @dataclass
 class FlattenedVariableFilter:
-    filter_on: Literal["entity_group", "entity", "variable", "year", "value"]
+    filter_on: Literal["entity_group", "entity", "variable", "period", "value"]
     desired_value: Any
 
 
@@ -44,7 +44,7 @@ def flatten_variables_from_household(
             for variable in household_dict[entity_group][entity].keys():
                 if variable in VARIABLE_BLACKLIST:
                     continue
-                for year in household_dict[entity_group][entity][
+                for period in household_dict[entity_group][entity][
                     variable
                 ].keys():
                     new_pair = FlattenedVariable.model_validate(
@@ -52,10 +52,10 @@ def flatten_variables_from_household(
                             "entity_group": entity_group,
                             "entity": entity,
                             "variable": variable,
-                            "year": int(year),
+                            "period": period,
                             "value": household_dict[entity_group][entity][
                                 variable
-                            ][year],
+                            ][period],
                         }
                     )
 
@@ -78,14 +78,16 @@ def flatten_variables_from_household(
 
 def filter_flattened_variables(
     flattened_variables: list[FlattenedVariable],
-    filter_on: Literal["entity_group", "entity", "variable", "year", "value"],
+    filter_on: Literal[
+        "entity_group", "entity", "variable", "period", "value"
+    ],
     desired_value: Any,
 ) -> list[FlattenedVariable]:
     """
     Filter parsed variables by a key-value pair.
     Args:
         flattened_variables (list[FlattenedVariable]): The parsed variables.
-        key (Literal["entity_group", "entity", "variable", "year"]): The key to filter by.
+        key (Literal["entity_group", "entity", "variable", "period"]): The key to filter by.
         value (Any): The value to filter by.
     Returns:
         list[FlattenedVariable]: The filtered parsed variables.

--- a/tests/data/customer_households/__init__.py
+++ b/tests/data/customer_households/__init__.py
@@ -1,1 +1,2 @@
 from .my_friend_ben import my_friend_ben_household
+from .benefits_navigator import benefits_navigator_household

--- a/tests/data/customer_households/benefits_navigator.py
+++ b/tests/data/customer_households/benefits_navigator.py
@@ -1,0 +1,88 @@
+benefits_navigator_household = {
+    "households": {
+        "household": {
+            "zip_code": {"2025": "90101"},
+            "lives_in_vehicle": {"2025": False},
+            "members": ["you"],
+            "ca_care": {"2025": None},
+            "ca_care_eligible": {"2025": None},
+            "ca_fera": {"2025": None},
+            "ca_fera_eligible": {"2025": None},
+            "ca_tanf_region1": {"2025": True},
+            "state_code_str": {"2025": "CA"},
+            "ca_la_ez_save": {"2025-3": None},
+            "ca_la_ez_save_eligible": {"2025-3": None},
+            "in_la": {"2025": True},
+        }
+    },
+    "people": {
+        "you": {
+            "age": {"2025": 19},
+            "was_in_foster_care": {"2025": True},
+            "immigration_status_str": {"2025": "CITIZEN"},
+            "employment_income": {"2025": 1111},
+            "medical_out_of_pocket_expenses": {"2025": 132},
+            "rent": {"2025": 1332},
+            "is_aca_eshi_eligible": {"2025": False},
+            "is_pregnant": {"2025": True},
+            "ca_calworks_child_care_time_category": {"2025": "MONTHLY"},
+            "ca_la_expectant_parent_payment_eligible": {"2025-3": None},
+            "ca_la_expectant_parent_payment": {"2025-3": None},
+            "ca_foster_care_minor_dependent": {"2025-3": None},
+            "current_pregnancy_month": {"2025-3": 9},
+            "is_in_foster_care": {"2025-3": True},
+            "medicaid": {"2025": None},
+            "is_medicaid_eligible": {"2025": None},
+            "wic": {"2025": None},
+            "is_aca_ptc_eligible": {"2025": None},
+            "is_ssi_aged": {"2025": None},
+        }
+    },
+    "tax_units": {
+        "tax_unit": {
+            "tax_unit_is_joint": {"2025": False},
+            "members": ["you"],
+            # There may be a bug in aca_ptc/premium_tax_credit;
+            # this currently just returns None in testing;
+            # un-comment when we can confirm that's running smoothly
+            # "premium_tax_credit": { "2025": None },
+            "eitc": {"2025": None},
+            "eitc_eligible": {"2025": None},
+            "ca_eitc": {"2025": None},
+            "ca_eitc_eligible": {"2025": None},
+            "ctc": {"2025": None},
+            "refundable_ctc": {"2025": None},
+            "ca_yctc": {"2025": None},
+            "aca_ptc_ca": {"2025": None},
+            "ca_renter_credit": {"2025": None},
+            "cdcc": {"2025": None},
+            "ca_cdcc": {"2025": None},
+            "ca_foster_youth_tax_credit": {"2025": None},
+            "income_tax_before_credits": {"2025": None},
+            "income_tax_before_refundable_credits": {"2025": None},
+            "income_tax_refundable_credits": {"2025": None},
+            "income_tax_capped_non_refundable_credits": {"2025": None},
+            "income_tax_non_refundable_credits": {"2025": None},
+            "income_tax": {"2025": None},
+            "ca_income_tax_before_credits": {"2025": None},
+            "ca_income_tax_before_refundable_credits": {"2025": None},
+        }
+    },
+    "families": {"family": {"members": ["you"]}},
+    "spm_units": {
+        "spm_unit": {
+            "members": ["you"],
+            "ca_tanf": {"2025": None},
+            "ca_tanf_eligible": {"2025": None},
+            "snap": {"2025": None},
+            "is_snap_eligible": {"2025": None},
+            "lifeline": {"2025": None},
+            "is_lifeline_eligible": {"2025": None},
+            "phone_cost": {"2025": 999},
+            "la_general_relief": {"2025": None},
+            "la_general_relief_eligible": {"2025": None},
+            "ca_calworks_child_care": {"2025": None},
+            "ca_calworks_child_care_eligible": {"2025": None},
+        }
+    },
+}

--- a/tests/data/customer_households/benefits_navigator.py
+++ b/tests/data/customer_households/benefits_navigator.py
@@ -34,7 +34,7 @@ benefits_navigator_household = {
             "medicaid": {"2025": None},
             "is_medicaid_eligible": {"2025": None},
             "wic": {"2025": None},
-            "is_aca_ptc_eligible": {"2025": None},
+            # "is_aca_ptc_eligible": {"2025": None},
             "is_ssi_aged": {"2025": None},
         }
     },
@@ -53,7 +53,7 @@ benefits_navigator_household = {
             "ctc": {"2025": None},
             "refundable_ctc": {"2025": None},
             "ca_yctc": {"2025": None},
-            "aca_ptc_ca": {"2025": None},
+            # "aca_ptc_ca": {"2025": None},
             "ca_renter_credit": {"2025": None},
             "cdcc": {"2025": None},
             "ca_cdcc": {"2025": None},

--- a/tests/integration/test_customer_inputs.py
+++ b/tests/integration/test_customer_inputs.py
@@ -3,7 +3,10 @@ import json
 import os
 from flask import Response
 from typing import Any, List, Tuple
-from tests.data.customer_households import my_friend_ben_household
+from tests.data.customer_households import (
+    my_friend_ben_household,
+    benefits_navigator_household,
+)
 from policyengine_household_api.models.household import HouseholdModelUS
 from policyengine_household_api.utils.household import (
     FlattenedVariableFilter,
@@ -21,8 +24,20 @@ class TestCustomerInputs:
         ],
     )
     def test_my_friend_ben(self, client, household):
+        self.us_household_runner(client, household)
+
+    @pytest.mark.parametrize(
+        "household",
+        [
+            benefits_navigator_household,
+        ],
+    )
+    def test_benefits_navigator(self, client, household):
+        self.us_household_runner(client, household)
+
+    def us_household_runner(self, client, household):
         """
-        Test that household calculations work correctly for 'my_friend_ben' test case.
+        Test that household calculations work correctly for US test cases.
 
         Given a household with some input values and some values to be calculated
         When the calculation API is called with this household

--- a/tests/unit/endpoints/test_household_explainer.py
+++ b/tests/unit/endpoints/test_household_explainer.py
@@ -135,34 +135,6 @@ class TestGenerateAIExplainer:
         results = [obj["response"] for obj in json_objects]
         assert results == mock_claude_result_streaming
 
-    # Test invalid household, missing entity
-    def test_invalid_household_missing_entity(
-        self,
-        client,
-        mock_buffered_output,
-        mock_cloud_download,
-    ):
-        invalid_household = deepcopy(valid_household_requesting_calculation)
-        invalid_household.pop("families")
-
-        request_with_invalid_household = {
-            "computation_tree_uuid": valid_computation_tree_with_indiv_vars_uuid,
-            "household": invalid_household,
-            "use_streaming": False,
-        }
-
-        response = client.post(
-            "/us/ai-analysis",
-            json=request_with_invalid_household,
-            headers=self.auth_headers,
-        )
-
-        response_json = json.loads(response.data)
-        assert response.status_code == 400
-
-        response_json = json.loads(response.data)
-        assert "Error validating household data" in response_json["message"]
-
     # Test invalid household, too many variables are requesting computation
     def test_invalid_household_too_many_variables(
         self,


### PR DESCRIPTION
Fixes #539 

This PR loosens household entity requirements for customers who might not be emitting all household entities when making requests to our API. It also changes "year:int" to "period: year | int" in our variable filtering function. Finally, it adds a test based on a data object provided by Benefits Navigator.