### PR TITLE
Validate household variables and publish OpenAPI spec

### DIFF
--- a/changelog.d/1496.fixed
+++ b/changelog.d/1496.fixed
@@ -1,0 +1,5 @@
+Validate household calculate payload variables before simulation, returning
+HTTP 400 with structured `errors` for variables not available in the API's
+PolicyEngine model version while preserving allowlisted deprecated-variable
+warnings. Also expose the OpenAPI specification and document calculate request
+and response schemas.

--- a/policyengine_household_api/api.py
+++ b/policyengine_household_api/api.py
@@ -4,12 +4,14 @@ This is the main Flask app for the PolicyEngine API.
 
 # Python imports
 import os
+from pathlib import Path
 
 # External imports
 from flask_cors import CORS
 import flask
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+import yaml
 from policyengine_household_api.data.analytics_setup import (
     initialize_analytics_db_if_enabled,
 )
@@ -34,6 +36,7 @@ require_auth_if_enabled = create_auth_decorator()
 print("Initialising API...")
 
 app = application = flask.Flask(__name__)
+OPENAPI_SPEC_PATH = Path(__file__).with_name("openapi_spec.yaml")
 
 # Reject absurdly large request bodies before any view runs. 10 MiB is
 # well above the largest legitimate household payload we have seen
@@ -87,6 +90,12 @@ def readiness_check():
     return flask.Response(
         "OK", status=200, headers={"Content-Type": "text/plain"}
     )
+
+
+@app.route("/specification", methods=["GET"])
+def specification():
+    with OPENAPI_SPEC_PATH.open() as spec_file:
+        return flask.jsonify(yaml.safe_load(spec_file))
 
 
 # Note: `/calculate_demo` is intentionally public (documented in

