### PR TITLE
Create config loader, but don't use it yet

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Created config loader to load custom configuration files; this remains unused

--- a/config/README.md
+++ b/config/README.md
@@ -2,52 +2,187 @@
 
 This directory contains configuration files for the PolicyEngine Household API.
 
-## Current State
+## Current Implementation Status
 
-The application currently uses environment variables for all configuration. These configuration files are placeholders that establish the structure for future migration to a file-based configuration system.
+The application now has a `ConfigLoader` class (`policyengine_household_api/utils/config_loader.py`) that supports hierarchical configuration loading. While the system is ready, the application code still uses environment variables directly. Configuration files in this directory establish the structure for gradual migration.
 
-## Files
+## Configuration Priority
 
-- `default.yaml` - Default configuration for local development (currently empty placeholders)
-- `production.yaml.example` - Example production configuration (not used in deployment)
-- `development.yaml.example` - Example development configuration
+The `ConfigLoader` loads configuration from multiple sources in the following priority order (highest to lowest):
 
-## Migration Plan
+1. **Environment Variables** - Override everything
+2. **Mounted Config File** - External configuration file (via `CONFIG_FILE` env var)
+3. **Default Config** - Baked into the Docker image at `/app/config/default.yaml`
 
-The configuration system will be migrated gradually:
+Environment variables always win, allowing you to override specific settings without changing config files.
 
-1. **Phase 1 (Current)**: All configuration via environment variables
-2. **Phase 2**: Configuration files with environment variable overrides
-3. **Phase 3**: Configuration files as primary source, env vars for secrets only
+## Files in this Directory
+
+- `default.yaml` - Default configuration for local development (currently mostly empty/commented)
+- `custom.yaml.example` - Example template for mounting custom configuration
+- `production.yaml.example` - Example production configuration
+- `development.yaml.example` - Example development configuration  
+- `local.yaml.example` - Example for fully local runs without external dependencies
+
+## Configuration Methods
+
+### Method 1: Environment Variables (Highest Priority)
+
+Environment variables override all other configuration sources. They work in two ways:
+
+#### Explicit Mapping
+Pre-defined environment variables that map to specific config paths:
+
+```bash
+# Database configuration
+USER_ANALYTICS_DB_CONNECTION_NAME=my-connection
+USER_ANALYTICS_DB_USERNAME=myuser
+USER_ANALYTICS_DB_PASSWORD=secret
+
+# Auth configuration
+AUTH0_ADDRESS_NO_DOMAIN=my-auth0-domain
+AUTH0_AUDIENCE_NO_DOMAIN=my-audience
+
+# AI configuration
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Debug mode
+FLASK_DEBUG=1
+
+# Server configuration
+PORT=8080
+```
+
+#### Double Underscore Notation
+Any environment variable with double underscores (`__`) is automatically mapped to nested config:
+
+```bash
+# DATABASE__HOST becomes database.host
+DATABASE__HOST=localhost
+DATABASE__PORT=3306
+
+# AUTH__ENABLED becomes auth.enabled
+AUTH__ENABLED=true
+
+# SERVER__WORKERS becomes server.workers
+SERVER__WORKERS=4
+```
+
+Note: System environment variables starting with underscores are ignored.
+
+### Method 2: Mounted Config File (Medium Priority)
+
+You can mount an external configuration file to override the defaults:
+
+#### Docker Run
+```bash
+# Mount a custom config file
+docker run -v /path/to/your/config.yaml:/custom/config.yaml \
+           -e CONFIG_FILE=/custom/config.yaml \
+           policyengine/household-api
+```
+
+#### Docker Compose
+```yaml
+version: '3.8'
+services:
+  household-api:
+    image: policyengine/household-api
+    volumes:
+      - ./my-config.yaml:/app/config/custom.yaml
+    environment:
+      - CONFIG_FILE=/app/config/custom.yaml
+      # Still provide secrets via env vars
+      - DATABASE__PASSWORD=${DB_PASSWORD}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+```
+
+#### Kubernetes ConfigMap
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: household-api-config
+data:
+  config.yaml: |
+    database:
+      provider: postgres
+      host: postgres.default.svc.cluster.local
+    auth:
+      enabled: true
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: api
+        image: policyengine/household-api
+        env:
+        - name: CONFIG_FILE
+          value: /config/config.yaml
+        - name: DATABASE__PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db-secret
+              key: password
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        configMap:
+          name: household-api-config
+```
+
+### Method 3: Default Config (Lowest Priority)
+
+The default configuration is baked into the Docker image at `/app/config/default.yaml`. This provides sensible defaults for local development and serves as a fallback.
 
 ## Configuration Structure
 
 ```yaml
 app:
