### PR TITLE
Fix Modal release version scope

### DIFF
--- a/.github/scripts/check_modal_release_body.py
+++ b/.github/scripts/check_modal_release_body.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 from modal_release_check_common import (
     event_pr_body,
     get_changed_files,
+    get_file_at_ref,
     parse_pr_body_check_args,
 )
 from policyengine_household_api.modal_release.release_config import (
     ModalReleaseConfigError,
     body_contains_modal_release_config,
-    changed_files_require_modal_release_config,
     parse_modal_release_config_from_body,
+    release_package_versions_changed,
 )
 
 
@@ -21,9 +23,13 @@ def main() -> int:
     )
     body = event_pr_body(args.event_path)
     changed_files = get_changed_files(args.base_ref)
+    package_versions_changed = changed_files_update_release_packages(
+        changed_files,
+        args.base_ref,
+    )
 
     try:
-        validate_release_body_config(body, changed_files)
+        validate_release_body_config(body, package_versions_changed)
     except ModalReleaseConfigError as e:
         print(f"::error::{e}")
         return 1
@@ -34,22 +40,34 @@ def main() -> int:
 
 def validate_release_body_config(
     body: str | None,
-    changed_files: list[str],
+    package_versions_changed: bool,
 ) -> None:
-    requires_config = changed_files_require_modal_release_config(changed_files)
     has_config = body_contains_modal_release_config(body)
 
-    if not requires_config and not has_config:
-        print("No Modal release files changed; config block is optional.")
+    if not package_versions_changed and not has_config:
+        print("No US or UK package version changed; config block is optional.")
         return
 
-    if requires_config and not has_config:
+    if package_versions_changed and not has_config:
         raise ModalReleaseConfigError(
-            "This PR changes Modal release files and must include a "
-            "`modal_release` YAML block in the PR body"
+            "This PR changes a US or UK package version and must include "
+            "a `modal_release` YAML block in the PR body"
         )
 
     parse_modal_release_config_from_body(body)
+
+
+def changed_files_update_release_packages(
+    changed_files: list[str],
+    base_ref: str | None,
+) -> bool:
+    if "pyproject.toml" not in changed_files:
+        return False
+
+    return release_package_versions_changed(
+        get_file_at_ref("pyproject.toml", base_ref),
+        Path("pyproject.toml").read_text(encoding="utf-8"),
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/modal-cleanup-apps.sh
+++ b/.github/scripts/modal-cleanup-apps.sh
@@ -16,5 +16,5 @@ for app_name in payload.get("app_names", []):
   if [[ -z "${app_name}" ]]; then
     continue
   fi
-  modal app stop --env "${environment}" "${app_name}"
+  uv run modal app stop --env "${environment}" "${app_name}"
 done

--- a/.github/scripts/modal-sync-secrets.sh
+++ b/.github/scripts/modal-sync-secrets.sh
@@ -67,7 +67,7 @@ for key in required + optional:
 Path(sys.argv[1]).write_text(json.dumps(settings))
 ' "${secret_file}"
 
-modal secret create "${secret_name}" \
+uv run modal secret create "${secret_name}" \
   --env "${environment}" \
   --from-json "${secret_file}" \
   --force

--- a/.github/scripts/modal_release_check_common.py
+++ b/.github/scripts/modal_release_check_common.py
@@ -36,6 +36,28 @@ def get_changed_files(base_ref: str | None) -> list[str]:
     raise RuntimeError(f"Unable to determine changed files from {base_ref}")
 
 
+def get_file_at_ref(path: str, base_ref: str | None) -> str:
+    base_ref = base_ref or os.getenv("GITHUB_BASE_REF") or "main"
+    commands = [
+        ["git", "show", f"origin/{base_ref}:{path}"],
+        ["git", "show", f"{base_ref}:{path}"],
+    ]
+
+    for command in commands:
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            continue
+        return result.stdout
+
+    raise RuntimeError(f"Unable to read {path} from {base_ref}")
+
+
 def parse_changed_files_args(description: str) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--base-ref")

--- a/.github/scripts/test_check_modal_release_body.py
+++ b/.github/scripts/test_check_modal_release_body.py
@@ -16,22 +16,22 @@ modal_release:
 """
 
 
-def test_validate_release_body_allows_missing_config_for_unrelated_files():
-    validate_release_body_config(None, ["README.md"])
+def test_validate_release_body_allows_missing_config_without_package_change():
+    validate_release_body_config(None, package_versions_changed=False)
 
 
-def test_validate_release_body_requires_config_for_modal_release_files():
+def test_validate_release_body_requires_config_for_release_package_change():
     with pytest.raises(ModalReleaseConfigError, match="must include"):
         validate_release_body_config(
             None,
-            ["policyengine_household_api/modal_release/gateway.py"],
+            package_versions_changed=True,
         )
 
 
-def test_validate_release_body_accepts_config_for_modal_release_files():
+def test_validate_release_body_accepts_config_for_release_package_change():
     validate_release_body_config(
         VALID_BODY,
-        ["policyengine_household_api/modal_release/gateway.py"],
+        package_versions_changed=True,
     )
 
 
@@ -46,12 +46,12 @@ modal_release:
   cleanup_target: none
 ```
 """,
-            ["README.md"],
+            package_versions_changed=False,
         )
 
 
 def test_validate_release_body_allows_template_guidance_without_config_block():
     validate_release_body_config(
         "Modal release guidance may mention current/frontier workers.",
-        ["README.md"],
+        package_versions_changed=False,
     )

