### PR TITLE
Fail closed on missing auth config

### DIFF
--- a/changelog.d/1460.fixed.md
+++ b/changelog.d/1460.fixed.md
@@ -1,0 +1,1 @@
+Fail closed at startup when authentication is enabled but required Auth0 configuration is missing, instead of silently serving endpoints unauthenticated. The configuration error is reported through observability before the process exits.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fail closed when authentication is enabled but Auth0 configuration is
+      incomplete.

--- a/policyengine_household_api/decorators/auth.py
+++ b/policyengine_household_api/decorators/auth.py
@@ -10,7 +10,7 @@ from typing import Optional, Any, Callable
 from authlib.integrations.flask_oauth2 import ResourceProtector
 from authlib.oauth2.rfc6750 import BearerTokenValidator
 from ..auth.validation import Auth0JWTBearerTokenValidator
-from ..utils.config_loader import get_config, get_config_value
+from ..utils.config_loader import get_config_value
 
 
 class StaticBearerToken:
@@ -120,10 +120,15 @@ class ConditionalAuthDecorator:
                 resource_protector.register_token_validator(validator)
                 self._decorator = resource_protector
             else:
-                # Auth was requested but configuration is missing
-                print("Warning: Auth enabled but Auth0 configuration missing")
-                self._auth_enabled = False
-                self._decorator = NoOpDecorator()
+                missing = []
+                if not auth0_address:
+                    missing.append("auth.auth0.address")
+                if not auth0_audience:
+                    missing.append("auth.auth0.audience")
+                raise RuntimeError(
+                    "Authentication is enabled but required Auth0 "
+                    f"configuration is missing: {', '.join(missing)}"
+                )
         else:
             # Authentication is disabled
             self._decorator = NoOpDecorator()

--- a/policyengine_household_api/decorators/auth.py
+++ b/policyengine_household_api/decorators/auth.py
@@ -108,9 +108,13 @@ class ConditionalAuthDecorator:
         """
         Set up authentication based on configuration.
 
-        Authentication is enabled if:
-        1. The auth.enabled config value is True, OR
-        2. Both Auth0 configuration values are present (backward compatibility)
+        Authentication is enabled if the auth.enabled config value is True.
+
+        Raises:
+            RuntimeError: If authentication is enabled but the required
+                Auth0 configuration values are missing. Failing closed at
+                startup prevents serving endpoints unauthenticated when a
+                secret or environment variable is absent.
         """
         # Check if Auth0 is explicitly enabled via configuration
         self._auth_enabled = get_config_value("auth.enabled", False)
@@ -143,10 +147,19 @@ class ConditionalAuthDecorator:
                 resource_protector.register_token_validator(validator)
                 self._decorator = resource_protector
             else:
-                # Auth was requested but configuration is missing
-                print("Warning: Auth enabled but Auth0 configuration missing")
-                self._auth_enabled = False
-                self._decorator = NoOpDecorator()
+                # Auth was requested but configuration is missing; fail
+                # closed rather than silently serving unauthenticated.
+                missing = []
+                if not auth0_address:
+                    missing.append("auth.auth0.address")
+                if not auth0_audience:
+                    missing.append("auth.auth0.audience")
+                error = RuntimeError(
+                    "Authentication is enabled but required Auth0 "
+                    f"configuration is missing: {', '.join(missing)}"
+                )
+                record_error(error, handled=False, include_stack=False)
+                raise error
         else:
             # Authentication is disabled
             self._decorator = NoOpDecorator()

--- a/tests/fixtures/decorators/auth.py
+++ b/tests/fixtures/decorators/auth.py
@@ -176,6 +176,28 @@ def auth_enabled_missing_config_environment():
 
 
 @pytest.fixture