-  name: Application name
+  name: Application name (default: policyengine-household-api)
   environment: Environment (local/development/staging/production)
+  debug: Debug mode (true/false)
 
 database:
   provider: Database type (sqlite/mysql/postgres)
-  # Connection details
+  connection_name: Cloud SQL connection name (for GCP)
+  username: Database username
+  password: Database password
+  host: Database host
+  port: Database port
+  path: SQLite file path (for sqlite provider)
+  pool_size: Connection pool size
 
 storage:
   provider: Storage backend (local/gcs/s3)
-  # Provider-specific settings
+  bucket: Storage bucket name (for cloud providers)
+  path: Local storage path (for local provider)
 
 auth:
-  enabled: Whether authentication is required
+  enabled: Whether authentication is required (true/false)
   provider: Auth provider (none/auth0/cognito)
-  # Provider-specific settings
+  auth0:
+    address: Auth0 domain
+    audience: Auth0 audience
 
 ai:
-  enabled: Whether AI features are enabled
+  enabled: Whether AI features are enabled (true/false)
   provider: AI service provider (none/anthropic/openai)
-  # Provider-specific settings
+  anthropic:
+    api_key: Anthropic API key
+    model: Model name
+    max_tokens: Maximum tokens
+    temperature: Temperature setting
 
 server:
-  port: Server port
+  port: Server port (default: 8080)
   workers: Number of worker processes
+  threads: Number of threads per worker
   timeout: Request timeout in seconds
 
 logging:
@@ -55,43 +190,109 @@ logging:
   format: Log format (json/text)
 ```
 
-## Environment Variable Mapping
+## Usage Examples
 
-When migrated, environment variables will map to configuration as follows:
+### Production Deployment (Current)
 
-- `FLASK_DEBUG` → `app.debug`
-- `USER_ANALYTICS_DB_CONNECTION_NAME` → `database.connection_name`
-- `USER_ANALYTICS_DB_USERNAME` → `database.username`
-- `USER_ANALYTICS_DB_PASSWORD` → `database.password`
-- `AUTH0_ADDRESS_NO_DOMAIN` → `auth.auth0.address`
-- `AUTH0_AUDIENCE_NO_DOMAIN` → `auth.auth0.audience`
-- `ANTHROPIC_API_KEY` → `ai.anthropic.api_key`
+Currently in production, all configuration comes from environment variables:
 
-## Usage (Future)
-
-Once migration is complete:
+```bash
+# Via GitHub Actions secrets
+AUTH0_ADDRESS_NO_DOMAIN=${{ secrets.AUTH0_ADDRESS_NO_DOMAIN }}
+AUTH0_AUDIENCE_NO_DOMAIN=${{ secrets.AUTH0_AUDIENCE_NO_DOMAIN }}
+USER_ANALYTICS_DB_USERNAME=${{ secrets.USER_ANALYTICS_DB_USERNAME }}
+USER_ANALYTICS_DB_PASSWORD=${{ secrets.USER_ANALYTICS_DB_PASSWORD }}
+USER_ANALYTICS_DB_CONNECTION_NAME=${{ secrets.USER_ANALYTICS_DB_CONNECTION_NAME }}
+ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+```
 
 ### Local Development
-```bash
-# Use default.yaml automatically
-python -m policyengine_household_api.api
 
