### PR TITLE
Re-enable analytics logging

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Re-enabled automated analytics logging of calculate endpoint

--- a/policyengine_household_api/api.py
+++ b/policyengine_household_api/api.py
@@ -76,6 +76,7 @@ app.route("/", methods=["GET"])(get_home)
 
 @app.route("/<country_id>/calculate", methods=["POST"])
 @require_auth(None)
+@log_analytics
 def calculate(country_id):
     return get_calculate(country_id)
 


### PR DESCRIPTION
Fixes #593.

This PR re-enables automated logging of all inbound requests to the `/calculate` endpoint to allow for correct calculation of costs.