+def auth_test_environment_missing_config():
+    """Set up test_with_auth environment missing token and Auth0 config."""
+    with patch(
+        "policyengine_household_api.decorators.auth.get_config_value"
+    ) as mock_config:
+
+        def config_side_effect(path: str, default: Any = None) -> Any:
+            config_map = {
+                "app.environment": "test_with_auth",
+                "auth.enabled": True,
+                "auth.auth0.test_token": "",
+                "auth.auth0.test_token_scopes": "",
+                "auth.auth0.address": "",
+                "auth.auth0.audience": "",
+            }
+            return config_map.get(path, default)
+
+        mock_config.side_effect = config_side_effect
+        yield mock_config
+
+
+@pytest.fixture
 def auth_backward_compat_environment():
     """Set up environment for backward compatibility testing."""
     with patch(

--- a/tests/unit/decorators/test_auth.py
+++ b/tests/unit/decorators/test_auth.py
@@ -3,6 +3,7 @@ Unit tests for the conditional authentication decorator.
 """
 
 from unittest.mock import Mock
+import pytest
 from policyengine_household_api.decorators.auth import (
     NoOpDecorator,
     ConditionalAuthDecorator,
@@ -122,25 +123,25 @@ class TestConditionalAuthDecoratorWithAuthEnabled:
         auth_enabled_environment.assert_any_call("auth.auth0.address", "")
         auth_enabled_environment.assert_any_call("auth.auth0.audience", "")
 
-    def test__given_auth_enabled_missing_config__falls_back_to_noop(
+    def test__given_auth_enabled_missing_config__raises_configuration_error(
         self,
         auth_enabled_missing_config_environment,
         mock_resource_protector,
         mock_auth0_validator,
     ):
-        """Test fallback to NoOp when auth is enabled but config is missing."""
+        """Test auth fails closed when enabled but config is missing."""
         mock_protector_class, _ = mock_resource_protector
         mock_validator_class, _ = mock_auth0_validator
 
-        decorator = ConditionalAuthDecorator()
+        with pytest.raises(
+            RuntimeError,
+            match="Authentication is enabled but required Auth0 configuration is missing",
+        ):
+            ConditionalAuthDecorator()
 
         # Verify Auth0 components were not created
         mock_validator_class.assert_not_called()
         mock_protector_class.assert_not_called()
-
-        # Verify we get a NoOpDecorator
-        assert isinstance(decorator.get_decorator(), NoOpDecorator)
-        assert decorator.is_enabled is False
 
         # Verify configuration was checked
         auth_enabled_missing_config_environment.assert_any_call(

--- a/tests/unit/decorators/test_auth.py
+++ b/tests/unit/decorators/test_auth.py
@@ -5,6 +5,7 @@ Unit tests for the conditional authentication decorator.
 from contextlib import nullcontext
 from functools import wraps
 from unittest.mock import Mock
+import pytest
 import policyengine_household_api.decorators.auth as auth_module
 from policyengine_household_api.decorators.auth import (
     ANALYTICS_READ_SCOPE,
@@ -156,25 +157,41 @@ class TestConditionalAuthDecoratorWithAuthEnabled:
         auth_enabled_environment.assert_any_call("auth.auth0.address", "")
         auth_enabled_environment.assert_any_call("auth.auth0.audience", "")
 
-    def test__given_auth_enabled_missing_config__falls_back_to_noop(
+    def test__given_auth_enabled_missing_config__raises_configuration_error(
         self,
         auth_enabled_missing_config_environment,
         mock_resource_protector,
         mock_auth0_validator,
+        monkeypatch,
     ):
-        """Test fallback to NoOp when auth is enabled but config is missing."""
+        """Test auth fails closed when enabled but config is missing."""
         mock_protector_class, _ = mock_resource_protector
         mock_validator_class, _ = mock_auth0_validator
+        errors = []
+        monkeypatch.setattr(
+            auth_module,
+            "record_error",
+            lambda exc, **kwargs: errors.append((exc, kwargs)),
+        )
 
-        decorator = ConditionalAuthDecorator()
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                "Authentication is enabled but required Auth0 "
+                "configuration is missing: "
+                "auth.auth0.address, auth.auth0.audience"
+            ),
+        ):
+            ConditionalAuthDecorator()
 
         # Verify Auth0 components were not created
         mock_validator_class.assert_not_called()
         mock_protector_class.assert_not_called()
 
-        # Verify we get a NoOpDecorator
-        assert isinstance(decorator.get_decorator(), NoOpDecorator)
-        assert decorator.is_enabled is False
+        # Verify the failure was reported to observability
+        assert len(errors) == 1
+        assert isinstance(errors[0][0], RuntimeError)
+        assert errors[0][1] == {"handled": False, "include_stack": False}
 
         # Verify configuration was checked
         auth_enabled_missing_config_environment.assert_any_call(
@@ -186,6 +203,37 @@ class TestConditionalAuthDecoratorWithAuthEnabled:
         auth_enabled_missing_config_environment.assert_any_call(
             "auth.auth0.audience", ""
         )
+
+    def test__given_test_auth_environment_missing_config__raises_configuration_error(
+        self,
+        auth_test_environment_missing_config,
+        mock_resource_protector,
+        mock_auth0_validator,
+        monkeypatch,
+    ):
+        """Test test_with_auth without token or Auth0 config fails closed."""
+        mock_protector_class, _ = mock_resource_protector
+        mock_validator_class, _ = mock_auth0_validator
+        errors = []
+        monkeypatch.setattr(
+            auth_module,
+            "record_error",
+            lambda exc, **kwargs: errors.append((exc, kwargs)),
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                "Authentication is enabled but required Auth0 "
+                "configuration is missing"
+            ),
+        ):
+            ConditionalAuthDecorator()
+
+        # Verify no validator was created and the failure was recorded
+        mock_validator_class.assert_not_called()
+        mock_protector_class.assert_not_called()
+        assert len(errors) == 1
 
 
 class TestConditionalAuthDecoratorWithAuthDisabled:


### PR DESCRIPTION
Fixes #1460

## Summary
- Keep local auth-disabled mode available when `auth.enabled` is false
- Raise `RuntimeError` at startup when `auth.enabled` is true but the required Auth0 address or audience config is missing, naming the missing keys
- Report the configuration error through observability (`record_error`, `handled=False`) before raising
- Update the decorator unit test to assert fail-closed behaviour and that the error is recorded
- Add a test covering the `test_with_auth` environment with no static test token and no Auth0 config, which also fails closed
- Migrate the changelog entry to the Towncrier fragment format (`changelog.d/1460.fixed.md`)

## Security impact
Prevents production from silently falling back to unauthenticated endpoints when an Auth0 secret or env var is missing. Deploy workflows set `AUTH__ENABLED: true` and inject Auth0 config from repository secrets; if a secret goes missing, the process now crashes at boot (caught by pre-traffic health checks and integration tests) instead of serving an open API.

## Validation
- `uv run pytest tests/unit/decorators/test_auth.py` (14 passed)
- Full unit lane: `pytest .github/scripts tests/to_refactor tests/unit` (601 passed)
- Auth lane: `CONFIG_FILE=config/test_with_auth.yaml pytest tests/integration_with_auth` (6 passed)
- `make format-check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)