### PR TITLE
Return to using ratelimiter

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Reverted to using 'ratelimiter' instead of 'flask-limiter'.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "python-dotenv",
         "pymysql",
         "black==24.3.0",
-        "Flask-Limiter",
+        "ratelimiter",
         "pydantic",
     ],
     extras_require={


### PR DESCRIPTION
Fixes #837.

(At least temporarily) returns to using `ratelimiter` for rate limits instead of `flask-limiter`.