### PR TITLE
Add Modal gateway custom domain

### DIFF
--- a/changelog.d/1519.changed.md
+++ b/changelog.d/1519.changed.md
@@ -1,0 +1,1 @@
+Add the production household API custom domain to the Modal gateway app.

--- a/policyengine_household_api/modal_release/gateway_app.py
+++ b/policyengine_household_api/modal_release/gateway_app.py
@@ -19,6 +19,40 @@ GATEWAY_WEB_ENDPOINT_LABEL = os.getenv(
     "HOUSEHOLD_MODAL_GATEWAY_WEB_ENDPOINT_LABEL",
     "household-api-gateway",
 )
+GATEWAY_CUSTOM_DOMAIN = "household.api.policyengine.org"
+
+
+def gateway_custom_domains(
+    *,
+    modal_environment: str | None = None,
+    custom_domains: str | None = None,
+) -> tuple[str, ...]:
+    if custom_domains is None:
+        custom_domains = os.getenv("HOUSEHOLD_MODAL_GATEWAY_CUSTOM_DOMAINS")
+
+    if custom_domains is not None:
+        return tuple(
+            domain.strip()
+            for domain in custom_domains.split(",")
+            if domain.strip()
+        )
+
+    environment = modal_environment or os.getenv("MODAL_ENVIRONMENT", "main")
+    if environment == "main":
+        return (GATEWAY_CUSTOM_DOMAIN,)
+
+    return ()
+
+
+GATEWAY_CUSTOM_DOMAINS = gateway_custom_domains()
+
+
+def gateway_wsgi_app_options() -> dict[str, object]:
+    options: dict[str, object] = {"label": GATEWAY_WEB_ENDPOINT_LABEL}
+    if GATEWAY_CUSTOM_DOMAINS:
+        options["custom_domains"] = GATEWAY_CUSTOM_DOMAINS
+    return options
+
 
 app = modal.App(GATEWAY_APP_NAME)
 
@@ -29,6 +63,6 @@ app = modal.App(GATEWAY_APP_NAME)
     timeout=180,
     scaledown_window=300,
 )
-@modal.wsgi_app(label=GATEWAY_WEB_ENDPOINT_LABEL)
+@modal.wsgi_app(**gateway_wsgi_app_options())
 def web_app():
     return create_gateway_app()

--- a/tests/unit/modal_release/test_gateway_app.py
+++ b/tests/unit/modal_release/test_gateway_app.py
@@ -4,12 +4,32 @@ from pathlib import Path
 
 from policyengine_household_api.modal_release.gateway_app import (
     GATEWAY_APP_NAME,
+    GATEWAY_CUSTOM_DOMAIN,
     GATEWAY_WEB_ENDPOINT_LABEL,
+    gateway_custom_domains,
 )
 
 
 def test_gateway_web_endpoint_label_is_short_and_stable():
     assert GATEWAY_WEB_ENDPOINT_LABEL == "household-api-gateway"
+
+
+def test_gateway_custom_domain_defaults_to_main_environment_only():
+    assert gateway_custom_domains(modal_environment="main") == (
+        GATEWAY_CUSTOM_DOMAIN,
+    )
+    assert gateway_custom_domains(modal_environment="staging") == ()
+    assert gateway_custom_domains(modal_environment="testing") == ()
+
+
+def test_gateway_custom_domain_accepts_explicit_override():
+    assert gateway_custom_domains(
+        custom_domains="example.com, alt.example.com"
+    ) == (
+        "example.com",
+        "alt.example.com",
+    )
+    assert gateway_custom_domains(custom_domains="") == ()
 
 
 def test_gateway_web_endpoint_label_fits_modal_hostname_limit():


### PR DESCRIPTION
Fixes #1519

## Summary
- Attach household.api.policyengine.org to the Modal gateway in the main environment by default.
- Keep staging and testing on generated Modal URLs unless HOUSEHOLD_MODAL_GATEWAY_CUSTOM_DOMAINS is explicitly set.
- Add focused unit coverage for gateway custom-domain selection.

## Verification
- make format-check
- ruff check policyengine_household_api/modal_release/gateway_app.py tests/unit/modal_release/test_gateway_app.py

Focused pytest was skipped per request.