### PR TITLE
Fix Modal gateway endpoint label

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,8 @@ env:
   PYTHON_VERSION: "3.12"
 
 concurrency:
-  group: household-api-pr
-  cancel-in-progress: false
+  group: household-api-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-modal-release-body:

--- a/changelog.d/1513.fixed.md
+++ b/changelog.d/1513.fixed.md
@@ -1,1 +1,1 @@
-Fix the Modal gateway web endpoint label so release smoke checks use a stable URL.
+Fix the Modal gateway web endpoint label so release smoke checks use a stable URL, and scope PR workflow concurrency per pull request so stale runs do not block newer commits.

--- a/changelog.d/1513.fixed.md
+++ b/changelog.d/1513.fixed.md
@@ -1,0 +1,1 @@
+Fix the Modal gateway web endpoint label so release smoke checks use a stable URL.

--- a/policyengine_household_api/modal_release/gateway_app.py
+++ b/policyengine_household_api/modal_release/gateway_app.py
@@ -15,6 +15,7 @@ GATEWAY_APP_NAME = os.getenv(
     "HOUSEHOLD_MODAL_GATEWAY_APP_NAME",
     "policyengine-household-api-gateway",
 )
+GATEWAY_WEB_ENDPOINT_LABEL = f"{GATEWAY_APP_NAME}-web-app"
 
 app = modal.App(GATEWAY_APP_NAME)
 
@@ -25,6 +26,6 @@ app = modal.App(GATEWAY_APP_NAME)
     timeout=180,
     scaledown_window=300,
 )
-@modal.wsgi_app(label=f"{GATEWAY_APP_NAME}-web-app")
+@modal.wsgi_app(label=GATEWAY_WEB_ENDPOINT_LABEL)
 def web_app():
     return create_gateway_app()

--- a/policyengine_household_api/modal_release/gateway_app.py
+++ b/policyengine_household_api/modal_release/gateway_app.py
@@ -25,6 +25,6 @@ app = modal.App(GATEWAY_APP_NAME)
     timeout=180,
     scaledown_window=300,
 )
-@modal.wsgi_app()
+@modal.wsgi_app(label=f"{GATEWAY_APP_NAME}-web-app")
 def web_app():
     return create_gateway_app()

--- a/tests/unit/modal_release/test_gateway_app.py
+++ b/tests/unit/modal_release/test_gateway_app.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+from pathlib import Path
+
+from policyengine_household_api.modal_release.gateway_app import (
+    GATEWAY_APP_NAME,
+    GATEWAY_WEB_ENDPOINT_LABEL,
+)
+
+
+def test_gateway_web_endpoint_label_matches_app_name():
+    assert GATEWAY_WEB_ENDPOINT_LABEL == f"{GATEWAY_APP_NAME}-web-app"
+
+
+def test_modal_get_url_matches_gateway_web_endpoint_label():
+    script = Path(".github/scripts/modal-get-url.sh")
+    env = {
+        **os.environ,
+        "MODAL_WORKSPACE": "policyengine",
+        "MODAL_ENVIRONMENT": "staging",
+        "HOUSEHOLD_MODAL_GATEWAY_APP_NAME": GATEWAY_APP_NAME,
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.strip() == (
+        f"https://policyengine-staging--{GATEWAY_WEB_ENDPOINT_LABEL}.modal.run"
+    )
+
+
+def test_modal_get_url_matches_main_gateway_web_endpoint_label():
+    script = Path(".github/scripts/modal-get-url.sh")
+    env = {
+        **os.environ,
+        "MODAL_WORKSPACE": "policyengine",
+        "MODAL_ENVIRONMENT": "main",
+        "HOUSEHOLD_MODAL_GATEWAY_APP_NAME": GATEWAY_APP_NAME,
+    }
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.strip() == (
+        f"https://policyengine--{GATEWAY_WEB_ENDPOINT_LABEL}.modal.run"
+    )


### PR DESCRIPTION
Fixes #1513

## Summary
- Set the Modal gateway WSGI endpoint label explicitly to match the URL generated by the release smoke-check script.
- Add unit coverage that checks the gateway label and modal-get-url.sh stay aligned for main and staging URLs.
- Add a changelog fragment for the deploy smoke-check fix.

## Testing
- `uv run ruff check policyengine_household_api/modal_release/gateway_app.py`
- `uv run ruff check policyengine_household_api/modal_release/gateway_app.py tests/unit/modal_release/test_gateway_app.py`
- `uv run pytest tests/unit/modal_release/test_gateway_app.py -q`