### PR TITLE
Migrate my_friend_ben fixture off removed medical_out_of_pocket_expenses

### DIFF
--- a/changelog.d/migrate-medical-out-of-pocket-expenses-fixture.changed.md
+++ b/changelog.d/migrate-medical-out-of-pocket-expenses-fixture.changed.md
@@ -1,0 +1,1 @@
+Migrated the `my_friend_ben` customer-household fixture off the removed `medical_out_of_pocket_expenses` input to `other_medical_expenses`, the load-bearing replacement for non-premium medical spending in policyengine-us 1.673.0+.

--- a/tests/data/customer_households/my_friend_ben.py
+++ b/tests/data/customer_households/my_friend_ben.py
@@ -111,7 +111,7 @@ my_friend_ben_household = {
             "real_estate_taxes": {
                 "2025": 0,
             },
-            "medical_out_of_pocket_expenses": {
+            "other_medical_expenses": {
                 "2025": 0,
             },
             "is_snap_ineligible_student": {


### PR DESCRIPTION
## Summary

Migrates the `my_friend_ben` customer-household integration fixture off the input variable `medical_out_of_pocket_expenses`, which is removed in `policyengine-us` 1.673.0+. Sends `other_medical_expenses` instead — the load-bearing replacement for non-premium medical spending.

Unblocks #1491 (the weekly `policyengine-us` 1.663.0 → 1.686.0 bump), whose CI currently fails because `tests/integration_with_auth/test_customer_inputs.py::TestCustomerInputs::test_my_friend_ben` returns HTTP 500 / `VariableNotFoundError` when the engine receives the removed variable.

## Why the change is needed

`policyengine-us` PR [PolicyEngine/policyengine-us#8178](https://github.com/PolicyEngine/policyengine-us/pull/8178) ("Decompose SPM MOOP premiums") removed the umbrella `medical_out_of_pocket_expenses` Person variable. It was previously `adds = ["health_insurance_premiums", "other_medical_expenses"]` — a convenience aggregate. Each statutory program (IRS §213 itemized, SNAP, HUD, Medicaid medically-needy, PA CCW, SPM MOOP) now has its own program-specific aggregate that follows its own legal definition, all of which read `other_medical_expenses` (and a premium variable) directly.

The granular pieces — `other_medical_expenses`, `health_insurance_premiums_without_medicare_part_b`, `over_the_counter_health_expenses` — have existed since [PolicyEngine/policyengine-us#4997](https://github.com/PolicyEngine/policyengine-us/pull/4997) (September 2024), so this migration carries no semantic loss. The fixture's prior value was `0`, so the substitution is exact regardless.

## Partner impact

Customers (e.g., MyFriendBen) sending `medical_out_of_pocket_expenses` in household payloads need the same migration. A separate partner notice covers the full mapping. For most cases, the substitution is `medical_out_of_pocket_expenses → other_medical_expenses`; if the value also represented premiums, send `health_insurance_premiums` alongside.

## Files

- `tests/data/customer_households/my_friend_ben.py` — rename input key
- `changelog.d/migrate-medical-out-of-pocket-expenses-fixture.changed.md` — fragment

## Test plan

- [x] `pytest tests/integration_with_auth/test_customer_inputs.py::TestCustomerInputs::test_my_friend_ben` passes locally against `policyengine-us` 1.686.0 (previously failed with `VariableNotFoundError`)
- [x] All 4 customer-input integration tests pass (my_friend_ben, amplifi×2, impactica)
- [x] All 223 unit tests pass
- [x] `ruff format --check` clean
- [ ] CI passes
- [ ] After merge: rebase #1491 onto main so its CI re-runs against this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)