### PR TITLE
Fix Modal gateway URL resolution

### DIFF
--- a/.github/scripts/modal-get-url.sh
+++ b/.github/scripts/modal-get-url.sh
@@ -1,13 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-workspace="${MODAL_WORKSPACE:-policyengine}"
 environment="${MODAL_ENVIRONMENT:-main}"
 app_name="${HOUSEHOLD_MODAL_GATEWAY_APP_NAME:-policyengine-household-api-gateway}"
+function_name="${HOUSEHOLD_MODAL_GATEWAY_FUNCTION_NAME:-web_app}"
 
-if [[ "${environment}" == "main" ]]; then
-  echo "https://${workspace}--${app_name}-web-app.modal.run"
-else
-  echo "https://${workspace}-${environment}--${app_name}-web-app.modal.run"
-fi
+uv run python - "${app_name}" "${function_name}" "${environment}" <<'PY'
+from __future__ import annotations
 
+import sys
+
+import modal
+
+
+app_name, function_name, environment = sys.argv[1:4]
+function = modal.Function.from_name(
+    app_name,
+    function_name,
+    environment_name=environment,
+)
+url = function.get_web_url()
+if not url:
+    raise SystemExit(
+        f"Modal function `{app_name}.{function_name}` has no web URL"
+    )
+print(url)
+PY

--- a/changelog.d/1515.fixed.md
+++ b/changelog.d/1515.fixed.md
@@ -1,0 +1,1 @@
+Fix Modal gateway URL lookup to use Modal's deployed web URL instead of reconstructing overlong hostnames.

--- a/policyengine_household_api/modal_release/gateway_app.py
+++ b/policyengine_household_api/modal_release/gateway_app.py
@@ -15,7 +15,10 @@ GATEWAY_APP_NAME = os.getenv(
     "HOUSEHOLD_MODAL_GATEWAY_APP_NAME",
     "policyengine-household-api-gateway",
 )
-GATEWAY_WEB_ENDPOINT_LABEL = f"{GATEWAY_APP_NAME}-web-app"
+GATEWAY_WEB_ENDPOINT_LABEL = os.getenv(
+    "HOUSEHOLD_MODAL_GATEWAY_WEB_ENDPOINT_LABEL",
+    "household-api-gateway",
+)
 
 app = modal.App(GATEWAY_APP_NAME)
 

--- a/tests/unit/modal_release/test_gateway_app.py
+++ b/tests/unit/modal_release/test_gateway_app.py
@@ -8,17 +8,42 @@ from policyengine_household_api.modal_release.gateway_app import (
 )
 
 
-def test_gateway_web_endpoint_label_matches_app_name():
-    assert GATEWAY_WEB_ENDPOINT_LABEL == f"{GATEWAY_APP_NAME}-web-app"
+def test_gateway_web_endpoint_label_is_short_and_stable():
+    assert GATEWAY_WEB_ENDPOINT_LABEL == "household-api-gateway"
 
 
-def test_modal_get_url_matches_gateway_web_endpoint_label():
+def test_gateway_web_endpoint_label_fits_modal_hostname_limit():
+    for environment in ("main", "staging", "testing"):
+        source = _modal_source(environment)
+        subdomain = f"{source}--{GATEWAY_WEB_ENDPOINT_LABEL}"
+
+        assert len(subdomain) <= 63
+
+
+def test_modal_get_url_uses_deployed_modal_function_url(tmp_path):
     script = Path(".github/scripts/modal-get-url.sh")
+    fake_uv = tmp_path / "uv"
+    args_file = tmp_path / "uv-args.txt"
+    fake_uv.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                'printf "%s %s %s\\n" "$4" "$5" "$6" > "$UV_ARGS_FILE"',
+                "cat >/dev/null",
+                "echo https://policyengine-testing--household-api-gateway.modal.run",
+            ]
+        )
+        + "\n"
+    )
+    fake_uv.chmod(0o755)
+
     env = {
         **os.environ,
-        "MODAL_WORKSPACE": "policyengine",
-        "MODAL_ENVIRONMENT": "staging",
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "MODAL_ENVIRONMENT": "testing",
         "HOUSEHOLD_MODAL_GATEWAY_APP_NAME": GATEWAY_APP_NAME,
+        "UV_ARGS_FILE": str(args_file),
     }
 
     result = subprocess.run(
@@ -29,28 +54,14 @@ def test_modal_get_url_matches_gateway_web_endpoint_label():
         text=True,
     )
 
-    assert result.stdout.strip() == (
-        f"https://policyengine-staging--{GATEWAY_WEB_ENDPOINT_LABEL}.modal.run"
+    assert (
+        result.stdout.strip()
+        == "https://policyengine-testing--household-api-gateway.modal.run"
     )
+    assert args_file.read_text() == f"{GATEWAY_APP_NAME} web_app testing\n"
 
 
-def test_modal_get_url_matches_main_gateway_web_endpoint_label():
-    script = Path(".github/scripts/modal-get-url.sh")
-    env = {
-        **os.environ,
-        "MODAL_WORKSPACE": "policyengine",
-        "MODAL_ENVIRONMENT": "main",
-        "HOUSEHOLD_MODAL_GATEWAY_APP_NAME": GATEWAY_APP_NAME,
-    }
-
-    result = subprocess.run(
-        ["bash", str(script)],
-        check=True,
-        capture_output=True,
-        env=env,
-        text=True,
-    )
-
-    assert result.stdout.strip() == (
-        f"https://policyengine--{GATEWAY_WEB_ENDPOINT_LABEL}.modal.run"
-    )
+def _modal_source(environment: str) -> str:
+    if environment == "main":
+        return "policyengine"
+    return f"policyengine-{environment}"


### PR DESCRIPTION
Fixes #1515

## Summary
- Resolve the deployed Modal gateway URL with `modal.Function.from_name(...).get_web_url()` instead of reconstructing the hostname.
- Shorten the household API gateway web endpoint label so testing/staging hostnames stay under Modal's DNS label limit.
- Update gateway URL tests to cover the shortened label and script arguments.

## Testing
- `uv run ruff check policyengine_household_api/modal_release/gateway_app.py tests/unit/modal_release/test_gateway_app.py`
- `bash -n .github/scripts/modal-get-url.sh`
- `uv run pytest tests/unit/modal_release/test_gateway_app.py -q` did not complete locally; the tests printed passing dots and then hung during teardown, so I stopped the process.