--- a/policyengine_household_api/api.py
+++ b/policyengine_household_api/api.py
@@ -3,8 +3,12 @@ This is the main Flask app for the PolicyEngine API.
 """
 
 # Python imports
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 import os
 from pathlib import Path
+import tomllib
 
 # External imports
 from flask_cors import CORS
@@ -37,6 +41,8 @@ print("Initialising API...")
 
 app = application = flask.Flask(__name__)
 OPENAPI_SPEC_PATH = Path(__file__).with_name("openapi_spec.yaml")
+PACKAGE_NAME = "policyengine-household-api"
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
 
 # Reject absurdly large request bodies before any view runs. 10 MiB is
 # well above the largest legitimate household payload we have seen
@@ -94,8 +100,24 @@ def readiness_check():
 
 @app.route("/specification", methods=["GET"])
 def specification():
+    spec = load_openapi_spec()
+    return flask.jsonify(spec)
+
+
+def load_openapi_spec() -> dict:
     with OPENAPI_SPEC_PATH.open() as spec_file:
-        return flask.jsonify(yaml.safe_load(spec_file))
+        spec = yaml.safe_load(spec_file)
+    spec.setdefault("info", {})["version"] = get_api_version()
+    return spec
+
+
+@lru_cache
+def get_api_version() -> str:
+    try:
+        return package_version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        with PYPROJECT_PATH.open("rb") as pyproject_file:
+            return tomllib.load(pyproject_file)["project"]["version"]
 
 
 # Note: `/calculate_demo` is intentionally public (documented in

--- a/policyengine_household_api/endpoints/home.py
+++ b/policyengine_household_api/endpoints/home.py
@@ -12,6 +12,9 @@ def get_home() -> Response:
         "result": {
             "docs_url": "https://www.policyengine.org/us/api",
             "container_image": "ghcr.io/policyengine/policyengine-household-api",
+            "openapi_spec_url": (
+                "https://household.api.policyengine.org/specification"
+            ),
             "hosted_calculate_url_template": (
                 "https://household.api.policyengine.org/{country_id}/calculate"
             ),

--- a/policyengine_household_api/endpoints/household.py
+++ b/policyengine_household_api/endpoints/household.py
@@ -17,6 +17,9 @@ from policyengine_household_api.models.household import (
 from policyengine_household_api.utils.deprecated_inputs import (
     drop_deprecated_inputs,
 )
+from policyengine_household_api.utils.variable_validation import (
+    validate_household_variables,
+)
 from policyengine_household_api.utils.validate_country import validate_country
 
 
@@ -127,15 +130,44 @@ def get_calculate(country_id: str, add_missing: bool = False) -> Response:
 
     country = COUNTRIES.get(country_id)
 
-    # Strip deprecated inputs before validation so partners who still pass
-    # removed/renamed variables get a warning + working response instead
-    # of a `VariableNotFoundError` HTTP 500.
-    deprecation_warnings = drop_deprecated_inputs(household_json)
-
     # Validate inbound payload shape before reaching the compute layer.
     try:
         _validate_household_payload(country_id, household_json)
         _validate_axes(household_json)
+    except ValueError as e:
+        return Response(
+            json.dumps({"status": "error", "message": str(e)}),
+            status=400,
+            mimetype="application/json",
+        )
+
+    variable_errors = validate_household_variables(
+        household=household_json,
+        system=country.tax_benefit_system,
+        model_version=country.policyengine_bundle["model_version"],
+    )
+    if variable_errors:
+        return Response(
+            json.dumps(
+                {
+                    "status": "error",
+                    "message": "Invalid household variables.",
+                    "errors": [error.message for error in variable_errors],
+                }
+            ),
+            status=400,
+            mimetype="application/json",
+        )
+
+    # Strip deprecated inputs from a copy before period validation so
+    # partners who still pass removed/renamed variables get a warning +
+    # working response instead of a `VariableNotFoundError` HTTP 500.
+    deprecated_inputs = drop_deprecated_inputs(household_json)
+    household_json = deprecated_inputs.household
+    deprecation_warnings = deprecated_inputs.warnings
+
+    # Validate inbound period data before reaching the compute layer.
+    try:
         validate_period_keys(household_json, country.tax_benefit_system)
         validate_period_budgets(household_json, country.tax_benefit_system)
     except ValueError as e:

--- a/policyengine_household_api/openapi_spec.yaml
+++ b/policyengine_household_api/openapi_spec.yaml
@@ -1,15 +1,17 @@
 openapi: 3.0.0
 info:
-  title: PolicyEngine API
-  description: The PolicyEngine API provides programmatic access to PolicyEngine functionalities, including managing policies and retrieving policy-related information.
-  version: null
+  title: PolicyEngine Household API
+  description: The PolicyEngine Household API calculates policy outcomes for household JSON payloads without storing household data.
+  version: "1.0.0"
   contact:
     name: PolicyEngine Support
     email: hello@policyengine.org
     url: https://policyengine.org
 servers:
-  - url: https://api.policyengine.org
-    description: Production server
+  - url: https://household.api.policyengine.org
+    description: Hosted household API
+  - url: http://localhost:8080
+    description: Local Docker household API
 paths:
   /:
     get:
@@ -539,6 +541,8 @@ paths:
       summary: Calculate household and policy without storing data
       operationId: get_calculate
       description: Lightweight endpoint for passing in household JSON objects and calculating without storing data. Specify the country ID.
+      security:
+        - bearerAuth: []
       parameters:
         - name: country_id
           in: path
@@ -546,43 +550,131 @@ paths:
           required: true
           schema:
             type: string
+            enum:
+              - us
+              - uk
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                household:
-                  type: object
-                policy:
-                  type: object
+              $ref: "#/components/schemas/CalculateRequest"
+            examples:
+              us_single_adult:
+                summary: US single adult
+                value:
+                  household:
+                    people:
+                      you:
+                        age:
+                          "2025": 30
+                        employment_income:
+                          "2025": 50000
+                    households:
+                      your household:
+                        members:
+                          - you
+                        state_name:
+                          "2025": CA
+                    families:
+                      your family:
+                        members:
+                          - you
+                    tax_units:
+                      your tax unit:
+                        members:
+                          - you
+                    marital_units:
+                      your marital unit:
+                        members:
+                          - you
+                    spm_units:
+                      your spm unit:
+                        members:
+                          - you
+              uk_single_adult:
+                summary: UK single adult
+                value:
+                  household:
+                    people:
+                      person:
+                        age:
+                          "2025": 30
+                        employment_income:
+                          "2025": 30000
+                    benunits:
+                      benunit:
+                        members:
+                          - person
+                    households:
+                      household:
+                        members:
+                          - person
       responses:
         200:
           description: The calculation result.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                  message:
-                    type: string
-                    nullable: true
-                  result:
-                    type: object
+                $ref: "#/components/schemas/CalculateSuccessResponse"
+              examples:
+                success:
+                  summary: Successful calculation
+                  value:
+                    status: ok
+                    message: null
+                    result:
+                      people:
+                        you:
+                          age:
+                            "2025": 30
+                          employment_income:
+                            "2025": 50000
+                      households:
+                        your household:
+                          household_net_income:
+                            "2025": 46375.0
+                    policyengine_bundle:
+                      model_version: 1.687.0
+                      data_version: null
+                      dataset: null
+        400:
+          description: Invalid request payload or unsupported household variable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+              examples:
+                unknown_variable:
+                  summary: Variable not available
+                  value:
+                    status: error
+                    message: Invalid household variables.
+                    errors:
+                      - Variable `not_a_variable` on `people/you` is not available in PolicyEngine model version 1.687.0 used by this API. Remove it or migrate to a supported variable.
+                invalid_payload:
+                  summary: Invalid household payload
+                  value:
+                    status: error
+                    message: "'household' must be a JSON object"
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: The bearer token is valid but not authorized for this API.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
         500:
           description: Error calculating household under policy.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                  message:
-                    type: string
+                $ref: "#/components/schemas/ApiErrorResponse"
         404:
           description: Invalid country ID.
           content:
@@ -876,3 +968,203 @@ paths:
                     type: object
                   servers:
                     type: array
+                  components:
+                    type: object
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Hosted API requests require an Auth0 bearer token. Local Docker requests usually run without authentication.
+  schemas:
+    CalculateRequest:
+      type: object
+      required:
+        - household
+      properties:
+        household:
+          $ref: "#/components/schemas/Household"
+        policy:
+          type: object
+          description: Optional policy reform object passed through to the country model.
+          additionalProperties: true
+        enable_ai_explainer:
+          type: boolean
+          default: false
+          description: When true, the response includes a computation tree UUID that can be passed to the AI analysis endpoint.
+      additionalProperties: false
+    Household:
+      type: object
+      description: A household is a map of entity groups. Each entity group maps entity IDs to variables. Each variable maps periods to values.
+      required:
+        - people
+      properties:
+        people:
+          $ref: "#/components/schemas/EntityGroup"
+        households:
+          $ref: "#/components/schemas/EntityGroup"
+        families:
+          $ref: "#/components/schemas/EntityGroup"
+        tax_units:
+          $ref: "#/components/schemas/EntityGroup"
+        marital_units:
+          $ref: "#/components/schemas/EntityGroup"
+        spm_units:
+          $ref: "#/components/schemas/EntityGroup"
+        benunits:
+          $ref: "#/components/schemas/EntityGroup"
+        axes:
+          type: array
+          description: Optional scan axes. Each axis can vary one variable over a bounded range.
+          items:
+            $ref: "#/components/schemas/AxisEntry"
+      additionalProperties:
+        $ref: "#/components/schemas/EntityGroup"
+    EntityGroup:
+      type: object
+      description: Map of entity IDs to entity payloads.
+      additionalProperties:
+        $ref: "#/components/schemas/Entity"
+      example:
+        you:
+          age:
+            "2025": 30
+          employment_income:
+            "2025": 50000
+    Entity:
+      type: object
+      description: Variables for one entity. The members property links group entities back to people.
+      properties:
+        members:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        $ref: "#/components/schemas/PeriodValueMap"
+    PeriodValueMap:
+      type: object
+      description: Map from a year, month, or other model period to a value.
+      additionalProperties:
+        $ref: "#/components/schemas/HouseholdValue"
+      example:
+        "2025": 50000
+    HouseholdValue:
+      description: A model input or output value for one period.
+      nullable: true
+      oneOf:
+        - type: number
+        - type: string
+        - type: boolean
+        - type: array
+          items: {}
+        - type: object
+          additionalProperties: true
+    AxisEntry:
+      description: A single axis specification or a crossed list of axis specifications.
+      oneOf:
+        - $ref: "#/components/schemas/Axis"
+        - type: array
+          items:
+            $ref: "#/components/schemas/Axis"
+    Axis:
+      type: object
+      required:
+        - name
+        - min
+        - max
+        - count
+      properties:
+        name:
+          type: string
+          description: Variable name to scan.
+          example: employment_income
+        period:
+          type: string
+          description: Period to scan.
+          example: "2025"
+        min:
+          type: number
+          example: 0
+        max:
+          type: number
+          example: 100000
+        count:
+          type: integer
+          minimum: 1
+          maximum: 100
+          example: 11
+    CalculateSuccessResponse:
+      type: object
+      required:
+        - status
+        - message
+        - result
+        - policyengine_bundle
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+        message:
+          type: string
+          nullable: true
+        result:
+          $ref: "#/components/schemas/CalculationResult"
+        policyengine_bundle:
+          $ref: "#/components/schemas/PolicyEngineBundle"
+        warnings:
+          type: array
+          description: Non-fatal request warnings, such as deprecated variable inputs or surprising period shapes.
+          items:
+            type: string
+        computation_tree_uuid:
+          type: string
+          format: uuid
+          description: Returned only when enable_ai_explainer is true.
+    CalculationResult:
+      type: object
+      description: Calculated household data, keyed by entity group, entity ID, variable name, and period.
+      additionalProperties:
+        $ref: "#/components/schemas/EntityGroup"
+    PolicyEngineBundle:
+      type: object
+      required:
+        - model_version
+      properties:
+        model_version:
+          type: string
+          description: Version of the country model used for the calculation.
+        data_version:
+          type: string
+          nullable: true
+          description: Version of the input data used by the country model, when available.
+        dataset:
+          type: string
+          nullable: true
+          description: Dataset used by the country model, when available.
+      additionalProperties: true
+    ApiErrorResponse:
+      type: object
+      required:
+        - status
+        - message
+      properties:
+        status:
+          type: string
+          enum:
+            - error
+        message:
+          type: string
+        errors:
+          type: array
+          description: Field-level or variable-level validation messages.
+          items:
+            type: string
+    AuthErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        error_description:
+          type: string

--- a/policyengine_household_api/openapi_spec.yaml
+++ b/policyengine_household_api/openapi_spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: PolicyEngine Household API
   description: The PolicyEngine Household API calculates policy outcomes for household JSON payloads without storing household data.
-  version: "1.0.0"
+  version: PACKAGE_VERSION
   contact:
     name: PolicyEngine Support
     email: hello@policyengine.org

--- a/policyengine_household_api/utils/deprecated_inputs.py
+++ b/policyengine_household_api/utils/deprecated_inputs.py
@@ -8,6 +8,7 @@ landing — every other output computes normally; only outputs that
 depended on the deprecated input fall back to defaults.
 """
 
