### PR TITLE
Update Docker address

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update Docker build address to use GitHub Container Registry

--- a/gcp/policyengine_household_api/Dockerfile
+++ b/gcp/policyengine_household_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM policyengine/policyengine-household-api:latest
+FROM ghcr.io/policyengine/policyengine-household-api:latest
 
 ENV GOOGLE_APPLICATION_CREDENTIALS .gac.json
 ENV AUTH0_ADDRESS_NO_DOMAIN .address


### PR DESCRIPTION
Fixes #815.

Updates Docker address for main image to use GitHub Container Registry.