### PR TITLE
Add per-partner test-case CRUD service

### DIFF
--- a/changelog.d/test-cases-service.added.md
+++ b/changelog.d/test-cases-service.added.md
@@ -1,0 +1,1 @@
+Added per-partner test-case CRUD endpoints (`/test-cases`) backed by a new `test_cases` table. Each partner client_id owns a library of saved household payloads; an append-only `test_case_audits` table records every mutation for the upcoming staff activity feed.

--- a/policyengine_household_api/api.py
+++ b/policyengine_household_api/api.py
@@ -28,10 +28,15 @@ from policyengine_household_api.decorators.analytics import (
 
 # Endpoints
 from .endpoints import (
-    get_home,
-    get_calculate_analytics_requests,
-    get_calculate,
+    create_test_case,
+    delete_test_case,
     generate_ai_explainer,
+    get_calculate,
+    get_calculate_analytics_requests,
+    get_home,
+    get_test_case,
+    list_test_cases,
+    update_test_case,
 )
 
 # Create the authentication decorator (will be either Auth0 or no-op based on config)
@@ -84,6 +89,46 @@ def calculate(country_id):
 @limiter.limit("60 per minute")
 def calculate_analytics_requests():
     return get_calculate_analytics_requests()
+
+
+# ---------------------------------------------------------------------------
+# Test cases (per-partner saved household payloads, scoped by client_id)
+# ---------------------------------------------------------------------------
+
+
+@app.route("/test-cases", methods=["GET"])
+@require_auth_if_enabled()
+@limiter.limit("60 per minute")
+def test_cases_list():
+    return list_test_cases()
+
+
+@app.route("/test-cases", methods=["POST"])
+@require_auth_if_enabled()
+@limiter.limit("60 per minute")
+def test_cases_create():
+    return create_test_case()
+
+
+@app.route("/test-cases/<int:test_case_id>", methods=["GET"])
+@require_auth_if_enabled()
+@limiter.limit("60 per minute")
+def test_cases_get(test_case_id: int):
+    return get_test_case(test_case_id)
+
+
+@app.route("/test-cases/<int:test_case_id>", methods=["PUT"])
+@require_auth_if_enabled()
+@limiter.limit("60 per minute")
+def test_cases_update(test_case_id: int):
+    return update_test_case(test_case_id)
+
+
+@app.route("/test-cases/<int:test_case_id>", methods=["DELETE"])
+@require_auth_if_enabled()
+@limiter.limit("60 per minute")
+def test_cases_delete(test_case_id: int):
+    return delete_test_case(test_case_id)
 
 
 @app.route("/<country_id>/ai-analysis", methods=["POST"])

--- a/policyengine_household_api/data/models.py
+++ b/policyengine_household_api/data/models.py
@@ -6,12 +6,14 @@ from policyengine_household_api.models.analytics import (
     VariableSource,
 )
 from sqlalchemy import (
+    JSON,
     Boolean,
     DateTime,
     ForeignKey,
     Index,
     Integer,
     String,
+    Text,
 )
 from sqlalchemy.orm import mapped_column
 
@@ -147,4 +149,64 @@ class CalculateRequestVariable(db.Model):
             "model_version",
             "variable_name",
         ),