+import copy
 from dataclasses import dataclass
 
 
@@ -43,14 +44,22 @@ class DeprecatedVariableWarning:
         )
 
 
+@dataclass(frozen=True)
+class DeprecatedInputsResult:
+    """A household copy with deprecated inputs removed plus warnings."""
+
+    household: dict
+    warnings: list[DeprecatedVariableWarning]
+
+
 def drop_deprecated_inputs(
     household: dict,
-) -> list[DeprecatedVariableWarning]:
-    """Strip deprecated input keys from ``household`` in place.
+) -> DeprecatedInputsResult:
+    """Return a household copy with deprecated input keys stripped.
 
-    Returns one warning per (entity, deprecated-key) occurrence. Mutates
-    ``household`` so downstream validation and the simulation never see
-    the deprecated keys.
+    Returns one warning per (entity, deprecated-key) occurrence. The
+    caller's ``household`` is never mutated; downstream validation and
+    simulation receive the returned copy.
 
     Non-dict inputs are returned unchanged with no warnings; the
     Pydantic schema check that runs immediately after will reject the
@@ -59,9 +68,11 @@ def drop_deprecated_inputs(
     warnings: list[DeprecatedVariableWarning] = []
 
     if not isinstance(household, dict):
-        return warnings
+        return DeprecatedInputsResult(household=household, warnings=warnings)
 
-    for entity_plural, entity_group in household.items():
+    cleaned_household = copy.deepcopy(household)
+
+    for entity_plural, entity_group in cleaned_household.items():
         if entity_plural == "axes":
             continue
         if not isinstance(entity_group, dict):
@@ -83,9 +94,11 @@ def drop_deprecated_inputs(
                 )
                 del variables[variable_name]
 
-    _drop_deprecated_axes(household, warnings)
+    _drop_deprecated_axes(cleaned_household, warnings)
 
-    return warnings
+    return DeprecatedInputsResult(
+        household=cleaned_household, warnings=warnings
+    )
 
 
 def _drop_deprecated_axes(

--- a/policyengine_household_api/utils/variable_validation.py
+++ b/policyengine_household_api/utils/variable_validation.py
@@ -1,0 +1,121 @@
+"""Validate household variable names before building a simulation."""
+
+from dataclasses import dataclass
+
+from policyengine_household_api.utils.deprecated_inputs import (
+    DEPRECATED_VARIABLES,
+)
+from policyengine_household_api.utils.household import VARIABLE_BLACKLIST
+
+
+@dataclass(frozen=True)
+class HouseholdVariableValidationError:
+    """An unavailable variable name was supplied in a household payload."""
+
+    variable: str
+    entity_plural: str
+    entity_id: str
+    model_version: str | None = None
+
+    @property
+    def location(self) -> str:
+        if self.entity_plural == "axes":
+            return f"`axes[{self.entity_id}].name`"
+        return f"`{self.entity_plural}/{self.entity_id}`"
+
+    @property
+    def message(self) -> str:
+        version = (
+            f"PolicyEngine model version {self.model_version}"
+            if self.model_version
+            else "the current PolicyEngine model version"
+        )
+        return (
+            f"Variable `{self.variable}` on {self.location} is not available "
+            f"in {version} "
+            f"used by this API. Remove it or migrate to a supported variable."
+        )
+
+
+def validate_household_variables(
+    household: dict,
+    system,
+    model_version: str | None = None,
+) -> list[HouseholdVariableValidationError]:
+    """Return unavailable variable names found in ``household``.
+
+    A variable is accepted when it exists in the active tax-benefit
+    system or is explicitly listed in the deprecated-variable allowlist.
+    Deprecated variables are filtered out later with a warning.
+    """
+    if not isinstance(household, dict):
+        return []
+
+    errors: list[HouseholdVariableValidationError] = []
+
+    for entity_plural, entity_group in household.items():
+        if entity_plural == "axes" or not isinstance(entity_group, dict):
+            continue
+        for entity_id, variables in entity_group.items():
+            if not isinstance(variables, dict):
+                continue
+            for variable_name, period_map in variables.items():
+                if variable_name in VARIABLE_BLACKLIST:
+                    continue
+                if not isinstance(period_map, dict):
+                    continue
+                if _is_available_variable(variable_name, system):
+                    continue
+                errors.append(
+                    HouseholdVariableValidationError(
+                        variable=variable_name,
+                        entity_plural=entity_plural,
+                        entity_id=entity_id,
+                        model_version=model_version,
+                    )
+                )
+
+    for location, variable_name in _walk_axis_variable_names(household):
+        if _is_available_variable(variable_name, system):
+            continue
+        errors.append(
+            HouseholdVariableValidationError(
+                variable=variable_name,
+                entity_plural="axes",
+                entity_id=location,
+                model_version=model_version,
+            )
+        )
+
+    return errors
+
+
+def _is_available_variable(variable_name: str, system) -> bool:
+    return (
+        variable_name in system.variables
+        or variable_name in DEPRECATED_VARIABLES
+    )
+
+
+def _walk_axis_variable_names(household: dict):
+    axes = household.get("axes")
+    if not isinstance(axes, list):
+        return
+
+    for entry_index, entry in enumerate(axes):
+        if isinstance(entry, list):
+            for axis_index, axis in enumerate(entry):
+                if not isinstance(axis, dict):
+                    continue
+                variable_name = axis.get("name")
+                if variable_name is None:
+                    continue
+                yield f"{entry_index}][{axis_index}", variable_name
+            continue
+
+        if not isinstance(entry, dict):
+            continue
+        variable_name = entry.get("name")
+        if variable_name is None:
+            continue
+        yield str(entry_index), variable_name

--- a/tests/unit/endpoints/test_home.py
+++ b/tests/unit/endpoints/test_home.py
@@ -19,6 +19,10 @@ class TestHomeEndpoint:
             result["container_image"]
             == "ghcr.io/policyengine/policyengine-household-api"
         )
+        assert (
+            result["openapi_spec_url"]
+            == "https://household.api.policyengine.org/specification"
+        )
         assert result["hosted_calculate_url_template"] == (
             "https://household.api.policyengine.org/{country_id}/calculate"
         )
@@ -29,3 +33,20 @@ class TestHomeEndpoint:
             "liveness": "/liveness_check",
             "readiness": "/readiness_check",
         }