-# Or specify a config file
-CONFIG_FILE=config/development.yaml python -m policyengine_household_api.api
+Use environment variables to override specific settings:
+
+```bash
+docker run -e FLASK_DEBUG=1 \
+           -e AUTH__ENABLED=false \
+           -e AI__ENABLED=false \
+           -e DATABASE__PROVIDER=sqlite \
+           policyengine/household-api
 ```
 
-### Docker
-```bash
-# Mount custom config
-docker run -v $(pwd)/my-config.yaml:/app/config/active.yaml household-api
+### Custom Cloud Provider
 
-# Or use environment variable to specify config location
-docker run -e CONFIG_FILE=/app/config/production.yaml household-api
+Mount a complete custom configuration:
+
+```bash
+# Create custom config
+cat > aws-config.yaml <<EOF
+database:
+  provider: postgres
+  host: my-rds-instance.amazonaws.com
+storage:
+  provider: s3
+  bucket: my-household-data
+auth:
+  provider: cognito
+  pool_id: us-east-1_xxxxx
+EOF
+
+# Run with custom config
+docker run -v $(pwd)/aws-config.yaml:/app/config/aws.yaml \
+           -e CONFIG_FILE=/app/config/aws.yaml \
+           -e DATABASE__PASSWORD="${RDS_PASSWORD}" \
+           policyengine/household-api
 ```
 
-### Production
-Environment variables will override config file values for sensitive data:
-```bash
-# Config file provides structure, env vars provide secrets
-DATABASE__PASSWORD=secret CONFIG_FILE=production.yaml python -m app
+## Migration Status
+
+### Phase 1 (Current)
+- ✅ `ConfigLoader` class implemented
+- ✅ Hierarchical configuration loading working
+- ✅ Environment variable mapping functional
+- ✅ Docker image includes default config
+- ⏳ Application code still uses `os.getenv()` directly
+
+### Phase 2 (Next Steps)
+- Gradually update application code to use `get_config_value()` instead of `os.getenv()`
+- Move non-sensitive defaults to config files
+- Keep sensitive values in environment variables
+
+### Phase 3 (Future)
+- Configuration files become primary source
+- Environment variables used only for secrets and overrides
+- Full configuration validation with Pydantic models
+
+## Using ConfigLoader in Code
+
+To use the configuration system in new code:
+
+```python
+from policyengine_household_api.utils import get_config_value
+
+# Get a configuration value with a default
+db_provider = get_config_value("database.provider", "sqlite")
+
+# Get nested configuration
+auth_enabled = get_config_value("auth.enabled", False)
 ```
+
+## Best Practices
+
+1. **Never put secrets in config files** - Use environment variables for sensitive data
+2. **Use mounted configs for structure** - Define your infrastructure layout in config files
+3. **Use env vars for secrets** - Override sensitive values at runtime
+4. **Version control your configs** - Keep config files in source control (without secrets)
+5. **Environment-specific configs** - Have separate config files for dev/staging/prod
+
+## Debugging Configuration
+
+To see what configuration is being loaded, set the log level to DEBUG:
+
+```bash
+docker run -e LOGGING__LEVEL=DEBUG policyengine/household-api
+```
+
+The application will log:
+- Which config files were loaded
+- Which environment variables were applied
+- Any errors in loading configuration files

