### PR TITLE
Check out repo before staged release scripts

### DIFF
--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -255,6 +255,9 @@ jobs:
     environment: staging
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -281,6 +284,9 @@ jobs:
     environment: staging
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:

--- a/changelog.d/staged-release-script-checkouts.fixed.md
+++ b/changelog.d/staged-release-script-checkouts.fixed.md
@@ -1,0 +1,1 @@
+Check out repository files before staged release promotion and cleanup jobs run local scripts.


### PR DESCRIPTION
Fixes #1484

## Summary
- Add `actions/checkout@v4` to the staged release promotion job before it runs `.github/scripts/set-traffic.sh`.
- Add `actions/checkout@v4` to the failed staging cleanup job before it runs `.github/scripts/delete-appengine-version.sh`.
- Add a changelog fragment for the workflow fix.

## Validation
- YAML parse with Ruby
- `bash .github/scripts/check-changelog-fragment.sh`
- `git diff --check`

I also scanned all workflows for `.github/...` script runs without checkout and found no remaining cases.