### PR TITLE
Bump policyengine-core to 3.23.5 for pandas 3.0 compatibility

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Bumped policyengine-core minimum version to 3.23.5 for pandas 3.0 compatibility

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         "anthropic",
         "Authlib>=1.3.1",
+        "policyengine-core>=3.23.5",
         "cloud-sql-python-connector",
         "flask>=2.2",
         "flask-cors>=3",

--- a/tests/test_pandas3_compatibility.py
+++ b/tests/test_pandas3_compatibility.py
@@ -1,0 +1,19 @@
+"""Test pandas 3.0 compatibility with enum encoding."""
+import pandas as pd
+from policyengine_core.enums import Enum
+
+
+class SampleEnum(Enum):
+    VALUE_A = "value_a"
+    VALUE_B = "value_b"
+
+
+def test_enum_encode_with_pandas_series():
+    """Test that Enum.encode works with pandas Series."""
+    enum_items = [SampleEnum.VALUE_A, SampleEnum.VALUE_B, SampleEnum.VALUE_A]
+    series = pd.Series(enum_items)
+    
+    encoded = SampleEnum.encode(series)
+    
+    assert len(encoded) == 3
+    assert list(encoded) == [0, 1, 0]

--- a/tests/test_pandas3_compatibility.py
+++ b/tests/test_pandas3_compatibility.py
@@ -1,4 +1,5 @@
 """Test pandas 3.0 compatibility with enum encoding."""
+
 import pandas as pd
 from policyengine_core.enums import Enum
 
@@ -12,8 +13,8 @@ def test_enum_encode_with_pandas_series():
     """Test that Enum.encode works with pandas Series."""
     enum_items = [SampleEnum.VALUE_A, SampleEnum.VALUE_B, SampleEnum.VALUE_A]
     series = pd.Series(enum_items)
-    
+
     encoded = SampleEnum.encode(series)
-    
+
     assert len(encoded) == 3
     assert list(encoded) == [0, 1, 0]


### PR DESCRIPTION
## Summary
- Added explicit policyengine-core>=3.23.5 dependency for pandas 3.0 compatibility

## Test plan
- [ ] Verify CI passes
- [ ] Confirm household API endpoints work correctly with updated core version

Generated with [Claude Code](https://claude.com/claude-code)