### PR TITLE
Pin Authlib below 1.7.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Pin Authlib below 1.7.0 because the current auth module reproduces ValueError "Invalid key" on 1.7.0 but not on 1.6.11

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires=">=3.12",
     install_requires=[
         "anthropic",
-        "Authlib>=1.3.1",
+        "Authlib>=1.3.1,<1.7.0",
         "cloud-sql-python-connector",
         "flask>=2.2",
         "flask-cors>=3",


### PR DESCRIPTION
Fixes #1477

## Summary

- pin `Authlib` to `<1.7.0` while preserving the existing lower bound
- add a patch changelog entry for the temporary version cap

## Why

We reproduced a version-specific auth failure with the current auth module:

- on `Authlib 1.7.0`, the validator path raises `ValueError: Invalid key`
- on `Authlib 1.6.11`, the same path does not raise that exception

This pin keeps the app on the known-good behavior while the auth implementation is updated for the newer Authlib/joserfc decode path.

## Validation

- ran `git ls-files '*.py' | xargs black -l 79`
- ran `git ls-files '*.py' | xargs black -l 79 --check`
- reproduced the auth-module behavior difference between `Authlib 1.7.0` and `Authlib 1.6.11` in isolated temporary virtualenvs