### PR TITLE
Add /admin/partners and /admin/activity endpoints

### DIFF
--- a/changelog.d/admin-endpoints.added.md
+++ b/changelog.d/admin-endpoints.added.md
@@ -1,0 +1,1 @@
+Added two staff-only admin endpoints powering the developer portal's master view: `GET /admin/partners` lists every partner client_id with last activity and test-case count; `GET /admin/activity` returns recent test_case_audits rows. Both gated by the `policyengine-staff` scope.

--- a/policyengine_household_api/api.py
+++ b/policyengine_household_api/api.py
@@ -35,6 +35,8 @@ from .endpoints import (
     get_calculate_analytics_requests,
     get_home,
     get_test_case,
+    list_activity,
+    list_partners,
     list_test_cases,
     update_test_case,
 )
@@ -129,6 +131,27 @@ def test_cases_update(test_case_id: int):
 @limiter.limit("60 per minute")
 def test_cases_delete(test_case_id: int):
     return delete_test_case(test_case_id)
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints — staff-only via the policyengine-staff scope check
+# inside the handlers (so non-staff get our domain 403 message rather
+# than authlib's generic one).
+# ---------------------------------------------------------------------------
+
+
+@app.route("/admin/partners", methods=["GET"])
+@require_auth_if_enabled()
+@limiter.limit("60 per minute")
+def admin_partners():
+    return list_partners()
+
+
+@app.route("/admin/activity", methods=["GET"])
+@require_auth_if_enabled()
+@limiter.limit("60 per minute")
+def admin_activity():
+    return list_activity()
 
 
 @app.route("/<country_id>/ai-analysis", methods=["POST"])

--- a/policyengine_household_api/endpoints/__init__.py
+++ b/policyengine_household_api/endpoints/__init__.py
@@ -13,3 +13,7 @@ from .test_cases import (
     list_test_cases as list_test_cases,
     update_test_case as update_test_case,
 )
+from .admin import (
+    list_activity as list_activity,
+    list_partners as list_partners,
+)