--- a/config/custom.yaml.example
+++ b/config/custom.yaml.example
@@ -1,0 +1,70 @@
+# Example custom configuration file for mounting
+# 
+# This file shows the structure for a custom configuration that can be
+# mounted into the container at runtime. Currently, all values are commented
+# out as the application still uses environment variables.
+#
+# To use this file:
+# 1. Copy it to your own location: cp custom.yaml.example my-config.yaml
+# 2. Uncomment and modify the settings you want to override
+# 3. Mount it when running the container:
+#    docker run -v $(pwd)/my-config.yaml:/app/config/custom.yaml \
+#               -e CONFIG_FILE=/app/config/custom.yaml \
+#               policyengine/household-api
+#
+# IMPORTANT: Do not put secrets in this file. Use environment variables for sensitive data.
+
+---
+# All sections below are optional and will be filled by defaults or env vars if not specified
+
+# Application settings
+# app:
+#   name: policyengine-household-api
+#   environment: custom
+#   debug: false
+
+# Database configuration
+# database:
+#   provider: mysql  # Options: sqlite, mysql, postgres
+#   # For MySQL/Postgres:
+#   # host: localhost
+#   # port: 3306
+#   # database: household_api
+#   # pool_size: 10
+#   # For SQLite:
+#   # path: /data/household.db
+
+# Storage configuration
+# storage:
+#   provider: local  # Options: local, gcs, s3
+#   # For local:
+#   # path: /data/storage
+#   # For GCS:
+#   # bucket: my-bucket
+#   # For S3:
+#   # bucket: my-bucket
+#   # region: us-east-1
+
+# Authentication configuration
+# auth:
+#   enabled: true
+#   provider: auth0  # Options: none, auth0, cognito
+#   # Provider-specific settings added as needed
+
+# AI services configuration
+# ai:
+#   enabled: true
+#   provider: anthropic  # Options: none, anthropic, openai
+#   # Provider-specific settings added as needed
+
+# Server configuration
+# server:
+#   port: 8080
+#   workers: 2
+#   threads: 2
+#   timeout: 300
+
+# Logging configuration
+# logging:
+#   level: INFO  # Options: DEBUG, INFO, WARNING, ERROR
+#   format: json  # Options: json, text