+
+    def test_specification_returns_openapi_json(self, client):
+        response = client.get("/specification")
+
+        assert response.status_code == 200
+        assert response.mimetype == "application/json"
+
+        payload = json.loads(response.data)
+        assert payload["openapi"] == "3.0.0"
+        assert payload["info"]["title"] == "PolicyEngine Household API"
+        assert (
+            payload["paths"]["/{country_id}/calculate"]["post"]["requestBody"][
+                "content"
+            ]["application/json"]["schema"]["$ref"]
+            == "#/components/schemas/CalculateRequest"
+        )
+        assert "bearerAuth" in payload["components"]["securitySchemes"]

--- a/tests/unit/endpoints/test_home.py
+++ b/tests/unit/endpoints/test_home.py
@@ -1,5 +1,7 @@
 import json
 
+from policyengine_household_api.api import get_api_version
+
 
 class TestHomeEndpoint:
     def test_returns_json_service_metadata(self, client):
@@ -43,6 +45,7 @@ class TestHomeEndpoint:
         payload = json.loads(response.data)
         assert payload["openapi"] == "3.0.0"
         assert payload["info"]["title"] == "PolicyEngine Household API"
+        assert payload["info"]["version"] == get_api_version()
         assert (
             payload["paths"]["/{country_id}/calculate"]["post"]["requestBody"][
                 "content"

--- a/tests/unit/endpoints/test_household.py
+++ b/tests/unit/endpoints/test_household.py
@@ -223,6 +223,55 @@ class TestCalculateEndpoint:
             for w in payload["warnings"]
         )
 
+    def test__unknown_input_variable__returns_400_with_errors(self, client):
+        household = {
+            **valid_household_requesting_ctc_calculation,
+            "people": {
+                "you": {
+                    "age": {"2024": 40},
+                    "definitely_not_a_variable": {"2024": 0},
+                }
+            },
+        }
+
+        response = client.post(
+            "/us/calculate",
+            json={"household": household},
+            headers=self.auth_headers,
+        )
+
+        assert response.status_code == 400
+        payload = json.loads(response.data)
+        assert payload["status"] == "error"
+        assert payload["message"] == "Invalid household variables."
+        assert "errors" in payload
+        assert any(
+            "Variable `definitely_not_a_variable`" in error
+            and "PolicyEngine model version" in error
+            for error in payload["errors"]
+        )
+
+    def test__unknown_axis_variable__returns_400_with_errors(self, client):
+        household = {
+            **valid_household_requesting_ctc_calculation,
+            "axes": [{"name": "definitely_not_a_variable", "count": 2}],
+        }
+
+        response = client.post(
+            "/us/calculate",
+            json={"household": household},
+            headers=self.auth_headers,
+        )
+
+        assert response.status_code == 400
+        payload = json.loads(response.data)
+        assert payload["status"] == "error"
+        assert any(
+            "Variable `definitely_not_a_variable`" in error
+            and "axes[0].name" in error
+            for error in payload["errors"]
+        )
+
     def test__given_ai_explainer_tracer_fails__returns_500(self, client):
         with patch(
             "policyengine_household_api.country.generate_computation_tree",

--- a/tests/unit/utils/test_deprecated_inputs.py
+++ b/tests/unit/utils/test_deprecated_inputs.py
@@ -1,13 +1,16 @@
 """Unit tests for the deprecated-input warn-and-drop helper.
 
-`drop_deprecated_inputs` strips removed/renamed model variables from the
-inbound household payload before validation so partners who still pass
+`drop_deprecated_inputs` returns a household copy with removed/renamed
+model variables stripped before validation so partners who still pass
 them get a structured warning + working response instead of a
 `VariableNotFoundError` HTTP 500 from the engine.
 """
 
+import copy
+
 from policyengine_household_api.utils.deprecated_inputs import (
     DEPRECATED_VARIABLES,
+    DeprecatedInputsResult,
     DeprecatedVariableWarning,
     drop_deprecated_inputs,
 )
@@ -23,14 +26,20 @@ class TestDropDeprecatedInputs:
                 }
             }
         }
