### PR TITLE
Add as_client_id staff overlay to test-case endpoints

### DIFF
--- a/changelog.d/staff-as-client-id.added.md
+++ b/changelog.d/staff-as-client-id.added.md
@@ -1,0 +1,1 @@
+Added the `as_client_id` query parameter to all `/test-cases` endpoints. Honored only for callers carrying the new `policyengine-staff` JWT scope; lets PolicyEngine staff read or mutate any partner's test cases on their behalf. Audit rows record the staff actor's client_id separately from the partner whose data was changed.

--- a/policyengine_household_api/decorators/auth.py
+++ b/policyengine_household_api/decorators/auth.py
@@ -14,6 +14,11 @@ from ..utils.config_loader import get_config_value
 
 ANALYTICS_READ_SCOPE = "read:calculate-analytics"
 
+# JWT scope that grants PolicyEngine-staff access — read across any
+# partner's resources, plus the ability to act on a partner's behalf
+# via the ``as_client_id`` query parameter on supported endpoints.
+STAFF_SCOPE = "policyengine-staff"
+
 
 class StaticBearerToken:
     """Minimal token object for test-only bearer token validation."""

--- a/policyengine_household_api/endpoints/test_cases.py
+++ b/policyengine_household_api/endpoints/test_cases.py
@@ -2,17 +2,20 @@
 Per-partner saved test-case storage.
 
 Each partner client_id owns a library of household payloads. CRUD is
-scoped to the caller's authenticated client_id. Phase 2 will add an
-``as_client_id`` query param honored only for callers carrying the
-``policyengine-staff`` scope.
+scoped to the caller's authenticated client_id. PolicyEngine-staff
+tokens (those carrying the ``policyengine-staff`` scope) can act on
+any partner's behalf via the ``as_client_id`` query parameter.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
+import logging
 from typing import Any
 
