### PR TITLE
Migrate to importlib

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Migrated from pkg_resources to importlib for package management utilities.

--- a/policyengine_household_api/constants.py
+++ b/policyengine_household_api/constants.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import pkg_resources
+from importlib.metadata import version
 
 REPO = Path(__file__).parents[1]
 GET = "GET"
@@ -17,7 +17,7 @@ COUNTRY_PACKAGE_NAMES = (
 )
 try:
     COUNTRY_PACKAGE_VERSIONS = {
-        country: pkg_resources.get_distribution(package_name).version
+        country: version(package_name)
         for country, package_name in zip(COUNTRIES, COUNTRY_PACKAGE_NAMES)
     }
 except:

--- a/policyengine_household_api/country.py
+++ b/policyengine_household_api/country.py
@@ -23,7 +23,7 @@ from policyengine_core.parameters import (
 )
 from typing import Annotated
 from policyengine_core.parameters import get_parameter
-import pkg_resources
+from importlib.metadata import version
 from policyengine_core.model_api import Reform, Enum
 from policyengine_core.periods import instant
 import dpath
@@ -65,9 +65,7 @@ class PolicyEngineCountry:
                 }[self.country_id],
                 basicInputs=self.tax_benefit_system.basic_inputs,
                 modelled_policies=self.tax_benefit_system.modelled_policies,
-                version=pkg_resources.get_distribution(
-                    self.country_package_name
-                ).version,
+                version=version(self.country_package_name),
             ),
         )
 


### PR DESCRIPTION
Fixes #982. Migrates to using `importlib` in place of `pkg_resources`.