+        original = copy.deepcopy(household)
 
-        warnings = drop_deprecated_inputs(household)
+        result = drop_deprecated_inputs(household)
+        cleaned = result.household
+        warnings = result.warnings
 
         assert (
-            "medical_out_of_pocket_expenses" not in household["people"]["you"]
+            "medical_out_of_pocket_expenses"
+            not in cleaned["people"]["you"]
         )
-        assert household["people"]["you"]["age"] == {"2025": 49}
+        assert household == original
+        assert cleaned["people"]["you"]["age"] == {"2025": 49}
         assert len(warnings) == 1
+        assert isinstance(result, DeprecatedInputsResult)
         assert isinstance(warnings[0], DeprecatedVariableWarning)
         assert warnings[0].variable == "medical_out_of_pocket_expenses"
         assert warnings[0].entity_plural == "people"
@@ -42,12 +51,14 @@ class TestDropDeprecatedInputs:
             "people": {"you": {"age": {"2025": 49}}},
             "households": {"household": {"members": ["you"]}},
         }
-        original = {"people": dict(household["people"]["you"])}
+        original = copy.deepcopy(household)
 
-        warnings = drop_deprecated_inputs(household)
+        result = drop_deprecated_inputs(household)
 
-        assert warnings == []
-        assert household["people"]["you"] == original["people"]
+        assert result.warnings == []
+        assert result.household == household
+        assert result.household is not household
+        assert household == original
 
     def test__deprecated_variable_on_multiple_people__warns_each(self):
         household = {
@@ -60,14 +71,17 @@ class TestDropDeprecatedInputs:
                 },
             }
         }