--- a/changelog.d/1510.fixed.md
+++ b/changelog.d/1510.fixed.md
@@ -1,0 +1,1 @@
+Fix Modal release app naming and manifest metadata so only US and UK package versions are release-significant, and invoke the Modal CLI through the project environment in deployment helpers.

--- a/docs/engineering/skills/modal-release-prs.md
+++ b/docs/engineering/skills/modal-release-prs.md
@@ -50,6 +50,11 @@ explicitly configured.
 
 Do not use PR labels, branch names, model-specific tags, or title prefixes to
 control Modal release behavior. The PR body YAML block is the source of truth.
+The PR-body YAML block is required only when the PR changes a release-significant
+country package version, meaning `policyengine_us` or `policyengine_uk` in
+`pyproject.toml`. Code-only changes, including changes to Modal release code,
+must not require a `modal_release` block unless those US or UK package versions
+also change.
 The release workflow deploys from the finalized
 `Update PolicyEngine Household API` versioning commit; ordinary push events do
 not deploy Modal apps. Manual `workflow_dispatch` runs use the default weekly

--- a/docs/engineering/skills/modal-release-prs.md
+++ b/docs/engineering/skills/modal-release-prs.md
@@ -66,6 +66,12 @@ Each channel is tested by channel name and by the exact US package version from
 SQL analytics database access and for syncing the Modal worker secret needed to
 reach that database.
 
+Only the US and UK package versions are release-significant. Do not include
+Canada, Nigeria, or Israel package versions in Modal worker app names, manifest
+package version references, or release validation. Those countries may still be
+served by the worker, but their package versions must not control a Modal
+release.
+
 Manual workflow dispatch exposes the same `new_app_target`,
 `promote_existing_frontier`, and `cleanup_target` settings as the PR-body YAML
 block. The deploy workflow and Modal images use Python 3.13.

--- a/policyengine_household_api/modal_release/manifest.py
+++ b/policyengine_household_api/modal_release/manifest.py
@@ -6,10 +6,7 @@ from datetime import datetime, timezone
 import re
 from typing import Any, Mapping
 
-from policyengine_household_api.constants import (
-    COUNTRIES,
-    COUNTRY_PACKAGE_VERSIONS,
-)
+from policyengine_household_api.constants import COUNTRY_PACKAGE_VERSIONS
 from policyengine_household_api.data.analytics_migration import (
     ANALYTICS_ALEMBIC_MINIMUM_REVISION,
 )
@@ -24,6 +21,7 @@ MANIFEST_SCHEMA_VERSION = 1
 MANIFEST_DICT_NAME = "household-api-release-manifest"
 MANIFEST_DICT_KEY = "manifest"
 APP_NAME_PREFIX = "policyengine-household-api"
+RELEASE_PACKAGE_VERSION_COUNTRIES = ("uk", "us")
 
 
 @dataclass(frozen=True)