--- a/gcp/policyengine_household_api/Dockerfile.production
+++ b/gcp/policyengine_household_api/Dockerfile.production
@@ -27,6 +27,10 @@ RUN rm -rf /var/lib/apt/lists/*
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /build/policyengine_household_api /app/policyengine_household_api
   
+# Copy default configuration
+RUN mkdir -p /app/config
+COPY ./config/default.yaml /app/config/default.yaml
+  
 # Copy startup script
 COPY ./gcp/policyengine_household_api/start.sh /app/start.sh
 RUN chmod +x /app/start.sh

--- a/policyengine_household_api/utils/__init__.py
+++ b/policyengine_household_api/utils/__init__.py
@@ -2,3 +2,4 @@ from .json import *
 from .computation_tree import *
 from .google_cloud import *
 from .validate_country import *
+from .config_loader import ConfigLoader, get_config, get_config_value

--- a/policyengine_household_api/utils/config_loader.py
+++ b/policyengine_household_api/utils/config_loader.py
@@ -1,0 +1,323 @@
+"""
+Configuration loader for PolicyEngine Household API.
+
+Loads configuration with the following priority (highest to lowest):
+1. Environment variables (override everything)
+2. Mounted config file (if provided via CONFIG_FILE env var)
+3. Default config baked into image
+"""
+
+import os
+import yaml
+from pathlib import Path
+from typing import Any, Dict, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigLoader:
+    """
+    Loads and merges configuration from multiple sources.
+
+    Priority order (highest wins):
+    1. Environment variables
+    2. External config file (if CONFIG_FILE is set)
+    3. Default config file baked into image
+    """
+
+    # Default location for baked-in config
+    DEFAULT_CONFIG_PATH = "/app/config/default.yaml"
+
+    # Environment variable to specify external config
+    CONFIG_FILE_ENV_VAR = "CONFIG_FILE"
+
+    # Mapping of environment variables to config paths
+    # Format: "ENV_VAR_NAME": "config.path.to.value"
+    ENV_VAR_MAPPING = {
+        # Flask settings
+        "FLASK_DEBUG": "app.debug",
+        # Database settings
+        "USER_ANALYTICS_DB_CONNECTION_NAME": "database.connection_name",
+        "USER_ANALYTICS_DB_USERNAME": "database.username",
+        "USER_ANALYTICS_DB_PASSWORD": "database.password",
+        # Auth0 settings
+        "AUTH0_ADDRESS_NO_DOMAIN": "auth.auth0.address",
+        "AUTH0_AUDIENCE_NO_DOMAIN": "auth.auth0.audience",
+        # AI settings
+        "ANTHROPIC_API_KEY": "ai.anthropic.api_key",
+        # Server settings
+        "PORT": "server.port",
+    }
+
+    def __init__(self, default_config_path: Optional[str] = None):
+        """
+        Initialize the config loader.
+
+        Args:
+            default_config_path: Override the default config file location
+        """
+        self.default_config_path = (
+            default_config_path or self.DEFAULT_CONFIG_PATH
+        )
+        self._config: Optional[Dict[str, Any]] = None
+
+    def load(self) -> Dict[str, Any]:
+        """
+        Load and merge configuration from all sources.
+
+        Returns:
+            Merged configuration dictionary
+        """
+        if self._config is not None:
+            return self._config
+
+        # Start with empty config
+        config = {}
+
+        # 1. Load default config (lowest priority)
+        default_config = self._load_default_config()
+        if default_config:
+            config = self._deep_merge(config, default_config)
+            logger.info(
+                f"Loaded default config from {self.default_config_path}"
+            )
+
+        # 2. Load external config file if specified
+        external_config = self._load_external_config()
+        if external_config:
+            config = self._deep_merge(config, external_config)
+            logger.info(
+                f"Loaded external config from {os.getenv(self.CONFIG_FILE_ENV_VAR)}"
+            )
+
+        # 3. Override with environment variables (highest priority)
+        env_overrides = self._load_env_overrides()
+        if env_overrides:
+            config = self._deep_merge(config, env_overrides)
+            logger.info("Applied environment variable overrides")
+
+        self._config = config
+        return config
+
+    def _load_default_config(self) -> Optional[Dict[str, Any]]:
+        """Load the default config file baked into the image."""
+        path = Path(self.default_config_path)
+        if not path.exists():
+            # It's acceptable for default config not to exist - just use empty dict
+            logger.debug(
+                f"Default config not found at {self.default_config_path}, using empty configuration"
+            )
+            return {}
+
+        try:
+            with open(path, "r") as f:
+                content = yaml.safe_load(f)
+                return content if content is not None else {}
+        except yaml.YAMLError as e:
+            logger.error(
+                f"Error parsing YAML in default config at {self.default_config_path}: {e}"
+            )
+            # For YAML errors, return empty dict but log the error
+            return {}
+        except PermissionError as e:
+            logger.error(
+                f"Permission denied reading default config at {self.default_config_path}: {e}"
+            )
+            # For permission errors, return empty dict but log the error
+            return {}
+        except Exception as e:
+            logger.error(
+                f"Unexpected error loading default config at {self.default_config_path}: {e}"
+            )
+            # For unexpected errors, return empty dict but log the error
+            return {}
+
+    def _load_external_config(self) -> Optional[Dict[str, Any]]:
+        """Load external config file if CONFIG_FILE env var is set."""
+        config_file = os.getenv(self.CONFIG_FILE_ENV_VAR)
+        if not config_file:
+            return None
+
+        path = Path(config_file)
+        if not path.exists():
+            logger.warning(
+                f"External config file specified but not found: {config_file}"
+            )
+            return None
+
+        try:
+            with open(path, "r") as f:
+                content = yaml.safe_load(f)
+                if content is None:
+                    logger.debug(
+                        f"External config file {config_file} is empty"
+                    )
+                    return {}
+                return content
+        except yaml.YAMLError as e:
+            logger.error(
+                f"Error parsing YAML in external config at {config_file}: {e}"
+            )
+            return None
+        except PermissionError as e:
+            logger.error(
+                f"Permission denied reading external config at {config_file}: {e}"
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                f"Unexpected error loading external config from {config_file}: {e}"
+            )
+            return None
+
+    def _load_env_overrides(self) -> Dict[str, Any]:
+        """
+        Load configuration overrides from environment variables.
+
+        Supports two methods:
+        1. Explicit mapping (ENV_VAR_MAPPING)
+        2. Double underscore notation (DATABASE__HOST -> database.host)
+        """
+        overrides = {}
+
+        # Process explicitly mapped environment variables
+        for env_var, config_path in self.ENV_VAR_MAPPING.items():
+            value = os.getenv(env_var)
+            if value is not None:
+                self._set_nested_value(overrides, config_path, value)
+
+        # Process double-underscore notation env vars
+        # Format: SECTION__KEY__SUBKEY -> section.key.subkey
+        for key, value in os.environ.items():
+            if "__" in key and key not in self.ENV_VAR_MAPPING:
+                # Skip system environment variables (those starting with underscores)
+                if key.startswith("_"):
+                    continue
+
+                # Convert to lowercase and split
+                path_parts = key.lower().split("__")
+
+                # Skip if any part is empty (e.g., from vars starting/ending with __)
+                if any(not part for part in path_parts):
+                    continue
+
+                config_path = ".".join(path_parts)
+                self._set_nested_value(overrides, config_path, value)
+
+        return overrides
+
+    def _set_nested_value(
+        self, d: Dict[str, Any], path: str, value: Any
+    ) -> None:
+        """
+        Set a nested value in a dictionary using dot notation.
+
+        Args:
+            d: Dictionary to modify
+            path: Dot-separated path (e.g., "database.host")
+            value: Value to set
+        """
+        keys = path.split(".")
+        current = d
+
+        for key in keys[:-1]:
+            if key not in current:
+                current[key] = {}
+            current = current[key]
+
+        # Convert string values to appropriate types
+        current[keys[-1]] = self._convert_value(value)
+
+    def _convert_value(self, value: str) -> Any:
+        """
+        Convert string values to appropriate Python types.
+
+        Args:
+            value: String value from environment variable
+
+        Returns:
+            Converted value (bool, int, float, or original string)
+        """
+        if value.lower() in ("true", "yes", "1"):
+            return True
+        if value.lower() in ("false", "no", "0"):
+            return False
+
+        try:
+            return int(value)
+        except ValueError:
+            pass
+
+        try:
+            return float(value)
+        except ValueError:
+            pass
+
+        return value
+
+    def _deep_merge(
+        self, base: Dict[str, Any], override: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Deep merge two dictionaries, with override taking precedence.
+
+        Args:
+            base: Base dictionary
+            override: Dictionary with values to override
+
+        Returns:
+            Merged dictionary
+        """
+        result = base.copy()
+
+        for key, value in override.items():
+            if (
+                key in result
+                and isinstance(result[key], dict)
+                and isinstance(value, dict)
+            ):
+                result[key] = self._deep_merge(result[key], value)
+            else:
+                result[key] = value
+
+        return result
+
+    def get(self, path: str, default: Any = None) -> Any:
+        """
+        Get a configuration value using dot notation.
+
+        Args:
+            path: Dot-separated path (e.g., "database.host")
+            default: Default value if path not found
+
+        Returns:
+            Configuration value or default
+        """
+        if self._config is None:
+            self.load()
+
+        keys = path.split(".")
+        current = self._config
+
+        for key in keys:
+            if isinstance(current, dict) and key in current:
+                current = current[key]
+            else:
+                return default
+
+        return current
+
+
+# Global instance for convenience
+_config_loader = ConfigLoader()
+
+
+def get_config() -> Dict[str, Any]:
+    """Get the loaded configuration."""
+    return _config_loader.load()
+
+
+def get_config_value(path: str, default: Any = None) -> Any:
+    """Get a specific configuration value."""
+    return _config_loader.get(path, default)

--- a/tests/fixtures/utils/config_loader.py
+++ b/tests/fixtures/utils/config_loader.py
@@ -1,0 +1,243 @@
+"""
+Fixtures for config loader unit tests.
+"""
+
+import tempfile
+import yaml
+from pathlib import Path
+from typing import Dict, Any
+import pytest
+
+
+# Sample configuration data constants
+DEFAULT_CONFIG_DATA = {
+    "app": {
+        "name": "policyengine-household-api",
+        "environment": "default",
+        "debug": False,
+    },
+    "database": {"provider": "sqlite", "path": ":memory:"},
+    "server": {"port": 8080, "workers": 1, "timeout": 300},
+}
+
+EXTERNAL_CONFIG_DATA = {
+    "app": {"environment": "external", "debug": True},
+    "database": {"provider": "mysql", "host": "external-host", "port": 3306},
+    "storage": {"provider": "gcs", "bucket": "test-bucket"},
+}
+
+CUSTOM_CONFIG_DATA = {
+    "app": {"environment": "custom"},
+    "database": {
+        "provider": "postgres",
+        "host": "custom-host",
+        "port": 5432,
+        "database": "custom_db",
+    },
+    "auth": {"enabled": True, "provider": "auth0"},
+    "ai": {"enabled": True, "provider": "anthropic"},
+}
+
+# Environment variable test data
+ENV_VAR_TEST_DATA = {
+    # Traditional PolicyEngine env vars
+    "FLASK_DEBUG": "1",
+    "USER_ANALYTICS_DB_CONNECTION_NAME": "test-connection-name",
+    "USER_ANALYTICS_DB_USERNAME": "test-username",
+    "USER_ANALYTICS_DB_PASSWORD": "test-password",
+    "AUTH0_ADDRESS_NO_DOMAIN": "test-auth0-address",
+    "AUTH0_AUDIENCE_NO_DOMAIN": "test-auth0-audience",
+    "ANTHROPIC_API_KEY": "sk-ant-test-key",
+    "PORT": "9090",
+}
+
+# Double underscore notation test data
+DOUBLE_UNDERSCORE_ENV_VARS = {
+    "DATABASE__HOST": "env-db-host",
+    "DATABASE__PORT": "5432",
+    "DATABASE__POOL_SIZE": "20",
+    "SERVER__WORKERS": "4",
+    "SERVER__THREADS": "2",
+    "AUTH__ENABLED": "true",
+    "AUTH__PROVIDER": "cognito",
+    "LOGGING__LEVEL": "DEBUG",
+    "LOGGING__FORMAT": "json",
+}
+
+# Type conversion test data
+TYPE_CONVERSION_TEST_CASES = [
+    # Boolean conversions
+    ("true", True),
+    ("True", True),
+    ("TRUE", True),
+    ("yes", True),
+    ("Yes", True),
+    ("1", True),
+    ("false", False),
+    ("False", False),
+    ("FALSE", False),
+    ("no", False),
+    ("No", False),
+    ("0", False),
+    # Integer conversions
+    ("123", 123),
+    ("-456", -456),
+    ("0", False),  # Note: "0" converts to False, not 0
+    # Float conversions
+    ("3.14", 3.14),
+    ("-2.5", -2.5),
+    ("1.0", 1.0),
+    # String (no conversion)
+    ("hello", "hello"),
+    ("true_but_not_bool", "true_but_not_bool"),
+    ("123.456.789", "123.456.789"),  # Not a valid float
+]
+
+
+@pytest.fixture
+def temp_default_config():
+    """Create a temporary default config file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        yaml.dump(DEFAULT_CONFIG_DATA, f)
+        temp_path = f.name
+
+    yield temp_path
+
+    # Cleanup
+    Path(temp_path).unlink()
+
+
+@pytest.fixture
+def temp_external_config():
+    """Create a temporary external config file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        yaml.dump(EXTERNAL_CONFIG_DATA, f)
+        temp_path = f.name
+
+    yield temp_path
+
+    # Cleanup
+    Path(temp_path).unlink()
+
+
+@pytest.fixture
+def temp_custom_config():
+    """Create a temporary custom config file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        yaml.dump(CUSTOM_CONFIG_DATA, f)
+        temp_path = f.name
+
+    yield temp_path
+
+    # Cleanup
+    Path(temp_path).unlink()
+
+
+@pytest.fixture
+def temp_empty_config():
+    """Create a temporary empty config file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        f.write("# Empty config file\n")
+        temp_path = f.name
+
+    yield temp_path
+
+    # Cleanup
+    Path(temp_path).unlink()
+
+
+@pytest.fixture
+def temp_invalid_yaml_config():
+    """Create a temporary config file with invalid YAML."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        f.write(
+            "invalid: yaml: content:\n  - this is not: valid\n    yaml syntax"
+        )
+        temp_path = f.name
+
+    yield temp_path
+
+    # Cleanup
+    Path(temp_path).unlink()
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """
+    Fixture to ensure a clean environment for each test.
+    Returns the monkeypatch object for setting env vars.
+    """
+    import os
+
+    # Remove any CONFIG_FILE env var
+    monkeypatch.delenv("CONFIG_FILE", raising=False)
+
+    # Remove all test env vars if they exist
+    for env_var in ENV_VAR_TEST_DATA:
+        monkeypatch.delenv(env_var, raising=False)
+
+    for env_var in DOUBLE_UNDERSCORE_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+    # Remove any environment variables that might be picked up by the config loader
+    # This includes PolicyEngine-specific vars that might be set in the dev environment
+    policyengine_env_vars = [
+        "USER_ANALYTICS_DB_CONNECTION_NAME",
+        "USER_ANALYTICS_DB_USERNAME",
+        "USER_ANALYTICS_DB_PASSWORD",
+        "AUTH0_ADDRESS_NO_DOMAIN",
+        "AUTH0_AUDIENCE_NO_DOMAIN",
+        "ANTHROPIC_API_KEY",
+        "FLASK_DEBUG",
+        "PORT",
+    ]
+
+    for env_var in policyengine_env_vars:
+        monkeypatch.delenv(env_var, raising=False)
+
+    # Also remove any env vars with double underscores that might interfere
+    # We need to be careful not to remove system-critical vars
+    current_env_vars = list(os.environ.keys())
+    for env_var in current_env_vars:
+        if "__" in env_var and not env_var.startswith("__"):
+            # Only remove non-system double underscore vars
+            # System vars typically start with __ (like __CF_USER_TEXT_ENCODING)
+            monkeypatch.delenv(env_var, raising=False)
+
+    return monkeypatch
+
+
+@pytest.fixture
+def config_with_env_vars(clean_env):
+    """Set up traditional PolicyEngine environment variables."""
+    for key, value in ENV_VAR_TEST_DATA.items():
+        clean_env.setenv(key, value)
+    return clean_env
+
+
+@pytest.fixture
+def config_with_double_underscore(clean_env):
+    """Set up double underscore notation environment variables."""
+    for key, value in DOUBLE_UNDERSCORE_ENV_VARS.items():
+        clean_env.setenv(key, value)
+    return clean_env
+
+
+@pytest.fixture
+def config_with_mixed_env_vars(clean_env):
+    """Set up both traditional and double underscore env vars."""
+    for key, value in ENV_VAR_TEST_DATA.items():
+        clean_env.setenv(key, value)
+    for key, value in DOUBLE_UNDERSCORE_ENV_VARS.items():
+        clean_env.setenv(key, value)
+    return clean_env


### PR DESCRIPTION
Fixes #890 

Creates a new `ConfigLoader` class to allow for the structured loading of custom configuration files, but does not yet use it. All deployment settings remain unchanged.