+    )
+
+
+class TestCase(db.Model):
+    """A saved household payload partners run against the API for migration
+    validation. Owned by the partner client_id that created it; staff
+    callers can read across all client_ids via the as_client_id query
+    param (Phase 2)."""
+
+    # Pytest auto-collects classes named ``Test*``; this is a SQLAlchemy
+    # model, not a test class.
+    __test__ = False
+
+    __tablename__ = "test_cases"
+
+    id = mapped_column(Integer, primary_key=True)
+    client_id = mapped_column(String(255), nullable=False)
+    name = mapped_column(String(255), nullable=False)
+    description = mapped_column(Text, nullable=True)
+    payload = mapped_column(JSON, nullable=False)
+    created_at = mapped_column(DateTime, nullable=False)
+    updated_at = mapped_column(DateTime, nullable=False)
+
+    __table_args__ = (
+        Index("ix_test_cases_client_id", "client_id"),
+        Index("ix_test_cases_client_updated", "client_id", "updated_at"),
+    )
+
+
+class TestCaseAudit(db.Model):
+    """Append-only log of test-case mutations. Powers the staff activity
+    feed and provides forensic history independent of the test_cases
+    row's current state (deletions still leave a trail)."""
+
+    # Pytest auto-collects classes named ``Test*``; this is a SQLAlchemy
+    # model, not a test class.
+    __test__ = False
+
+    __tablename__ = "test_case_audits"
+
+    id = mapped_column(Integer, primary_key=True)
+    # Not a ForeignKey so deletes don't cascade-wipe the audit history.
+    test_case_id = mapped_column(Integer, nullable=False)
+    # The owning partner client_id — used for activity-feed scoping.
+    client_id = mapped_column(String(255), nullable=False)
+    # The client_id that performed the action — equals client_id for
+    # partner self-service, differs when staff edit on a partner's
+    # behalf (Phase 2+).
+    actor_client_id = mapped_column(String(255), nullable=False)
+    action = mapped_column(
+        String(16),
+        nullable=False,
+        info={"options": ("created", "updated", "deleted")},
+    )
+    name_snapshot = mapped_column(String(255), nullable=True)
+    occurred_at = mapped_column(DateTime, nullable=False)
+
+    __table_args__ = (
+        Index("ix_test_case_audits_client_occurred", "client_id", "occurred_at"),
+        Index("ix_test_case_audits_test_case_id", "test_case_id"),
     )

--- a/policyengine_household_api/endpoints/__init__.py
+++ b/policyengine_household_api/endpoints/__init__.py
@@ -6,3 +6,10 @@ from .household import get_calculate as get_calculate
 from .household_explainer import (
     generate_ai_explainer as generate_ai_explainer,
 )
+from .test_cases import (
+    create_test_case as create_test_case,
+    delete_test_case as delete_test_case,
+    get_test_case as get_test_case,
+    list_test_cases as list_test_cases,
+    update_test_case as update_test_case,
+)