@@ -59,7 +57,7 @@ def current_timestamp() -> str:
 
 
 def current_package_versions() -> dict[str, str]:
-    return dict(COUNTRY_PACKAGE_VERSIONS)
+    return _release_package_versions(COUNTRY_PACKAGE_VERSIONS)
 
 
 def build_app_name(
@@ -68,7 +66,7 @@ def build_app_name(
     versions = package_versions or current_package_versions()
     version_slug = "-".join(
         f"{country}{_slugify_version(versions[country])}"
-        for country in COUNTRIES
+        for country in RELEASE_PACKAGE_VERSION_COUNTRIES
         if country in versions
     )
     return f"{APP_NAME_PREFIX}-{version_slug}"
@@ -82,7 +80,9 @@ def build_app_reference(
     deployed_at: str | None = None,
     analytics_database_revision: str | None = None,
 ) -> dict[str, Any]:
-    versions = dict(package_versions or current_package_versions())
+    versions = _release_package_versions(
+        package_versions or current_package_versions()
+    )
     reference = AppReference(
         app_name=app_name or build_app_name(versions),
         package_versions=versions,
@@ -262,3 +262,13 @@ def _retire_entry(
 def _slugify_version(version: str) -> str:
     slug = re.sub(r"[^a-zA-Z0-9]+", "-", version).strip("-").lower()
     return slug or "unknown"
+
+
+def _release_package_versions(
+    package_versions: Mapping[str, str],
+) -> dict[str, str]:
+    return {
+        country: package_versions[country]
+        for country in RELEASE_PACKAGE_VERSION_COUNTRIES
+        if country in package_versions
+    }

--- a/policyengine_household_api/modal_release/release_config.py
+++ b/policyengine_household_api/modal_release/release_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 import re
+import tomllib
 from typing import Any
 
 import yaml
@@ -13,6 +14,10 @@ REQUIRED_CONFIG_KEYS = {
     "new_app_target",
     "promote_existing_frontier",
     "cleanup_target",
+}
+RELEASE_PACKAGE_DEPENDENCIES = {
+    "policyengine-uk",
+    "policyengine-us",
 }
 MODAL_RELEASE_PATH_PREFIXES = (
     ".github/scripts/modal",
@@ -186,6 +191,15 @@ def changed_files_require_modal_release_config(
     )
 
 
+def release_package_versions_changed(
+    base_pyproject: str,
+    head_pyproject: str,
+) -> bool:
+    return _release_package_versions_from_pyproject(
+        base_pyproject
+    ) != _release_package_versions_from_pyproject(head_pyproject)
+
+
 def _candidate_yaml_blocks(body: str) -> list[str]:
     fenced_blocks = [
         match.group("body")
@@ -233,3 +247,26 @@ def _enum_value(
         raise ModalReleaseConfigError(
             f"`{key}` must be one of: {valid_values}"
         ) from e
+
+
+def _release_package_versions_from_pyproject(
+    pyproject_text: str,
+) -> dict[str, str]:
+    try:
+        dependencies = tomllib.loads(pyproject_text)["project"]["dependencies"]
+    except (KeyError, tomllib.TOMLDecodeError) as e:
+        raise ModalReleaseConfigError(
+            "Could not read project dependencies from pyproject.toml"
+        ) from e
+
+    versions: dict[str, str] = {}
+    for dependency in dependencies:
+        if not isinstance(dependency, str):
+            continue
+        match = re.match(r"^\s*([A-Za-z0-9_.-]+)\s*==\s*([^;\s]+)", dependency)
+        if not match:
+            continue
+        package_name = match.group(1).replace("_", "-").lower()
+        if package_name in RELEASE_PACKAGE_DEPENDENCIES:
+            versions[package_name] = match.group(2)
+    return versions

--- a/tests/unit/modal_release/test_manifest.py
+++ b/tests/unit/modal_release/test_manifest.py
@@ -3,7 +3,12 @@ import pytest
 from policyengine_household_api.modal_release.manifest import (
     apply_release_config,
     build_app_reference,
+    build_app_name,
     cleanup_app_names_for_target,
+    current_package_versions,
+)
+from policyengine_household_api.modal_release import (
+    manifest as manifest_module,
 )
 from policyengine_household_api.modal_release.release_config import (
     CleanupTarget,
@@ -153,3 +158,49 @@ def test_app_reference_includes_analytics_migration_metadata():
 
     assert app["analytics_migration_minimum_revision"] == "20260512_0003"
     assert app["analytics_database_revision"] == "20260512_0003"
+
+
+def test_app_reference_only_records_release_package_versions():
+    app = build_app_reference(
+        app_name="worker-app",
+        package_versions={
+            "uk": "2.31.0",
+            "us": "1.691.1",
+            "ca": "0.96.3",
+            "ng": "0.5.1",
+            "il": "0.1.0",
+        },
+        deployed_at="2026-01-01T00:00:00+00:00",
+    )
+
+    assert app["package_versions"] == {"uk": "2.31.0", "us": "1.691.1"}
+
+
+def test_app_name_only_includes_us_and_uk_package_versions():
+    app_name = build_app_name(
+        {
+            "uk": "2.31.0",
+            "us": "1.691.1",
+            "ca": "0.96.3",
+            "ng": "0.5.1",
+            "il": "0.1.0",
+        }
+    )
+
+    assert app_name == "policyengine-household-api-uk2-31-0-us1-691-1"
+
+
+def test_current_package_versions_only_includes_us_and_uk(monkeypatch):
+    monkeypatch.setattr(
+        manifest_module,
+        "COUNTRY_PACKAGE_VERSIONS",
+        {
+            "uk": "2.31.0",
+            "us": "1.691.1",
+            "ca": "0.96.3",
+            "ng": "0.5.1",
+            "il": "0.1.0",
+        },
+    )
+
+    assert current_package_versions() == {"uk": "2.31.0", "us": "1.691.1"}

--- a/tests/unit/modal_release/test_release_config.py
+++ b/tests/unit/modal_release/test_release_config.py
@@ -6,6 +6,7 @@ from policyengine_household_api.modal_release.release_config import (
     body_contains_modal_release_config,
     changed_files_require_modal_release_config,
     parse_modal_release_config_from_body,
+    release_package_versions_changed,
 )
 
 
@@ -91,3 +92,43 @@ def test_changed_files_require_config_for_modal_channel_test_script():
 
 def test_changed_files_do_not_require_config_for_unrelated_paths():
     assert not changed_files_require_modal_release_config(["README.md"])
+
+
+def test_release_package_versions_changed_detects_us_updates():
+    base = """
+[project]
+dependencies = [
+    "policyengine_uk==2.31.0",
+    "policyengine_us==1.691.1",
+]
+"""
+    head = """
+[project]
+dependencies = [
+    "policyengine_uk==2.31.0",
+    "policyengine_us==1.692.0",
+]
+"""
+
+    assert release_package_versions_changed(base, head)
+
+
+def test_release_package_versions_changed_ignores_other_country_updates():
+    base = """
+[project]
+dependencies = [
+    "policyengine_uk==2.31.0",
+    "policyengine_us==1.691.1",
+    "policyengine_canada==0.96.3",
+]
+"""
+    head = """
+[project]
+dependencies = [
+    "policyengine_uk==2.31.0",
+    "policyengine_us==1.691.1",
+    "policyengine_canada==0.97.0",
+]
+"""
+
+    assert not release_package_versions_changed(base, head)


### PR DESCRIPTION
Fixes #1510

## Summary
- Scope Modal release package versions to UK and US only for app names and manifest references.
- Invoke Modal through `uv run` in deploy helper scripts so CI can find the CLI.
- Document that non-US/UK package versions must not control Modal release behavior.

## Testing
- `uv run ruff check policyengine_household_api/modal_release/manifest.py tests/unit/modal_release/test_manifest.py .github/scripts/modal_extract_versions.py`
- `bash -n .github/scripts/modal-sync-secrets.sh .github/scripts/modal-cleanup-apps.sh .github/scripts/modal-deploy-release.sh`
- `uv run pytest tests/unit/modal_release/test_manifest.py tests/unit/modal_release/test_gateway.py .github/scripts/test_check_modal_release_body.py .github/scripts/test_check_modal_release_alembic.py -q`
- `uv run python .github/scripts/modal_extract_versions.py`