+        original = copy.deepcopy(household)
 
-        warnings = drop_deprecated_inputs(household)
+        result = drop_deprecated_inputs(household)
+        warnings = result.warnings
 
         assert len(warnings) == 2
         ids = {w.entity_id for w in warnings}
         assert ids == {"you", "spouse"}
-        assert household["people"]["you"] == {}
-        assert household["people"]["spouse"] == {}
+        assert result.household["people"]["you"] == {}
+        assert result.household["people"]["spouse"] == {}
+        assert household == original
 
     def test__list_valued_entity_group__is_skipped_safely(self):
         # `axes` is a list at the household level, not an entity dict.
@@ -76,13 +90,15 @@ class TestDropDeprecatedInputs:
             "people": {"you": {"age": {"2025": 49}}},
             "axes": [[{"name": "employment_income", "count": 5}]],
         }
+        original = copy.deepcopy(household)
 
-        warnings = drop_deprecated_inputs(household)
+        result = drop_deprecated_inputs(household)
 
-        assert warnings == []
-        assert household["axes"] == [
+        assert result.warnings == []
+        assert result.household["axes"] == [
             [{"name": "employment_income", "count": 5}]
         ]
+        assert household == original
 
     def test__deprecated_axis_name__is_dropped_with_warning(self):
         household = {
@@ -106,10 +122,12 @@ class TestDropDeprecatedInputs:
                 ]
             ],
         }