+import jwt
 from flask import Response, request
 
 from policyengine_household_api.data.analytics_setup import (
@@ -22,8 +25,13 @@ from policyengine_household_api.data.analytics_setup import (
 )
 from policyengine_household_api.data.models import TestCase, TestCaseAudit
 from policyengine_household_api.decorators.analytics import (
-    _verified_sub_claim,
+    _get_jwks_client,
 )
+from policyengine_household_api.decorators.auth import STAFF_SCOPE
+from policyengine_household_api.utils.config_loader import get_config_value
+
+
+logger = logging.getLogger(__name__)
 
 
 MAX_NAME_LENGTH = 255
@@ -39,13 +47,13 @@ def list_test_cases() -> Response:
     if storage_error is not None:
         return storage_error
 
-    client_id = _resolve_caller_client_id()
-    if client_id is None:
-        return _auth_error()
+    target = _resolve_target_client_id()
+    if target.error is not None:
+        return target.error
 
     rows = (
         db.session.query(TestCase)
-        .filter(TestCase.client_id == client_id)
+        .filter(TestCase.client_id == target.client_id)
         .order_by(TestCase.updated_at.desc())
         .all()
     )
@@ -63,9 +71,11 @@ def get_test_case(test_case_id: int) -> Response:
     if storage_error is not None:
         return storage_error
 
-    client_id = _resolve_caller_client_id()
-    if client_id is None:
-        return _auth_error()
+    target = _resolve_target_client_id()
+    if target.error is not None:
+        return target.error
+    client_id = target.client_id
+    actor_client_id = target.actor_client_id
 
     row = db.session.get(TestCase, test_case_id)
     if row is None or row.client_id != client_id:
@@ -81,9 +91,11 @@ def create_test_case() -> Response:
     if storage_error is not None:
         return storage_error
 
-    client_id = _resolve_caller_client_id()
-    if client_id is None:
-        return _auth_error()
+    target = _resolve_target_client_id()
+    if target.error is not None:
+        return target.error
+    client_id = target.client_id
+    actor_client_id = target.actor_client_id
 
     try:
         body = _parse_body(request.get_data())
@@ -112,7 +124,7 @@ def create_test_case() -> Response:
     _record_audit(
         test_case_id=row.id,
         client_id=client_id,
-        actor_client_id=client_id,
+        actor_client_id=actor_client_id,
         action="created",
         name_snapshot=name,
         occurred_at=now,
@@ -130,9 +142,11 @@ def update_test_case(test_case_id: int) -> Response:
     if storage_error is not None:
         return storage_error
 
-    client_id = _resolve_caller_client_id()
-    if client_id is None:
-        return _auth_error()
+    target = _resolve_target_client_id()
+    if target.error is not None:
+        return target.error
+    client_id = target.client_id
+    actor_client_id = target.actor_client_id
 
     row = db.session.get(TestCase, test_case_id)
     if row is None or row.client_id != client_id:
@@ -170,7 +184,7 @@ def update_test_case(test_case_id: int) -> Response:
     _record_audit(
         test_case_id=row.id,
         client_id=client_id,
-        actor_client_id=client_id,
+        actor_client_id=actor_client_id,
         action="updated",
         name_snapshot=row.name,
         occurred_at=now,
@@ -187,9 +201,11 @@ def delete_test_case(test_case_id: int) -> Response:
     if storage_error is not None:
         return storage_error
 
-    client_id = _resolve_caller_client_id()
-    if client_id is None:
-        return _auth_error()
+    target = _resolve_target_client_id()
+    if target.error is not None:
+        return target.error
+    client_id = target.client_id
+    actor_client_id = target.actor_client_id
 
     row = db.session.get(TestCase, test_case_id)
     if row is None or row.client_id != client_id:
@@ -200,7 +216,7 @@ def delete_test_case(test_case_id: int) -> Response:
     _record_audit(
         test_case_id=test_case_id,
         client_id=client_id,
-        actor_client_id=client_id,
+        actor_client_id=actor_client_id,
         action="deleted",
         name_snapshot=name_snapshot,
         occurred_at=datetime.now(timezone.utc),
@@ -235,19 +251,113 @@ def _storage_error_response() -> Response | None:
     return None
 
 
-def _resolve_caller_client_id() -> str | None:
-    """Extract and verify the bearer-token sub claim, normalize the
-    Auth0 ``@clients`` suffix, and return the resulting client_id."""
+@dataclass(frozen=True)
+class _ResolvedTarget:
+    """Result of resolving who a request is operating *as*.
+
+    ``client_id`` is the partner whose data the request reads or writes.
+    ``actor_client_id`` is the authenticated caller — the same as
+    ``client_id`` for partner self-service, different when staff act on
+    a partner's behalf via ``?as_client_id=…``. ``error`` is set when
+    the caller can't be authenticated or the staff override is invalid.
+    """
+
+    client_id: str
+    actor_client_id: str
+    error: Response | None
+
+
+def _resolve_target_client_id() -> _ResolvedTarget:
+    claims = _verified_token_claims(_bearer_token_from_header())
+    if claims is None:
+        return _ResolvedTarget("", "", _auth_error())
+
+    sub = claims.get("sub")
+    if not isinstance(sub, str):
+        return _ResolvedTarget("", "", _auth_error())
+    actor = _strip_clients_suffix(sub)
+
+    requested = request.args.get("as_client_id")
+    if not requested:
+        return _ResolvedTarget(
+            client_id=actor, actor_client_id=actor, error=None
+        )
+
+    if not _has_scope(claims, STAFF_SCOPE):
+        return _ResolvedTarget(
+            "",
+            "",
+            _json_response(
+                {
+                    "status": "error",
+                    "message": (
+                        "`as_client_id` requires the policyengine-staff scope."
+                    ),
+                },
+                status=403,
+            ),
+        )
+
+    return _ResolvedTarget(
+        client_id=requested, actor_client_id=actor, error=None
+    )
+
+
+def _bearer_token_from_header() -> str | None:
+    auth_header = request.headers.get("Authorization", "")
+    parts = auth_header.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1].strip() or None
+
+
+def _verified_token_claims(token: str | None) -> dict[str, Any] | None:
+    """Decode the bearer token against the configured Auth0 JWKS and
+    return its full claims dict on success. Mirrors the verification
+    discipline used by ``decorators.analytics._verified_sub_claim`` —
+    if Auth0 isn't configured the token can't be trusted and we return
+    ``None`` so the caller falls back to the auth-error path.
+    """
+    if not token:
+        return None
+    auth0_address = get_config_value("auth.auth0.address", "")
+    auth0_audience = get_config_value("auth.auth0.audience", "")
+    if not auth0_address or not auth0_audience:
+        return None
     try:
-        auth_header = str(request.authorization)
-        token = auth_header.split(" ")[1]
-    except Exception:
+        signing_key = _get_jwks_client(auth0_address).get_signing_key_from_jwt(
+            token
+        )
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=auth0_audience,
+            issuer=f"https://{auth0_address}/",
+            options={"verify_signature": True},
+        )
+    except Exception as e:
+        logger.debug(f"JWT signature verification failed: {e}")
         return None
-    sub = _verified_sub_claim(token)
-    if sub is None:
-        return None
+    return claims
+
+
+def _strip_clients_suffix(sub: str) -> str:
     suffix = "@clients"
     return sub[: -len(suffix)] if sub.endswith(suffix) else sub
+
+
+def _has_scope(claims: dict[str, Any], scope: str) -> bool:
+    """Return True if the JWT carries the named scope. Auth0 issues
+    scopes as a space-separated string in the ``scope`` claim and (on
+    M2M tokens) sometimes as a list under ``scopes``."""
+    scope_value = claims.get("scope")
+    if isinstance(scope_value, str):
+        return scope in scope_value.split()
+    scopes_value = claims.get("scopes")
+    if isinstance(scopes_value, (list, tuple)):
+        return scope in scopes_value
+    return False
 
 
 def _record_audit(

--- a/policyengine_household_api/openapi_spec.yaml
+++ b/policyengine_household_api/openapi_spec.yaml
@@ -809,12 +809,19 @@ paths:
     get:
       summary: List test cases owned by the caller
       operationId: list_test_cases
-      description: Returns every saved test case belonging to the authenticated client_id, most recently updated first.
+      description: Returns every saved test case belonging to the authenticated client_id (or the partner identified by `as_client_id` when the caller carries the `policyengine-staff` scope), most recently updated first.
       security:
         - bearerAuth: []
+      parameters:
+        - name: as_client_id
+          in: query
+          required: false
+          description: When set, return test cases owned by this partner client_id instead of the caller's. Requires the `policyengine-staff` scope; otherwise returns 403.
+          schema:
+            type: string
       responses:
         200:
-          description: Test cases owned by the caller.
+          description: Test cases owned by the target client_id.
           content:
             application/json:
               schema:
@@ -825,6 +832,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: The bearer token does not include the `policyengine-staff` scope required to use `as_client_id`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         503:
           description: Test-case storage is disabled or not ready.
           content:
@@ -834,9 +847,16 @@ paths:
     post:
       summary: Create a test case
       operationId: create_test_case
-      description: Persist a new household payload owned by the authenticated client_id.
+      description: Persist a new household payload owned by the authenticated client_id (or by the partner identified by `as_client_id` when the caller is staff).
       security:
         - bearerAuth: []
+      parameters:
+        - name: as_client_id
+          in: query
+          required: false
+          description: When set, the new test case is owned by this partner client_id instead of the caller's. Requires the `policyengine-staff` scope.
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -862,6 +882,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: The bearer token does not include the `policyengine-staff` scope required to use `as_client_id`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         503:
           description: Test-case storage is disabled or not ready.
           content:
@@ -880,6 +906,12 @@ paths:
           required: true
           schema:
             type: integer
+        - name: as_client_id
+          in: query
+          required: false
+          description: Read against this partner's library instead of the caller's. Requires the `policyengine-staff` scope.
+          schema:
+            type: string
       responses:
         200:
           description: The requested test case.
@@ -893,8 +925,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: The bearer token does not include the `policyengine-staff` scope required to use `as_client_id`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         404:
-          description: No test case with that id is owned by the caller.
+          description: No test case with that id is owned by the target client_id.
           content:
             application/json:
               schema:
@@ -911,6 +949,12 @@ paths:
           required: true
           schema:
             type: integer
+        - name: as_client_id
+          in: query
+          required: false
+          description: Update against this partner's library instead of the caller's. Requires the `policyengine-staff` scope.
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -936,8 +980,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: The bearer token does not include the `policyengine-staff` scope required to use `as_client_id`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         404:
-          description: No test case with that id is owned by the caller.
+          description: No test case with that id is owned by the target client_id.
           content:
             application/json:
               schema:
@@ -953,6 +1003,12 @@ paths:
           required: true
           schema:
             type: integer
+        - name: as_client_id
+          in: query
+          required: false
+          description: Delete against this partner's library instead of the caller's. Requires the `policyengine-staff` scope.
+          schema:
+            type: string
       responses:
         200:
           description: The test case was deleted.
@@ -973,8 +1029,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: The bearer token does not include the `policyengine-staff` scope required to use `as_client_id`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
         404:
-          description: No test case with that id is owned by the caller.
+          description: No test case with that id is owned by the target client_id.
           content:
             application/json:
               schema:

--- a/tests/unit/endpoints/test_test_cases.py
+++ b/tests/unit/endpoints/test_test_cases.py
@@ -56,14 +56,19 @@ def test_cases_app(tmp_path, monkeypatch):
 
 @pytest.fixture
 def call_as(monkeypatch):
-    """Returns a context manager that pretends a request arrived from
-    the given client_id. Stubs the bearer-token sub-claim verification
-    so handlers see ``client_id`` without going through Auth0."""
+    """Returns a function that stubs the bearer-token claim verification
+    so handlers see the given ``client_id`` (and optional scopes) without
+    going through Auth0."""
 
-    def _stub(client_id: str | None):
+    def _stub(client_id: str | None, scopes: str = ""):
+        def fake_verify(token):
+            if client_id is None:
+                return None
+            return {"sub": f"{client_id}@clients", "scope": scopes}
+
         monkeypatch.setattr(
-            "policyengine_household_api.endpoints.test_cases._verified_sub_claim",
-            lambda token: f"{client_id}@clients" if client_id else None,
+            "policyengine_household_api.endpoints.test_cases._verified_token_claims",
+            fake_verify,
         )
 
     return _stub
@@ -308,3 +313,78 @@ def test__delete__rejects_other_clients_case(test_cases_app, call_as):
         response = delete_test_case(created["id"])
     assert response.status_code == 404
     assert db.session.get(TestCase, created["id"]) is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: as_client_id staff overlay
+# ---------------------------------------------------------------------------
+
+
+def _request_context_with_query(app, *, method: str, query: str):
+    return app.test_request_context(
+        path=f"/test-cases?{query}",
+        method=method,
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+
+def test__as_client_id__rejected_without_staff_scope(
+    test_cases_app, call_as
+):
+    # acme (a partner with no staff scope) tries to read impactica's data.
+    call_as("acme")
+    with _request_context_with_query(
+        test_cases_app, method="GET", query="as_client_id=impactica"
+    ):
+        response = list_test_cases()
+    assert response.status_code == 403
+    assert "policyengine-staff" in json.loads(response.data)["message"]
+
+
+def test__as_client_id__honored_for_staff_callers(test_cases_app, call_as):
+    # Partner acme creates a case as themselves.
+    call_as("acme")
+    with _request_context(
+        test_cases_app,
+        method="POST",
+        body={"name": "acme case", "payload": _payload()},
+    ):
+        create_test_case()
+
+    # Staff caller lists with as_client_id=acme — sees acme's case.
+    call_as("staff-user", scopes="policyengine-staff")
+    with _request_context_with_query(
+        test_cases_app, method="GET", query="as_client_id=acme"
+    ):
+        response = list_test_cases()
+    body = json.loads(response.data)
+    assert response.status_code == 200
+    assert {c["name"] for c in body["test_cases"]} == {"acme case"}
+
+    # Same staff caller with no as_client_id sees their own (empty) list.
+    with _request_context(test_cases_app, method="GET"):
+        response = list_test_cases()
+    assert json.loads(response.data)["test_cases"] == []
+
+
+def test__as_client_id__staff_create_records_actor_separately(
+    test_cases_app, call_as
+):
+    # Staff creates a case on acme's behalf.
+    call_as("staff-user", scopes="policyengine-staff")
+    with test_cases_app.test_request_context(
+        path="/test-cases?as_client_id=acme",
+        method="POST",
+        json={"name": "by staff", "payload": _payload()},
+        headers={"Authorization": "Bearer test-token"},
+    ):
+        response = create_test_case()
+    assert response.status_code == 201
+
+    # The case is owned by acme; the audit captures staff as the actor.
+    cases = db.session.query(TestCase).all()
+    assert [c.client_id for c in cases] == ["acme"]
+    audit = db.session.query(TestCaseAudit).one()
+    assert audit.client_id == "acme"
+    assert audit.actor_client_id == "staff-user"
+    assert audit.action == "created"


### PR DESCRIPTION
## Summary

Phase 2 of the multi-tenant test-case work. **Stacked on top of #1506.**

Lets PolicyEngine staff (callers carrying the new \`policyengine-staff\` JWT scope) act on any partner's behalf via \`?as_client_id=<partner>\`. Without the scope, the parameter is rejected with 403 — partners can never read or mutate another partner's data.

## What changes

- **\`STAFF_SCOPE\` constant** in \`decorators/auth.py\` — \"policyengine-staff\".
- **\`_verified_token_claims()\`** in \`endpoints/test_cases.py\` — returns the full JWT claims dict so we can check sub and scope from one verification pass (mirrors the discipline of \`decorators.analytics._verified_sub_claim\`).
- **\`_resolve_target_client_id()\`** returns \`(client_id, actor_client_id, error)\`:
  - Partner self-service: \`client_id == actor_client_id\`
  - Staff with \`as_client_id\`: \`client_id\` is the partner; \`actor_client_id\` is the staff caller. Both written into the audit log so we always know who did what to whom.
- **All four /test-cases ops** now check + honor \`as_client_id\`.
- **3 new unit tests** covering: param rejected without staff scope (403), honored for staff (200), and audit log separates ownership from actor on writes.
- **OpenAPI spec** documents the new param and the 403 response on every test-case op.

## Manual setup needed before deploy

- Add the \`policyengine-staff\` scope to the household-API audience in Auth0.
- Grant the scope to the small set of internal/admin clients (PolicyEngine staff M2M apps, or the SPA login used by the developer portal).

## Test plan

15 total tests pass (\`uv run pytest -q tests/unit/endpoints/test_test_cases.py\`):

- [x] All 12 Phase 1 tests still pass
- [x] \`as_client_id\` rejected without staff scope (403, message references \"policyengine-staff\")
- [x] \`as_client_id\` honored for staff: list returns the target partner's cases; with no \`as_client_id\` staff sees their own (empty) library
- [x] Staff-created case is owned by the partner; audit row records staff as the actor

🤖 Generated with [Claude Code](https://claude.com/claude-code)