--- a/policyengine_household_api/endpoints/test_cases.py
+++ b/policyengine_household_api/endpoints/test_cases.py
@@ -1,0 +1,368 @@
+"""
+Per-partner saved test-case storage.
+
+Each partner client_id owns a library of household payloads. CRUD is
+scoped to the caller's authenticated client_id. Phase 2 will add an
+``as_client_id`` query param honored only for callers carrying the
+``policyengine-staff`` scope.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from typing import Any
+
+from flask import Response, request
+
+from policyengine_household_api.data.analytics_setup import (
+    db,
+    is_analytics_enabled,
+    is_analytics_schema_ready,
+)
+from policyengine_household_api.data.models import TestCase, TestCaseAudit
+from policyengine_household_api.decorators.analytics import (
+    _verified_sub_claim,
+)
+
+
+MAX_NAME_LENGTH = 255
+MAX_DESCRIPTION_LENGTH = 4096
+# Cap individual payloads to keep one-row writes bounded; the API rejects
+# household payloads larger than MAX_CONTENT_LENGTH at the request layer
+# already, but storage cost is per-row so add a tighter ceiling here.
+MAX_PAYLOAD_BYTES = 256 * 1024  # 256 KiB
+
+
+def list_test_cases() -> Response:
+    storage_error = _storage_error_response()
+    if storage_error is not None:
+        return storage_error
+
+    client_id = _resolve_caller_client_id()
+    if client_id is None:
+        return _auth_error()
+
+    rows = (
+        db.session.query(TestCase)
+        .filter(TestCase.client_id == client_id)
+        .order_by(TestCase.updated_at.desc())
+        .all()
+    )
+    return _json_response(
+        {
+            "status": "ok",
+            "message": None,
+            "test_cases": [_serialize(row) for row in rows],
+        }
+    )
+
+
+def get_test_case(test_case_id: int) -> Response:
+    storage_error = _storage_error_response()
+    if storage_error is not None:
+        return storage_error
+
+    client_id = _resolve_caller_client_id()
+    if client_id is None:
+        return _auth_error()
+
+    row = db.session.get(TestCase, test_case_id)
+    if row is None or row.client_id != client_id:
+        return _not_found()
+
+    return _json_response(
+        {"status": "ok", "message": None, "test_case": _serialize(row)}
+    )
+
+
+def create_test_case() -> Response:
+    storage_error = _storage_error_response()
+    if storage_error is not None:
+        return storage_error
+
+    client_id = _resolve_caller_client_id()
+    if client_id is None:
+        return _auth_error()
+
+    try:
+        body = _parse_body(request.get_data())
+    except ValueError as e:
+        return _validation_error(str(e))
+
+    name = body.get("name")
+    description = body.get("description")
+    payload = body.get("payload")
+    try:
+        _validate_writable_fields(name, description, payload)
+    except ValueError as e:
+        return _validation_error(str(e))
+
+    now = datetime.now(timezone.utc)
+    row = TestCase(
+        client_id=client_id,
+        name=name,
+        description=description,
+        payload=payload,
+        created_at=now,
+        updated_at=now,
+    )
+    db.session.add(row)
+    db.session.flush()  # populate row.id
+    _record_audit(
+        test_case_id=row.id,
+        client_id=client_id,
+        actor_client_id=client_id,
+        action="created",
+        name_snapshot=name,
+        occurred_at=now,
+    )
+    db.session.commit()
+
+    return _json_response(
+        {"status": "ok", "message": None, "test_case": _serialize(row)},
+        status=201,
+    )
+
+
+def update_test_case(test_case_id: int) -> Response:
+    storage_error = _storage_error_response()
+    if storage_error is not None:
+        return storage_error
+
+    client_id = _resolve_caller_client_id()
+    if client_id is None:
+        return _auth_error()
+
+    row = db.session.get(TestCase, test_case_id)
+    if row is None or row.client_id != client_id:
+        return _not_found()
+
+    try:
+        body = _parse_body(request.get_data())
+    except ValueError as e:
+        return _validation_error(str(e))
+
+    if "name" in body:
+        name = body["name"]
+        try:
+            _validate_name(name)
+        except ValueError as e:
+            return _validation_error(str(e))
+        row.name = name
+    if "description" in body:
+        description = body["description"]
+        try:
+            _validate_description(description)
+        except ValueError as e:
+            return _validation_error(str(e))
+        row.description = description
+    if "payload" in body:
+        payload = body["payload"]
+        try:
+            _validate_payload(payload)
+        except ValueError as e:
+            return _validation_error(str(e))
+        row.payload = payload
+
+    now = datetime.now(timezone.utc)
+    row.updated_at = now
+    _record_audit(
+        test_case_id=row.id,
+        client_id=client_id,
+        actor_client_id=client_id,
+        action="updated",
+        name_snapshot=row.name,
+        occurred_at=now,
+    )
+    db.session.commit()
+
+    return _json_response(
+        {"status": "ok", "message": None, "test_case": _serialize(row)}
+    )
+
+
+def delete_test_case(test_case_id: int) -> Response:
+    storage_error = _storage_error_response()
+    if storage_error is not None:
+        return storage_error
+
+    client_id = _resolve_caller_client_id()
+    if client_id is None:
+        return _auth_error()
+
+    row = db.session.get(TestCase, test_case_id)
+    if row is None or row.client_id != client_id:
+        return _not_found()
+
+    name_snapshot = row.name
+    db.session.delete(row)
+    _record_audit(
+        test_case_id=test_case_id,
+        client_id=client_id,
+        actor_client_id=client_id,
+        action="deleted",
+        name_snapshot=name_snapshot,
+        occurred_at=datetime.now(timezone.utc),
+    )
+    db.session.commit()
+
+    return _json_response({"status": "ok", "message": None})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _storage_error_response() -> Response | None:
+    if not is_analytics_enabled():
+        return _json_response(
+            {
+                "status": "error",
+                "message": "Test-case storage is not enabled for this API instance.",
+            },
+            status=503,
+        )
+    if not is_analytics_schema_ready():
+        return _json_response(
+            {
+                "status": "error",
+                "message": "Test-case storage is not ready.",
+            },
+            status=503,
+        )
+    return None
+
+
+def _resolve_caller_client_id() -> str | None:
+    """Extract and verify the bearer-token sub claim, normalize the
+    Auth0 ``@clients`` suffix, and return the resulting client_id."""
+    try:
+        auth_header = str(request.authorization)
+        token = auth_header.split(" ")[1]
+    except Exception:
+        return None
+    sub = _verified_sub_claim(token)
+    if sub is None:
+        return None
+    suffix = "@clients"
+    return sub[: -len(suffix)] if sub.endswith(suffix) else sub
+
+
+def _record_audit(
+    *,
+    test_case_id: int,
+    client_id: str,
+    actor_client_id: str,
+    action: str,
+    name_snapshot: str | None,
+    occurred_at: datetime,
+) -> None:
+    db.session.add(
+        TestCaseAudit(
+            test_case_id=test_case_id,
+            client_id=client_id,
+            actor_client_id=actor_client_id,
+            action=action,
+            name_snapshot=name_snapshot,
+            occurred_at=occurred_at,
+        )
+    )
+
+
+def _serialize(row: TestCase) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "name": row.name,
+        "description": row.description,
+        "payload": row.payload,
+        "created_at": _datetime_to_json(row.created_at),
+        "updated_at": _datetime_to_json(row.updated_at),
+    }
+
+
+def _parse_body(raw: bytes) -> dict[str, Any]:
+    if not raw:
+        raise ValueError("Request body is empty")
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON: {e}")
+    if not isinstance(decoded, dict):
+        raise ValueError("Request body must be a JSON object")
+    return decoded
+
+
+def _validate_writable_fields(
+    name: Any, description: Any, payload: Any
+) -> None:
+    _validate_name(name)
+    _validate_description(description)
+    _validate_payload(payload)
+
+
+def _validate_name(name: Any) -> None:
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("`name` must be a non-empty string")
+    if len(name) > MAX_NAME_LENGTH:
+        raise ValueError(f"`name` must be {MAX_NAME_LENGTH} characters or fewer")
+
+
+def _validate_description(description: Any) -> None:
+    if description is None:
+        return
+    if not isinstance(description, str):
+        raise ValueError("`description` must be a string or null")
+    if len(description) > MAX_DESCRIPTION_LENGTH:
+        raise ValueError(
+            f"`description` must be {MAX_DESCRIPTION_LENGTH} characters or fewer"
+        )
+
+
+def _validate_payload(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("`payload` must be a JSON object")
+    encoded_size = len(json.dumps(payload).encode("utf-8"))
+    if encoded_size > MAX_PAYLOAD_BYTES:
+        raise ValueError(
+            f"`payload` must be {MAX_PAYLOAD_BYTES} bytes or fewer "
+            f"when JSON-encoded; got {encoded_size}"
+        )
+
+
+def _datetime_to_json(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _validation_error(message: str) -> Response:
+    return _json_response(
+        {"status": "error", "message": message},
+        status=400,
+    )
+
+
+def _auth_error() -> Response:
+    return _json_response(
+        {"status": "error", "message": "Could not identify caller."},
+        status=401,
+    )
+
+
+def _not_found() -> Response:
+    return _json_response(
+        {"status": "error", "message": "Test case not found."},
+        status=404,
+    )
+
+
+def _json_response(body: dict[str, Any], status: int = 200) -> Response:
+    return Response(
+        json.dumps(body).encode("utf-8"),
+        status=status,
+        mimetype="application/json",
+    )

--- a/policyengine_household_api/openapi_spec.yaml
+++ b/policyengine_household_api/openapi_spec.yaml
@@ -805,6 +805,180 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiErrorResponse"
+  /test-cases:
+    get:
+      summary: List test cases owned by the caller
+      operationId: list_test_cases
+      description: Returns every saved test case belonging to the authenticated client_id, most recently updated first.
+      security:
+        - bearerAuth: []
+      responses:
+        200:
+          description: Test cases owned by the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestCaseListResponse"
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        503:
+          description: Test-case storage is disabled or not ready.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+    post:
+      summary: Create a test case
+      operationId: create_test_case
+      description: Persist a new household payload owned by the authenticated client_id.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestCaseWriteRequest"
+      responses:
+        201:
+          description: The created test case.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestCaseResponse"
+        400:
+          description: Invalid request payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        503:
+          description: Test-case storage is disabled or not ready.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+  /test-cases/{test_case_id}:
+    get:
+      summary: Get a single test case owned by the caller
+      operationId: get_test_case
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: test_case_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: The requested test case.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestCaseResponse"
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        404:
+          description: No test case with that id is owned by the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+    put:
+      summary: Update a test case owned by the caller
+      operationId: update_test_case
+      description: Partial update — fields omitted from the body are left unchanged.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: test_case_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestCaseWriteRequest"
+      responses:
+        200:
+          description: The updated test case.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestCaseResponse"
+        400:
+          description: Invalid request payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        404:
+          description: No test case with that id is owned by the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+    delete:
+      summary: Delete a test case owned by the caller
+      operationId: delete_test_case
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: test_case_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: The test case was deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [ok]
+                  message:
+                    type: string
+                    nullable: true
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        404:
+          description: No test case with that id is owned by the caller.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
   /{country_id}/economy/{policy_id}/over/{baseline_policy_id}:
     get:
       summary: Calculate the economic impact of a policy
@@ -1432,3 +1606,77 @@ components:
         - mixed
         - none
         - unknown
+    TestCase:
+      type: object
+      required:
+        - id
+        - name
+        - payload
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: integer
+          description: Server-assigned identifier.
+        name:
+          type: string
+          maxLength: 255
+          description: Short label shown in the partner UI.
+        description:
+          type: string
+          nullable: true
+          maxLength: 4096
+          description: Optional longer-form context for the test case.
+        payload:
+          $ref: "#/components/schemas/Household"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    TestCaseWriteRequest:
+      type: object
+      description: Request body for create/update. Update is partial — only fields present are changed.
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+          nullable: true
+          maxLength: 4096
+        payload:
+          $ref: "#/components/schemas/Household"
+    TestCaseResponse:
+      type: object
+      required:
+        - status
+        - message
+        - test_case
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        message:
+          type: string
+          nullable: true
+        test_case:
+          $ref: "#/components/schemas/TestCase"
+    TestCaseListResponse:
+      type: object
+      required:
+        - status
+        - message
+        - test_cases
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        message:
+          type: string
+          nullable: true
+        test_cases:
+          type: array
+          items:
+            $ref: "#/components/schemas/TestCase"

--- a/tests/unit/endpoints/test_test_cases.py
+++ b/tests/unit/endpoints/test_test_cases.py
@@ -1,0 +1,310 @@
+"""Unit tests for the test-cases CRUD endpoints.
+
+Verifies per-client_id scoping (one partner can never read or mutate
+another's cases), validation, and that the audit log captures every
+mutation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+
+from policyengine_household_api.data.analytics_setup import db
+from policyengine_household_api.data.models import TestCase, TestCaseAudit
+from policyengine_household_api.endpoints.test_cases import (
+    create_test_case,
+    delete_test_case,
+    get_test_case,
+    list_test_cases,
+    update_test_case,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_cases_app(tmp_path, monkeypatch):
+    """Minimal Flask app with the in-memory SQLite analytics DB and the
+    test-cases storage gating helpers stubbed to "ready"."""
+    monkeypatch.setattr(
+        "policyengine_household_api.endpoints.test_cases.is_analytics_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "policyengine_household_api.endpoints.test_cases.is_analytics_schema_ready",
+        lambda: True,
+    )
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = (
+        f"sqlite:///{tmp_path / 'test-cases.db'}"
+    )
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def call_as(monkeypatch):
+    """Returns a context manager that pretends a request arrived from
+    the given client_id. Stubs the bearer-token sub-claim verification
+    so handlers see ``client_id`` without going through Auth0."""
+
+    def _stub(client_id: str | None):
+        monkeypatch.setattr(
+            "policyengine_household_api.endpoints.test_cases._verified_sub_claim",
+            lambda token: f"{client_id}@clients" if client_id else None,
+        )
+
+    return _stub
+
+
+def _request_context(app, *, method: str, body: dict | None = None):
+    return app.test_request_context(
+        method=method,
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+
+def _payload() -> dict:
+    return {
+        "people": {"adult": {"age": {"2025": 30}}},
+        "households": {"household": {"members": ["adult"]}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+def test__create__persists_and_returns_201(test_cases_app, call_as):
+    call_as("acme")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={
+            "name": "Single filer",
+            "description": "30-year-old, $30k income",
+            "payload": _payload(),
+        },
+    ):
+        response = create_test_case()
+
+    body = json.loads(response.data)
+    assert response.status_code == 201
+    assert body["status"] == "ok"
+    assert body["test_case"]["name"] == "Single filer"
+    assert body["test_case"]["payload"] == _payload()
+    assert body["test_case"]["id"] > 0
+
+    # Persisted to the right client_id and audited.
+    rows = db.session.query(TestCase).all()
+    assert [r.client_id for r in rows] == ["acme"]
+    audits = db.session.query(TestCaseAudit).all()
+    assert [(a.action, a.actor_client_id) for a in audits] == [
+        ("created", "acme")
+    ]
+
+
+@pytest.mark.parametrize(
+    "body,expected_message_fragment",
+    [
+        ({"name": "", "payload": {}}, "non-empty string"),
+        ({"name": "x", "payload": "not a dict"}, "JSON object"),
+        ({"name": "x"}, "JSON object"),  # missing payload
+        ({"payload": {}}, "non-empty string"),  # missing name
+    ],
+)
+def test__create__rejects_invalid_input(
+    test_cases_app, call_as, body, expected_message_fragment
+):
+    call_as("acme")
+    with _request_context(test_cases_app, method="POST", body=body):
+        response = create_test_case()
+    assert response.status_code == 400
+    assert expected_message_fragment in json.loads(response.data)["message"]
+
+
+def test__create__rejects_unauthenticated_caller(test_cases_app, call_as):
+    call_as(None)
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={"name": "x", "payload": _payload()},
+    ):
+        response = create_test_case()
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# List + scoping
+# ---------------------------------------------------------------------------
+
+
+def test__list__only_returns_callers_cases(test_cases_app, call_as):
+    # acme creates two cases.
+    call_as("acme")
+    for name in ("acme-one", "acme-two"):
+        with _request_context(
+            test_cases_app,
+            method="POST",
+            body={"name": name, "payload": _payload()},
+        ):
+            create_test_case()
+
+    # impactica creates a third case with the same name.
+    call_as("impactica")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={"name": "acme-one", "payload": _payload()},
+    ):
+        create_test_case()
+
+    # impactica only sees their own.
+    with _request_context(test_cases_app, method="GET"):
+        response = list_test_cases()
+    body = json.loads(response.data)
+    assert response.status_code == 200
+    assert {c["name"] for c in body["test_cases"]} == {"acme-one"}
+
+    # acme only sees their two.
+    call_as("acme")
+    with _request_context(test_cases_app, method="GET"):
+        response = list_test_cases()
+    body = json.loads(response.data)
+    assert {c["name"] for c in body["test_cases"]} == {
+        "acme-one",
+        "acme-two",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Get + update + delete: cross-client isolation
+# ---------------------------------------------------------------------------
+
+
+def test__get__rejects_other_clients_case(test_cases_app, call_as):
+    call_as("acme")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={"name": "acme case", "payload": _payload()},
+    ):
+        created = json.loads(create_test_case().data)["test_case"]
+
+    call_as("impactica")
+    with _request_context(test_cases_app, method="GET"):
+        response = get_test_case(created["id"])
+    assert response.status_code == 404
+
+
+def test__update__changes_only_allowed_fields(test_cases_app, call_as):
+    call_as("acme")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={
+            "name": "before",
+            "description": "old",
+            "payload": _payload(),
+        },
+    ):
+        created = json.loads(create_test_case().data)["test_case"]
+
+    new_payload = {
+        "people": {"adult": {"age": {"2026": 31}}},
+        "households": {"household": {"members": ["adult"]}},
+    }
+    with _request_context(
+        test_cases_app,
+        method="PUT",
+        body={"name": "after", "payload": new_payload},
+    ):
+        response = update_test_case(created["id"])
+    body = json.loads(response.data)
+    assert response.status_code == 200
+    assert body["test_case"]["name"] == "after"
+    assert body["test_case"]["payload"] == new_payload
+    # Description was not in the body, so it stays.
+    assert body["test_case"]["description"] == "old"
+
+    # Update audited.
+    actions = [
+        a.action for a in db.session.query(TestCaseAudit).order_by(TestCaseAudit.id)
+    ]
+    assert actions == ["created", "updated"]
+
+
+def test__update__rejects_other_clients_case(test_cases_app, call_as):
+    call_as("acme")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={"name": "acme", "payload": _payload()},
+    ):
+        created = json.loads(create_test_case().data)["test_case"]
+
+    call_as("impactica")
+    with _request_context(
+        test_cases_app, method="PUT", body={"name": "stolen"}
+    ):
+        response = update_test_case(created["id"])
+    assert response.status_code == 404
+    # Still owned by acme with original name.
+    row = db.session.get(TestCase, created["id"])
+    assert row.client_id == "acme"
+    assert row.name == "acme"
+
+
+def test__delete__removes_row_and_audits(test_cases_app, call_as):
+    call_as("acme")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={"name": "doomed", "payload": _payload()},
+    ):
+        created = json.loads(create_test_case().data)["test_case"]
+
+    with _request_context(test_cases_app, method="DELETE"):
+        response = delete_test_case(created["id"])
+    assert response.status_code == 200
+    assert db.session.get(TestCase, created["id"]) is None
+
+    actions = [
+        a.action for a in db.session.query(TestCaseAudit).order_by(TestCaseAudit.id)
+    ]
+    assert actions == ["created", "deleted"]
+    # Audit retains the name even though the row is gone.
+    deleted_audit = (
+        db.session.query(TestCaseAudit).order_by(TestCaseAudit.id.desc()).first()
+    )
+    assert deleted_audit.name_snapshot == "doomed"
+
+
+def test__delete__rejects_other_clients_case(test_cases_app, call_as):
+    call_as("acme")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={"name": "acme", "payload": _payload()},
+    ):
+        created = json.loads(create_test_case().data)["test_case"]
+
+    call_as("impactica")
+    with _request_context(test_cases_app, method="DELETE"):
+        response = delete_test_case(created["id"])
+    assert response.status_code == 404
+    assert db.session.get(TestCase, created["id"]) is not None