+        original = copy.deepcopy(household)
 
-        warnings = drop_deprecated_inputs(household)
+        result = drop_deprecated_inputs(household)
+        warnings = result.warnings
 
-        assert household["axes"] == [
+        assert result.household["axes"] == [
             [
                 {
                     "name": "employment_income",
@@ -124,6 +142,7 @@ class TestDropDeprecatedInputs:
         assert warnings[0].entity_plural == "axes"
         assert warnings[0].entity_id == "0][0"
         assert "axes[0][0].name" in warnings[0].message
+        assert household == original
 
     def test__only_deprecated_axis_names__removes_axes_key(self):
         household = {
@@ -140,11 +159,13 @@ class TestDropDeprecatedInputs:
                 ]
             ],
         }
+        original = copy.deepcopy(household)
 
-        warnings = drop_deprecated_inputs(household)
+        result = drop_deprecated_inputs(household)
 
-        assert "axes" not in household
-        assert len(warnings) == 1
+        assert "axes" not in result.household
+        assert len(result.warnings) == 1
+        assert household == original
 
     def test__list_valued_variable__is_not_misinterpreted(self):
         # `members` is a list-valued slot on entity groups; the helper must
@@ -157,11 +178,13 @@ class TestDropDeprecatedInputs:
                 }
             }
         }
+        original = copy.deepcopy(household)
 
-        warnings = drop_deprecated_inputs(household)
+        result = drop_deprecated_inputs(household)
 
