### PR TITLE
Switch to using in-memory storage for rate limiting

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
           file: ./Dockerfile.build
           push: true
           tags: |
-            ghcr.io/policyengine/policyengine-household-api:python313
+            ghcr.io/policyengine/policyengine-household-api:python312
             ghcr.io/policyengine/policyengine-household-api:latest
             ghcr.io/policyengine/policyengine-household-api:${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/policyengine/policyengine-household-api:buildcache

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Switched to use of in-memory storage for rate limiting instead of Redis.

--- a/policyengine_household_api/api.py
+++ b/policyengine_household_api/api.py
@@ -43,8 +43,15 @@ app = application = flask.Flask(__name__)
 
 CORS(app)
 
-# Initialize rate limiter
-limiter = Limiter(app=app, key_func=get_remote_address, default_limits=[])
+# Use in-memory storage for rate limiting
+# Note that this provides limits per-instance;
+# rate limits not shared if scaling more than 1 instance.
+limiter = Limiter(
+    app=app,
+    key_func=get_remote_address,
+    default_limits=[],
+    storage_uri="memory://",
+)
 
 # Configure database connection
 if os.getenv("FLASK_DEBUG") == "1":


### PR DESCRIPTION
Fixes #835.

Attempt to get deploy working again by using in-memory storage for rate limiting. Related to #834.