### PR DESCRIPTION
## Summary

Move partner test-case libraries from the portal's browser localStorage to a server-side store on the household-API. This is the gating piece for the upcoming portal master view (PolicyEngine staff seeing across partner environments) — until ownership lives server-side, no cross-partner viewing is structurally possible.

## What changes

- **New tables.** \`test_cases\` (owned by partner client_id) + \`test_case_audits\` (append-only, survives row deletion). Created via the existing \`db.create_all()\` path; Alembic migration will follow once #1504 lands.
- **New CRUD endpoints** at \`/test-cases\` and \`/test-cases/{id}\` (GET list, POST, GET one, PUT, DELETE). Each handler resolves the caller's client_id from the verified bearer-token \`sub\` claim and scopes every query by it — partners can never read or mutate another partner's cases.
- **OpenAPI spec extended** with the new paths and \`TestCase\` / \`TestCaseWriteRequest\` / \`TestCaseResponse\` / \`TestCaseListResponse\` schemas.
- **Changelog fragment** added.

## What's deliberately not in this PR

- \`as_client_id\` query param + the \`policyengine-staff\` scope check that lets staff read across partners — that's Phase 2.
- Alembic migration — depends on the migration infra in #1504.
- Portal-side client wiring — separate PR on \`policyengine-developer-portal\`.

## Test plan

12 unit tests covering:

- [x] Create persists, returns 201, audits the action
- [x] Create rejects empty/missing/non-object inputs (4 parameterized cases)
- [x] Create rejects unauthenticated callers (401)
- [x] List only returns the caller's own cases (verified with two distinct client_ids both creating cases with the same name)
- [x] Get rejects another client's case (404, not 403 — intentional, no info leak)
- [x] Update modifies only fields present in the body, audits the action
- [x] Update rejects another client's case
- [x] Delete removes the row, audits with the name snapshot retained
- [x] Delete rejects another client's case

Run with \`uv run pytest -q tests/unit/endpoints/test_test_cases.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)