-        assert warnings == []
-        assert household["spm_units"]["spm_unit"]["members"] == ["you"]
+        assert result.warnings == []
+        assert result.household["spm_units"]["spm_unit"]["members"] == ["you"]
+        assert household == original
 
     def test__warning_message_includes_variable_entity_and_hint(self):
         warning = DeprecatedVariableWarning(

--- a/tests/unit/utils/test_deprecated_inputs.py
+++ b/tests/unit/utils/test_deprecated_inputs.py
@@ -32,10 +32,7 @@ class TestDropDeprecatedInputs:
         cleaned = result.household
         warnings = result.warnings
 
-        assert (
-            "medical_out_of_pocket_expenses"
-            not in cleaned["people"]["you"]
-        )
+        assert "medical_out_of_pocket_expenses" not in cleaned["people"]["you"]
         assert household == original
         assert cleaned["people"]["you"]["age"] == {"2025": 49}
         assert len(warnings) == 1

--- a/tests/unit/utils/test_variable_validation.py
+++ b/tests/unit/utils/test_variable_validation.py
@@ -1,0 +1,127 @@
+import pytest
+from policyengine_us import CountryTaxBenefitSystem
+
+from policyengine_household_api.utils.variable_validation import (
+    HouseholdVariableValidationError,
+    validate_household_variables,
+)
+
+
+@pytest.fixture(scope="module")
+def us_system():
+    return CountryTaxBenefitSystem()
+
+
+class TestValidateHouseholdVariables:
+    def test__known_variables__return_no_errors(self, us_system):
+        household = {
+            "people": {
+                "you": {
+                    "age": {"2026": 40},
+                    "employment_income": {"2026": 50_000},
+                }
+            },
+            "households": {
+                "household": {
+                    "members": ["you"],
+                    "state_code_str": {"2026": "CA"},
+                }
+            },
+        }
+
+        errors = validate_household_variables(
+            household, us_system, model_version="1.687.0"
+        )
+
+        assert errors == []
+
+    def test__deprecated_allowlisted_variable__returns_no_errors(
+        self, us_system
+    ):
+        household = {
+            "people": {
+                "you": {
+                    "medical_out_of_pocket_expenses": {"2026": 100},
+                }
+            }
+        }
+
+        errors = validate_household_variables(
+            household, us_system, model_version="1.687.0"
+        )
+
+        assert errors == []
+
+    def test__unknown_variable__returns_error(self, us_system):
+        household = {
+            "people": {
+                "you": {
+                    "definitely_not_a_variable": {"2026": 100},
+                }
+            }
+        }
+
+        errors = validate_household_variables(
+            household, us_system, model_version="1.687.0"
+        )
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], HouseholdVariableValidationError)
+        assert errors[0].variable == "definitely_not_a_variable"
+        assert errors[0].entity_plural == "people"
+        assert errors[0].entity_id == "you"
+        assert "Variable `definitely_not_a_variable`" in errors[0].message
+        assert "people/you" in errors[0].message
+        assert "1.687.0" in errors[0].message
+
+    def test__members_list__is_not_treated_as_variable(self, us_system):
+        household = {
+            "spm_units": {
+                "spm_unit": {
+                    "members": ["you"],
+                    "snap": {"2026": None},
+                }
+            }
+        }
+
+        errors = validate_household_variables(
+            household, us_system, model_version="1.687.0"
+        )
+
+        assert errors == []
+
+    def test__unknown_axis_name__returns_error(self, us_system):
+        household = {
+            "people": {"you": {"age": {"2026": 40}}},
+            "axes": [
+                [
+                    {
+                        "name": "not_available_on_this_model",
+                        "period": "2026",
+                        "min": 0,
+                        "max": 100,
+                        "count": 2,
+                    }
+                ]
+            ],
+        }
+
+        errors = validate_household_variables(
+            household, us_system, model_version="1.687.0"
+        )
+
+        assert len(errors) == 1
+        assert errors[0].variable == "not_available_on_this_model"
+        assert "axes[0][0].name" in errors[0].message
+
+    def test__deprecated_axis_name__returns_no_errors(self, us_system):
+        household = {
+            "people": {"you": {"age": {"2026": 40}}},
+            "axes": [{"name": "medical_out_of_pocket_expenses"}],
+        }
+
+        errors = validate_household_variables(
+            household, us_system, model_version="1.687.0"
+        )
+
+        assert errors == []


### PR DESCRIPTION
Fixes #1496

## Summary

- validate household input and axis variable names before calculation, returning HTTP 400 with `errors: string[]` for unsupported variables
- deep-copy household payloads when dropping deprecated allowlisted inputs, preserving existing warning behavior without mutating caller data
- expose `/specification` and expand the calculate OpenAPI contract with request, success, and error schemas/examples

## Tests

- `.venv/bin/python -m pytest -q tests/unit/endpoints/test_home.py tests/unit/endpoints/test_household.py tests/unit/utils/test_deprecated_inputs.py tests/unit/utils/test_variable_validation.py`
- `.venv/bin/ruff check policyengine_household_api/api.py policyengine_household_api/endpoints/home.py tests/unit/endpoints/test_home.py`