--- a/policyengine_household_api/endpoints/admin.py
+++ b/policyengine_household_api/endpoints/admin.py
@@ -1,0 +1,186 @@
+"""
+Staff-only admin endpoints for the developer portal.
+
+These are gated by the ``policyengine-staff`` JWT scope: any caller
+without it gets 403. The portal uses them to power the "All partners"
+overview and the test-case activity feed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from typing import Any
+
+from flask import Response, request
+from sqlalchemy import func
+
+from policyengine_household_api.data.analytics_setup import (
+    db,
+    is_analytics_enabled,
+    is_analytics_schema_ready,
+)
+from policyengine_household_api.data.models import TestCase, TestCaseAudit
+from policyengine_household_api.endpoints.test_cases import (
+    _verified_token_claims,
+    _bearer_token_from_header,
+    _has_scope,
+)
+from policyengine_household_api.decorators.auth import STAFF_SCOPE
+
+
+DEFAULT_ACTIVITY_LIMIT = 100
+MAX_ACTIVITY_LIMIT = 1000
+
+
+def list_partners() -> Response:
+    """Return one row per partner client_id seen in the test_cases
+    table, with last activity timestamp + case count."""
+    storage_error = _storage_error_response()
+    if storage_error is not None:
+        return storage_error
+
+    forbidden = _staff_only()
+    if forbidden is not None:
+        return forbidden
+
+    rows = (
+        db.session.query(
+            TestCase.client_id,
+            func.count(TestCase.id).label("test_case_count"),
+            func.max(TestCase.updated_at).label("last_updated"),
+        )
+        .group_by(TestCase.client_id)
+        .order_by(func.max(TestCase.updated_at).desc())
+        .all()
+    )
+
+    return _json_response(
+        {
+            "status": "ok",
+            "message": None,
+            "partners": [
+                {
+                    "client_id": row.client_id,
+                    "test_case_count": int(row.test_case_count or 0),
+                    "last_activity": _datetime_to_json(row.last_updated),
+                }
+                for row in rows
+            ],
+        }
+    )
+
+
+def list_activity() -> Response:
+    """Return recent test_case_audits rows. Most useful as a
+    chronological feed of "Acme created/updated/deleted X" — drives
+    the staff activity page."""
+    storage_error = _storage_error_response()
+    if storage_error is not None:
+        return storage_error
+
+    forbidden = _staff_only()
+    if forbidden is not None:
+        return forbidden
+
+    try:
+        limit = _parse_limit(request.args.get("limit"))
+    except ValueError as e:
+        return _json_response(
+            {"status": "error", "message": str(e)}, status=400
+        )
+
+    client_id = request.args.get("client_id")
+    query = db.session.query(TestCaseAudit).order_by(TestCaseAudit.id.desc())
+    if client_id:
+        query = query.filter(TestCaseAudit.client_id == client_id)
+    rows = query.limit(limit).all()
+
+    return _json_response(
+        {
+            "status": "ok",
+            "message": None,
+            "events": [
+                {
+                    "id": row.id,
+                    "test_case_id": row.test_case_id,
+                    "client_id": row.client_id,
+                    "actor_client_id": row.actor_client_id,
+                    "action": row.action,
+                    "name_snapshot": row.name_snapshot,
+                    "occurred_at": _datetime_to_json(row.occurred_at),
+                }
+                for row in rows
+            ],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _staff_only() -> Response | None:
+    claims = _verified_token_claims(_bearer_token_from_header())
+    if claims is None:
+        return _json_response(
+            {"status": "error", "message": "Could not identify caller."},
+            status=401,
+        )
+    if not _has_scope(claims, STAFF_SCOPE):
+        return _json_response(
+            {
+                "status": "error",
+                "message": "This endpoint requires the policyengine-staff scope.",
+            },
+            status=403,
+        )
+    return None
+
+
+def _storage_error_response() -> Response | None:
+    if not is_analytics_enabled():
+        return _json_response(
+            {
+                "status": "error",
+                "message": "Test-case storage is not enabled for this API instance.",
+            },
+            status=503,
+        )
+    if not is_analytics_schema_ready():
+        return _json_response(
+            {"status": "error", "message": "Test-case storage is not ready."},
+            status=503,
+        )
+    return None
+
+
+def _parse_limit(raw: str | None) -> int:
+    if raw is None:
+        return DEFAULT_ACTIVITY_LIMIT
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError("`limit` must be an integer")
+    if value < 1 or value > MAX_ACTIVITY_LIMIT:
+        raise ValueError(
+            f"`limit` must be between 1 and {MAX_ACTIVITY_LIMIT}; got {value}"
+        )
+    return value
+
+
+def _datetime_to_json(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _json_response(body: dict[str, Any], status: int = 200) -> Response:
+    return Response(
+        json.dumps(body).encode("utf-8"),
+        status=status,
+        mimetype="application/json",
+    )

--- a/policyengine_household_api/openapi_spec.yaml
+++ b/policyengine_household_api/openapi_spec.yaml
@@ -1041,6 +1041,92 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiErrorResponse"
+  /admin/partners:
+    get:
+      summary: List partner client_ids and their test-case activity
+      operationId: list_partners
+      description: Returns one row per partner client_id seen in the test_cases table, with last activity timestamp and test-case count. Requires the `policyengine-staff` scope.
+      security:
+        - bearerAuth: []
+      responses:
+        200:
+          description: Aggregated partner activity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminPartnersResponse"
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: Caller does not have the `policyengine-staff` scope.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        503:
+          description: Test-case storage is disabled or not ready.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+  /admin/activity:
+    get:
+      summary: Recent test-case audit events
+      operationId: list_activity
+      description: Returns recent rows from the `test_case_audits` table, newest first. Optionally filter by `client_id`. Requires the `policyengine-staff` scope.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: client_id
+          in: query
+          required: false
+          description: When set, only return events for the named partner client_id.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of events to return.
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 1000
+      responses:
+        200:
+          description: Recent audit events.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminActivityResponse"
+        400:
+          description: Invalid query parameter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        401:
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthErrorResponse"
+        403:
+          description: Caller does not have the `policyengine-staff` scope.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        503:
+          description: Test-case storage is disabled or not ready.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
   /{country_id}/economy/{policy_id}/over/{baseline_policy_id}:
     get:
       summary: Calculate the economic impact of a policy
@@ -1742,3 +1828,75 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TestCase"
+    AdminPartnersResponse:
+      type: object
+      required:
+        - status
+        - message
+        - partners
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        message:
+          type: string
+          nullable: true
+        partners:
+          type: array
+          items:
+            type: object
+            required:
+              - client_id
+              - test_case_count
+              - last_activity
+            properties:
+              client_id:
+                type: string
+              test_case_count:
+                type: integer
+              last_activity:
+                type: string
+                format: date-time
+                nullable: true
+    AdminActivityResponse:
+      type: object
+      required:
+        - status
+        - message
+        - events
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        message:
+          type: string
+          nullable: true
+        events:
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - test_case_id
+              - client_id
+              - actor_client_id
+              - action
+              - occurred_at
+            properties:
+              id:
+                type: integer
+              test_case_id:
+                type: integer
+              client_id:
+                type: string
+              actor_client_id:
+                type: string
+              action:
+                type: string
+                enum: [created, updated, deleted]
+              name_snapshot:
+                type: string
+                nullable: true
+              occurred_at:
+                type: string
+                format: date-time

--- a/tests/unit/endpoints/test_admin.py
+++ b/tests/unit/endpoints/test_admin.py
@@ -1,0 +1,169 @@
+"""Unit tests for the staff-only admin endpoints."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+
+from policyengine_household_api.data.analytics_setup import db
+from policyengine_household_api.endpoints.admin import (
+    list_activity,
+    list_partners,
+)
+from policyengine_household_api.endpoints.test_cases import create_test_case
+
+
+@pytest.fixture
+def admin_app(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "policyengine_household_api.endpoints.admin.is_analytics_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "policyengine_household_api.endpoints.admin.is_analytics_schema_ready",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "policyengine_household_api.endpoints.test_cases.is_analytics_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "policyengine_household_api.endpoints.test_cases.is_analytics_schema_ready",
+        lambda: True,
+    )
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = (
+        f"sqlite:///{tmp_path / 'admin.db'}"
+    )
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def call_as(monkeypatch):
+    def _stub(client_id: str | None, scopes: str = ""):
+        def fake(token):
+            if client_id is None:
+                return None
+            return {"sub": f"{client_id}@clients", "scope": scopes}
+
+        # admin.py and test_cases.py each hold their own reference to
+        # the verifier (imported by name), so monkeypatching the source
+        # module isn't enough — patch both targets explicitly.
+        monkeypatch.setattr(
+            "policyengine_household_api.endpoints.test_cases._verified_token_claims",
+            fake,
+        )
+        monkeypatch.setattr(
+            "policyengine_household_api.endpoints.admin._verified_token_claims",
+            fake,
+        )
+
+    return _stub
+
+
+def _ctx(app, *, path: str = "/admin/partners", method: str = "GET"):
+    return app.test_request_context(
+        path=path,
+        method=method,
+        headers={"Authorization": "Bearer token"},
+    )
+
+
+def _seed_two_partners(app, call_as):
+    """Have two partners each create a test case so list_partners has
+    something to aggregate."""
+    call_as("acme")
+    with _ctx(
+        app,
+        path="/test-cases",
+        method="POST",
+    ) as c:
+        c.request.get_data = lambda *a, **k: json.dumps(
+            {"name": "acme one", "payload": {"people": {}}}
+        ).encode()
+        create_test_case()
+
+    call_as("impactica")
+    with _ctx(
+        app,
+        path="/test-cases",
+        method="POST",
+    ) as c:
+        c.request.get_data = lambda *a, **k: json.dumps(
+            {"name": "impactica one", "payload": {"people": {}}}
+        ).encode()
+        create_test_case()
+
+
+def test__partners__rejected_without_staff_scope(admin_app, call_as):
+    call_as("acme")
+    with _ctx(admin_app):
+        response = list_partners()
+    assert response.status_code == 403
+
+
+def test__partners__lists_distinct_client_ids_with_counts(
+    admin_app, call_as
+):
+    _seed_two_partners(admin_app, call_as)
+
+    call_as("staff", scopes="policyengine-staff")
+    with _ctx(admin_app):
+        response = list_partners()
+    body = json.loads(response.data)
+    assert response.status_code == 200
+    rows = {p["client_id"]: p for p in body["partners"]}
+    assert set(rows.keys()) == {"acme", "impactica"}
+    assert rows["acme"]["test_case_count"] == 1
+    assert rows["impactica"]["test_case_count"] == 1
+    # Both have a non-null last_activity ISO string.
+    for p in body["partners"]:
+        assert p["last_activity"].endswith("Z")
+
+
+def test__activity__rejected_without_staff_scope(admin_app, call_as):
+    call_as("acme")
+    with _ctx(admin_app, path="/admin/activity"):
+        response = list_activity()
+    assert response.status_code == 403
+
+
+def test__activity__returns_recent_audits_newest_first(admin_app, call_as):
+    _seed_two_partners(admin_app, call_as)
+
+    call_as("staff", scopes="policyengine-staff")
+    with _ctx(admin_app, path="/admin/activity"):
+        response = list_activity()
+    body = json.loads(response.data)
+    assert response.status_code == 200
+    # Two creates, ordered newest-first by id desc.
+    assert [e["client_id"] for e in body["events"]] == ["impactica", "acme"]
+    assert all(e["action"] == "created" for e in body["events"])
+
+
+def test__activity__filter_by_client_id(admin_app, call_as):
+    _seed_two_partners(admin_app, call_as)
+
+    call_as("staff", scopes="policyengine-staff")
+    with _ctx(admin_app, path="/admin/activity?client_id=acme"):
+        response = list_activity()
+    body = json.loads(response.data)
+    assert {e["client_id"] for e in body["events"]} == {"acme"}
+
+
+def test__activity__limit_validation(admin_app, call_as):
+    call_as("staff", scopes="policyengine-staff")
+    with _ctx(admin_app, path="/admin/activity?limit=0"):
+        response = list_activity()
+    assert response.status_code == 400
+    with _ctx(admin_app, path="/admin/activity?limit=abc"):
+        response = list_activity()
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

Phase 3 backend. **Stacked on #1507** (which adds the staff scope).

Two staff-only endpoints powering the developer portal's master view:

- **\`GET /admin/partners\`** — one row per partner client_id seen in the \`test_cases\` table, with last activity timestamp and test-case count. Powers the \"All partners\" overview.
- **\`GET /admin/activity\`** — chronological feed from \`test_case_audits\` (newest first). Supports \`?client_id=X\` filter and \`?limit=N\` (default 100, max 1000). Powers the \"who's been adding what\" dashboard.

Both gated by the \`policyengine-staff\` scope inside the handler (so 403s return our domain message, not authlib's generic one).

## Test plan

21 total tests pass:

- [x] /admin/partners rejected without staff scope (403)
- [x] /admin/partners returns distinct client_ids with counts and a non-null last_activity ISO string
- [x] /admin/activity rejected without staff scope
- [x] /admin/activity returns events newest-first
- [x] /admin/activity supports ?client_id= filter
- [x] /admin/activity validates ?limit= (rejects 0 and non-numeric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)