### PR TITLE
Avoid Modal manifest transitions for code-only deploys

### DIFF
--- a/.github/scripts/modal-cleanup-apps.sh
+++ b/.github/scripts/modal-cleanup-apps.sh
@@ -16,5 +16,12 @@ for app_name in payload.get("app_names", []):
   if [[ -z "${app_name}" ]]; then
     continue
   fi
-  uv run modal app stop --env "${environment}" "${app_name}"
+  if ! output="$(uv run modal app stop --env "${environment}" "${app_name}" 2>&1)"; then
+    echo "${output}"
+    if [[ "${output}" == *"already stopped"* ]]; then
+      continue
+    fi
+    exit 1
+  fi
+  echo "${output}"
 done

--- a/.github/scripts/modal-deploy-release.sh
+++ b/.github/scripts/modal-deploy-release.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-config_json="${1:?Usage: modal-deploy-release.sh CONFIG_JSON}"
+config_json="${1:?Usage: modal-deploy-release.sh CONFIG_JSON [DEPLOY_MODE]}"
+deploy_mode="${2:-release}"
 output_file="${GITHUB_OUTPUT:-}"
+modal_extract_versions_script="${MODAL_EXTRACT_VERSIONS_SCRIPT:-.github/scripts/modal_extract_versions.py}"
+modal_sync_secrets_script="${MODAL_SYNC_SECRETS_SCRIPT:-.github/scripts/modal-sync-secrets.sh}"
+modal_active_worker_apps_script="${MODAL_ACTIVE_WORKER_APPS_SCRIPT:-.github/scripts/modal_active_worker_apps.py}"
+modal_cleanup_apps_script="${MODAL_CLEANUP_APPS_SCRIPT:-.github/scripts/modal-cleanup-apps.sh}"
+modal_get_url_script="${MODAL_GET_URL_SCRIPT:-.github/scripts/modal-get-url.sh}"
 
 require_env() {
   local missing=()
@@ -34,6 +40,18 @@ github_output() {
   fi
 }
 
+deploy_worker_app() {
+  local app_name="${1:?app name is required}"
+  local package_versions_json="${2:-}"
+
+  HOUSEHOLD_MODAL_WORKER_APP_NAME="${app_name}" \
+    HOUSEHOLD_MODAL_PACKAGE_VERSIONS_JSON="${package_versions_json}" \
+    MODAL_ENVIRONMENT="${modal_environment}" \
+    uv run modal deploy \
+      --env "${modal_environment}" \
+      -m policyengine_household_api.modal_release.worker_app
+}
+
 require_env \
   MODAL_ENVIRONMENT \
   USER_ANALYTICS_DB_USERNAME \
@@ -41,6 +59,15 @@ require_env \
   USER_ANALYTICS_DB_CONNECTION_NAME
 
 modal_environment="${MODAL_ENVIRONMENT}"
+
+case "${deploy_mode}" in
+  code|release)
+    ;;
+  *)
+    echo "::error::Unsupported Modal deploy mode: ${deploy_mode}"
+    exit 1
+    ;;
+esac
 
 uv run alembic upgrade head
 analytics_database_revision="$(
@@ -54,7 +81,7 @@ github_output "analytics_database_revision" "${analytics_database_revision}"
 
 versions_output="$(mktemp)"
 trap 'rm -f "${versions_output}"' EXIT
-uv run python .github/scripts/modal_extract_versions.py \
+uv run python "${modal_extract_versions_script}" \
   --github-output "${versions_output}"
 if [ -n "${output_file}" ]; then
   cat "${versions_output}" >> "${output_file}"
@@ -64,34 +91,47 @@ worker_app_name="$(
     "${versions_output}"
 )"
 
-bash .github/scripts/modal-sync-secrets.sh
+bash "${modal_sync_secrets_script}"
 
-new_app_target="$(config_value new_app_target)"
-if [ "${new_app_target}" != "none" ]; then
-  HOUSEHOLD_MODAL_WORKER_APP_NAME="${worker_app_name}" \
-    MODAL_ENVIRONMENT="${modal_environment}" \
-    uv run modal deploy \
-      --env "${modal_environment}" \
-      -m policyengine_household_api.modal_release.worker_app
+if [ "${deploy_mode}" = "code" ]; then
+  active_apps_tsv="$(mktemp)"
+  trap 'rm -f "${versions_output}" "${active_apps_tsv}"' EXIT
+
+  uv run python "${modal_active_worker_apps_script}" \
+    --modal-environment "${modal_environment}" \
+    --output-tsv "${active_apps_tsv}"
+
+  while IFS=$'\t' read -r active_app_name package_versions_json; do
+    if [ -z "${active_app_name}" ]; then
+      continue
+    fi
+    deploy_worker_app "${active_app_name}" "${package_versions_json}"
+  done < "${active_apps_tsv}"
+else
+  new_app_target="$(config_value new_app_target)"
+  if [ "${new_app_target}" != "none" ]; then
+    deploy_worker_app "${worker_app_name}" ""
+  fi
+
+  uv run python -m policyengine_household_api.modal_release.update_manifest \
+    --config-json "${config_json}" \
+    --new-app-name "${worker_app_name}" \
+    --analytics-database-revision "${analytics_database_revision}" \
+    --modal-environment "${modal_environment}" \
+    --cleanup-output modal-cleanup.json \
+    --manifest-output modal-manifest.json
 fi
-
-uv run python -m policyengine_household_api.modal_release.update_manifest \
-  --config-json "${config_json}" \
-  --new-app-name "${worker_app_name}" \
-  --source-commit "${GITHUB_SHA}" \
-  --analytics-database-revision "${analytics_database_revision}" \
-  --modal-environment "${modal_environment}" \
-  --cleanup-output modal-cleanup.json \
-  --manifest-output modal-manifest.json
 
 uv run modal deploy \
   --env "${modal_environment}" \
   -m policyengine_household_api.modal_release.gateway_app
 
-cleanup_target="$(config_value cleanup_target)"
-if [ "${cleanup_target}" != "none" ]; then
-  bash .github/scripts/modal-cleanup-apps.sh modal-cleanup.json
+if [ "${deploy_mode}" = "release" ]; then
+  cleanup_target="$(config_value cleanup_target)"
+  if [ "${cleanup_target}" != "none" ]; then
+    bash "${modal_cleanup_apps_script}" modal-cleanup.json
+  fi
 fi
 
-gateway_url="$(bash .github/scripts/modal-get-url.sh)"
+gateway_url="$(bash "${modal_get_url_script}")"
 curl -fsS "${gateway_url}/liveness_check"

--- a/.github/scripts/modal_active_worker_apps.py
+++ b/.github/scripts/modal_active_worker_apps.py
@@ -17,7 +17,7 @@ def main() -> None:
     args = _parse_args()
     manifest_dict = modal.Dict.from_name(
         MANIFEST_DICT_NAME,
-        create_if_missing=True,
+        create_if_missing=False,
         environment_name=args.modal_environment,
     )
     deployments = active_app_deployments(manifest_dict.get(MANIFEST_DICT_KEY))

--- a/.github/scripts/modal_active_worker_apps.py
+++ b/.github/scripts/modal_active_worker_apps.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import modal
+
+from policyengine_household_api.modal_release.manifest import (
+    MANIFEST_DICT_KEY,
+    MANIFEST_DICT_NAME,
+    active_app_deployments,
+)
+
+
+def main() -> None:
+    args = _parse_args()
+    manifest_dict = modal.Dict.from_name(
+        MANIFEST_DICT_NAME,
+        create_if_missing=True,
+        environment_name=args.modal_environment,
+    )
+    deployments = active_app_deployments(manifest_dict.get(MANIFEST_DICT_KEY))
+
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(deployments, indent=2, sort_keys=True) + "\n"
+        )
+    if args.output_tsv:
+        lines = [
+            "\t".join(
+                (
+                    deployment["app_name"],
+                    json.dumps(
+                        deployment["package_versions"],
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                )
+            )
+            for deployment in deployments
+        ]
+        Path(args.output_tsv).write_text("\n".join(lines) + "\n")
+
+    print(json.dumps(deployments, indent=2, sort_keys=True))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Emit active Modal worker apps from the release manifest."
+    )
+    parser.add_argument("--modal-environment", required=True)
+    parser.add_argument("--output-json")
+    parser.add_argument("--output-tsv")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/resolve_modal_release_config.py
+++ b/.github/scripts/resolve_modal_release_config.py
@@ -26,12 +26,14 @@ WEEKLY_UPDATE_COMMIT_MESSAGE = "Update PolicyEngine Household API"
 class ResolvedModalRelease:
     should_deploy: bool
     source: str
+    deploy_mode: str
     config: ModalReleaseConfig | None = None
 
     def to_dict(self) -> dict[str, Any]:
         data = {
             "should_deploy": self.should_deploy,
             "source": self.source,
+            "deploy_mode": self.deploy_mode,
             "config": None,
         }
         if self.config:
@@ -82,15 +84,16 @@ def resolve_release_from_event(
         return ResolvedModalRelease(
             True,
             "workflow-dispatch-inputs",
+            "release",
             workflow_dispatch_config_from_inputs(event.get("inputs") or {}),
         )
 
     if "head_commit" not in event:
-        return ResolvedModalRelease(False, "unsupported-event")
+        return ResolvedModalRelease(False, "unsupported-event", "none")
 
     message = (event.get("head_commit") or {}).get("message")
     if message != WEEKLY_UPDATE_COMMIT_MESSAGE:
-        return ResolvedModalRelease(False, "push-not-release-commit")
+        return ResolvedModalRelease(False, "push-not-release-commit", "none")
 
     repository = (event.get("repository") or {}).get("full_name")
     source_sha = event.get("before") or event.get("after")
@@ -109,8 +112,8 @@ def resolve_release_from_event(
 
     return ResolvedModalRelease(
         True,
-        "weekly-default",
-        default_weekly_config(),
+        "code-only",
+        "code",
     )
 
 
@@ -121,10 +124,15 @@ def resolve_release_from_body(
     deploy_when_missing: bool,
 ) -> ResolvedModalRelease:
     if not body_contains_modal_release_config(body):
-        return ResolvedModalRelease(deploy_when_missing, f"{source}-missing")
+        deploy_mode = "code" if deploy_when_missing else "none"
+        return ResolvedModalRelease(
+            deploy_when_missing,
+            f"{source}-missing",
+            deploy_mode,
+        )
 
     config = parse_modal_release_config_from_body(body)
-    return ResolvedModalRelease(True, source, config)
+    return ResolvedModalRelease(True, source, "release", config)
 
 
 def workflow_dispatch_config_from_inputs(
@@ -200,6 +208,7 @@ def write_github_outputs(
     outputs = {
         "should_deploy": str(result["should_deploy"]).lower(),
         "source": result["source"],
+        "deploy_mode": result["deploy_mode"],
         "new_app_target": config.get("new_app_target", "none"),
         "promote_existing_frontier": str(
             config.get("promote_existing_frontier", False)

--- a/.github/scripts/test_modal_cleanup_apps.py
+++ b/.github/scripts/test_modal_cleanup_apps.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def test_modal_cleanup_treats_already_stopped_app_as_success(tmp_path):
+    cleanup_file = tmp_path / "cleanup.json"
+    cleanup_file.write_text('{"app_names":["old-app"]}\n')
+    _write_fake_uv(tmp_path, exit_code=1, output="App is already stopped.")
+
+    result = subprocess.run(
+        [
+            "bash",
+            ".github/scripts/modal-cleanup-apps.sh",
+            str(cleanup_file),
+        ],
+        capture_output=True,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "MODAL_ENVIRONMENT": "testing",
+        },
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "already stopped" in result.stdout
+
+
+def test_modal_cleanup_fails_on_other_stop_errors(tmp_path):
+    cleanup_file = tmp_path / "cleanup.json"
+    cleanup_file.write_text('{"app_names":["old-app"]}\n')
+    _write_fake_uv(tmp_path, exit_code=1, output="Permission denied.")
+
+    result = subprocess.run(
+        [
+            "bash",
+            ".github/scripts/modal-cleanup-apps.sh",
+            str(cleanup_file),
+        ],
+        capture_output=True,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "MODAL_ENVIRONMENT": "testing",
+        },
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Permission denied" in result.stdout
+
+
+def _write_fake_uv(tmp_path, *, exit_code: int, output: str) -> None:
+    uv = tmp_path / "uv"
+    uv.write_text(
+        f"""#!/usr/bin/env bash
+echo "{output}" >&2
+exit {exit_code}
+"""
+    )
+    uv.chmod(0o755)

--- a/.github/scripts/test_modal_deploy_release.py
+++ b/.github/scripts/test_modal_deploy_release.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import subprocess
 
 
@@ -24,3 +25,161 @@ def test_modal_deploy_release_requires_explicit_modal_environment():
 
     assert result.returncode == 1
     assert "MODAL_ENVIRONMENT" in result.stdout
+
+
+def test_modal_deploy_release_code_mode_deploys_manifest_apps_only(tmp_path):
+    log_path = tmp_path / "uv.log"
+    env = _deploy_env(tmp_path, log_path)
+    active_apps_script = tmp_path / "modal_active_worker_apps.py"
+    active_apps_script.write_text("# fake active apps script\n")
+    env["MODAL_ACTIVE_WORKER_APPS_SCRIPT"] = str(active_apps_script)
+    _write_fake_uv(
+        tmp_path,
+        log_path,
+        active_apps_tsv=(
+            'current-app\t{"uk":"2.31.0","us":"1.690.0"}\n'
+            'frontier-app\t{"uk":"2.31.0","us":"1.691.1"}\n'
+        ),
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            ".github/scripts/modal-deploy-release.sh",
+            "{}",
+            "code",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    log = log_path.read_text()
+    assert "DEPLOY_APP=current-app" in log
+    assert 'VERSIONS={"uk":"2.31.0","us":"1.690.0"}' in log
+    assert "DEPLOY_APP=frontier-app" in log
+    assert 'VERSIONS={"uk":"2.31.0","us":"1.691.1"}' in log
+    assert (
+        "-m policyengine_household_api.modal_release.update_manifest"
+        not in log
+    )
+    assert "cleanup-called" not in log
+
+
+def test_modal_deploy_release_release_mode_updates_manifest_and_cleans(
+    tmp_path,
+):
+    log_path = tmp_path / "uv.log"
+    env = _deploy_env(tmp_path, log_path)
+    _write_fake_uv(tmp_path, log_path, active_apps_tsv="")
+
+    result = subprocess.run(
+        [
+            "bash",
+            ".github/scripts/modal-deploy-release.sh",
+            (
+                '{"new_app_target":"frontier",'
+                '"promote_existing_frontier":true,'
+                '"cleanup_target":"retired"}'
+            ),
+            "release",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    log = log_path.read_text()
+    assert "DEPLOY_APP=release-app" in log
+    assert "-m policyengine_household_api.modal_release.update_manifest" in log
+    assert "--source-commit" not in log
+    assert "cleanup-called" in log
+
+
+def _deploy_env(tmp_path: Path, log_path: Path) -> dict[str, str]:
+    sync_script = tmp_path / "sync-secrets.sh"
+    sync_script.write_text("#!/usr/bin/env bash\nexit 0\n")
+    sync_script.chmod(0o755)
+
+    cleanup_script = tmp_path / "cleanup.sh"
+    cleanup_script.write_text(
+        f"#!/usr/bin/env bash\necho cleanup-called >> {log_path}\n"
+    )
+    cleanup_script.chmod(0o755)
+
+    get_url_script = tmp_path / "get-url.sh"
+    get_url_script.write_text(
+        "#!/usr/bin/env bash\necho http://example.test\n"
+    )
+    get_url_script.chmod(0o755)
+
+    fake_curl = tmp_path / "curl"
+    fake_curl.write_text("#!/usr/bin/env bash\nexit 0\n")
+    fake_curl.chmod(0o755)
+
+    return {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "UV_LOG": str(log_path),
+        "MODAL_ENVIRONMENT": "testing",
+        "USER_ANALYTICS_DB_USERNAME": "user",
+        "USER_ANALYTICS_DB_PASSWORD": "password",
+        "USER_ANALYTICS_DB_CONNECTION_NAME": "project:region:instance",
+        "MODAL_SYNC_SECRETS_SCRIPT": str(sync_script),
+        "MODAL_CLEANUP_APPS_SCRIPT": str(cleanup_script),
+        "MODAL_GET_URL_SCRIPT": str(get_url_script),
+    }
+
+
+def _write_fake_uv(
+    tmp_path: Path,
+    log_path: Path,
+    *,
+    active_apps_tsv: str,
+) -> None:
+    uv = tmp_path / "uv"
+    uv.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${{UV_LOG}}"
+
+if [[ "$*" == *"policyengine_household_api.modal_release.analytics_revision"* ]]; then
+  echo "20260512_0003"
+  exit 0
+fi
+
+if [[ "$*" == *"modal_extract_versions.py"* ]]; then
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--github-output" ]]; then
+      shift
+      printf 'worker_app_name=release-app\\n' > "$1"
+      exit 0
+    fi
+    shift
+  done
+fi
+
+if [[ "$*" == *"modal_active_worker_apps.py"* ]]; then
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--output-tsv" ]]; then
+      shift
+      cat > "$1" <<'EOF'
+{active_apps_tsv}EOF
+      exit 0
+    fi
+    shift
+  done
+fi
+
+if [[ "$*" == *"modal deploy"* && "$*" == *"worker_app"* ]]; then
+  echo "DEPLOY_APP=${{HOUSEHOLD_MODAL_WORKER_APP_NAME:-}}" >> "{log_path}"
+  echo "VERSIONS=${{HOUSEHOLD_MODAL_PACKAGE_VERSIONS_JSON:-}}" >> "{log_path}"
+  exit 0
+fi
+
+exit 0
+"""
+    )
+    uv.chmod(0o755)

--- a/.github/scripts/test_resolve_modal_release_config.py
+++ b/.github/scripts/test_resolve_modal_release_config.py
@@ -21,6 +21,7 @@ def test_resolve_release_from_pull_request_body():
     )
 
     assert resolved.should_deploy is True
+    assert resolved.deploy_mode == "release"
     assert resolved.config is not None
 
 
@@ -36,6 +37,7 @@ def test_resolve_release_ignores_template_guidance_without_config_block():
 
     assert resolved.should_deploy is False
     assert resolved.source == "pull_request-missing"
+    assert resolved.deploy_mode == "none"
 
 
 def test_resolve_release_uses_workflow_dispatch_inputs():
@@ -53,6 +55,7 @@ def test_resolve_release_uses_workflow_dispatch_inputs():
 
     assert resolved.should_deploy is True
     assert resolved.source == "workflow-dispatch-inputs"
+    assert resolved.deploy_mode == "release"
     assert resolved.config is not None
     assert resolved.config.new_app_target == "current"
     assert resolved.config.promote_existing_frontier is False
@@ -68,6 +71,7 @@ def test_resolve_release_uses_weekly_default_for_empty_workflow_dispatch():
 
     assert resolved.should_deploy is True
     assert resolved.source == "workflow-dispatch-inputs"
+    assert resolved.deploy_mode == "release"
     assert resolved.config is not None
     assert resolved.config.cleanup_target == "retired"
 
@@ -90,6 +94,7 @@ def test_resolve_release_skips_regular_push_even_with_pr_config():
 
     assert resolved.should_deploy is False
     assert resolved.source == "push-not-release-commit"
+    assert resolved.deploy_mode == "none"
     assert fetched == []
 
 
@@ -113,10 +118,11 @@ def test_resolve_release_uses_versioning_parent_pr_body():
 
     assert resolved.should_deploy is True
     assert resolved.source == "versioning-parent-pull-request"
+    assert resolved.deploy_mode == "release"
     assert resolved.config is not None
 
 
-def test_resolve_release_uses_weekly_default_when_no_pr_body_exists():
+def test_resolve_release_uses_code_deploy_when_no_pr_body_exists():
     resolved = resolve_release_from_event(
         {
             "repository": {
@@ -130,6 +136,6 @@ def test_resolve_release_uses_weekly_default_when_no_pr_body_exists():
     )
 
     assert resolved.should_deploy is True
-    assert resolved.source == "weekly-default"
-    assert resolved.config is not None
-    assert resolved.config.cleanup_target == "retired"
+    assert resolved.source == "code-only"
+    assert resolved.deploy_mode == "code"
+    assert resolved.config is None

--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -93,6 +93,7 @@ jobs:
     outputs:
       should_deploy: ${{ steps.resolve.outputs.should_deploy }}
       source: ${{ steps.resolve.outputs.source }}
+      deploy_mode: ${{ steps.resolve.outputs.deploy_mode }}
       new_app_target: ${{ steps.resolve.outputs.new_app_target }}
       promote_existing_frontier: ${{ steps.resolve.outputs.promote_existing_frontier }}
       cleanup_target: ${{ steps.resolve.outputs.cleanup_target }}
@@ -166,7 +167,8 @@ jobs:
           GCP_CREDENTIALS_JSON: ${{ secrets.GCP_SA_KEY }}
         run: |
           bash .github/scripts/modal-deploy-release.sh \
-            '${{ needs.resolve-modal-release-config.outputs.config_json }}'
+            '${{ needs.resolve-modal-release-config.outputs.config_json }}' \
+            '${{ needs.resolve-modal-release-config.outputs.deploy_mode }}'
 
   integration-tests-staging:
     name: Integration tests against Modal staging (${{ matrix.channel }}, ${{ matrix.route_mode }})
@@ -260,7 +262,8 @@ jobs:
           GCP_CREDENTIALS_JSON: ${{ secrets.GCP_SA_KEY }}
         run: |
           bash .github/scripts/modal-deploy-release.sh \
-            '${{ needs.resolve-modal-release-config.outputs.config_json }}'
+            '${{ needs.resolve-modal-release-config.outputs.config_json }}' \
+            '${{ needs.resolve-modal-release-config.outputs.deploy_mode }}'
 
   publish:
     name: Publish to PyPI

--- a/changelog.d/modal-code-only-deploys.fixed.md
+++ b/changelog.d/modal-code-only-deploys.fixed.md
@@ -1,0 +1,1 @@
+Avoid current/frontier manifest transitions for Modal code-only deploys.

--- a/docs/engineering/skills/modal-release-prs.md
+++ b/docs/engineering/skills/modal-release-prs.md
@@ -84,6 +84,13 @@ package version references, or release validation. Those countries may still be
 served by the worker, but their package versions must not control a Modal
 release.
 
+The canonical manifest schema version is `1`. Runtime code should validate that
+stored manifests already match this schema; do not add legacy normalization to
+the gateway, release updater, or active-app discovery paths. The manifest
+rewrite command is the only bridge from older stored shapes: it copies the old
+`current` and `frontier` app references into canonical schema version `1`,
+drops retired history, and removes non-release package keys.
+
 Manual workflow dispatch exposes the same `new_app_target`,
 `promote_existing_frontier`, and `cleanup_target` settings as the PR-body YAML
 block. The deploy workflow and Modal images use Python 3.13.

--- a/docs/engineering/skills/modal-release-prs.md
+++ b/docs/engineering/skills/modal-release-prs.md
@@ -33,8 +33,8 @@ Normal PR validation rejects `cleanup_target: current` and
 regular code PR. `promote_existing_frontier: true` is only valid when
 `new_app_target: frontier`.
 
-Use the default weekly release shape unless the user explicitly asks for a
-different deployment behavior:
+Use this release shape for the normal weekly country-package release unless
+the user explicitly asks for different current/frontier behavior:
 
 ```yaml
 modal_release:
@@ -45,22 +45,27 @@ modal_release:
 
 This deploys the new worker to `frontier`, promotes the previous `frontier` to
 `current`, and moves the previous `current` into the manifest's `retired`
-history. The default weekly release shape uses `cleanup_target: retired`, so
+history. This release shape uses `cleanup_target: retired`, so
 apps in the retired history are stopped after the manifest is updated. Use
 `cleanup_target: none` only when the user explicitly asks to preserve retired
 worker apps after release.
 
 Do not use PR labels, branch names, model-specific tags, or title prefixes to
 control Modal release behavior. The PR body YAML block is the source of truth.
-The PR-body YAML block is required only when the PR changes a release-significant
-country package version, meaning `policyengine_us` or `policyengine_uk` in
-`pyproject.toml`. Code-only changes, including changes to Modal release code,
-must not require a `modal_release` block unless those US or UK package versions
-also change.
+The PR-body YAML block is the only automatic signal that a deployment should
+promote, retire, clean up, or otherwise mutate the current/frontier manifest.
+It is required when the PR changes a release-significant country package
+version, meaning `policyengine_us` or `policyengine_uk` in `pyproject.toml`.
+Code-only changes, including changes to Modal release code, must not require a
+`modal_release` block unless those US or UK package versions also change.
 The release workflow deploys from the finalized
-`Update PolicyEngine Household API` versioning commit; ordinary push events do
-not deploy Modal apps. Manual `workflow_dispatch` runs use the default weekly
-release shape.
+`Update PolicyEngine Household API` versioning commit. When that commit has no
+PR-body `modal_release` block, the workflow performs a code-only deploy: it
+redeploys the active `current` and `frontier` worker apps already named in the
+manifest, preserving each app's manifest-declared US/UK package versions, then
+redeploys the gateway without changing the manifest. Ordinary push events do
+not deploy Modal apps. Manual `workflow_dispatch` runs are explicit release
+operations and use the weekly release shape by default.
 
 The household API deploy pipeline is Modal-only. Do not add App Engine, GCP
 Artifact Registry, Docker image, or GCP traffic-promotion deployment steps to
@@ -102,6 +107,8 @@ the shared database.
 
 Each manifest app reference records the worker's minimum required analytics
 revision and the database revision observed after the release migration step.
+The manifest must not include source commit metadata; use GitHub Actions and
+Modal deployment history for deploy provenance.
 
 ## Request Routing
 

--- a/policyengine_household_api/modal_release/gateway.py
+++ b/policyengine_household_api/modal_release/gateway.py
@@ -11,7 +11,7 @@ from policyengine_household_api.modal_release.manifest import (
     MANIFEST_DICT_KEY,
     MANIFEST_DICT_NAME,
     empty_manifest,
-    normalize_manifest,
+    validate_manifest,
 )
 
 
@@ -45,7 +45,7 @@ def create_gateway_app(
     @app.get("/readiness_check")
     def readiness_check() -> Response:
         manifest = load_manifest()
-        if not normalize_manifest(manifest).get("current"):
+        if not validate_manifest(manifest).get("current"):
             return jsonify(
                 {
                     "status": "error",
@@ -56,14 +56,14 @@ def create_gateway_app(
 
     @app.get("/versions")
     def versions() -> Response:
-        return jsonify(normalize_manifest(load_manifest()))
+        return jsonify(validate_manifest(load_manifest()))
 
     @app.get("/versions/<country_id>")
     def country_versions(country_id: str) -> Response:
         if country_id not in COUNTRIES:
             return _json_error(f"Unsupported country `{country_id}`", 404)
 
-        manifest = normalize_manifest(load_manifest())
+        manifest = validate_manifest(load_manifest())
         country_versions = {}
         for channel in ("current", "frontier"):
             app_reference = manifest.get(channel)
@@ -88,7 +88,7 @@ def create_gateway_app(
         body = request.get_data()
 
         try:
-            manifest = normalize_manifest(load_manifest())
+            manifest = validate_manifest(load_manifest())
             if country_id and endpoint in VERSIONED_ENDPOINTS:
                 body, requested_version = _extract_requested_version(body)
             else:
@@ -119,7 +119,7 @@ def load_modal_manifest() -> dict[str, Any]:
         )
     except NotFoundError:
         return empty_manifest()
-    return normalize_manifest(manifest_dict.get(MANIFEST_DICT_KEY))
+    return validate_manifest(manifest_dict.get(MANIFEST_DICT_KEY))
 
 
 def resolve_app_for_request(

--- a/policyengine_household_api/modal_release/gateway.py
+++ b/policyengine_household_api/modal_release/gateway.py
@@ -10,6 +10,7 @@ from policyengine_household_api.constants import COUNTRIES
 from policyengine_household_api.modal_release.manifest import (
     MANIFEST_DICT_KEY,
     MANIFEST_DICT_NAME,
+    empty_manifest,
     normalize_manifest,
 )
 
@@ -109,11 +110,15 @@ def create_gateway_app(
 
 def load_modal_manifest() -> dict[str, Any]:
     import modal
+    from modal.exception import NotFoundError
 
-    manifest_dict = modal.Dict.from_name(
-        MANIFEST_DICT_NAME,
-        create_if_missing=True,
-    )
+    try:
+        manifest_dict = modal.Dict.from_name(
+            MANIFEST_DICT_NAME,
+            create_if_missing=False,
+        )
+    except NotFoundError:
+        return empty_manifest()
     return normalize_manifest(manifest_dict.get(MANIFEST_DICT_KEY))
 
 

--- a/policyengine_household_api/modal_release/images.py
+++ b/policyengine_household_api/modal_release/images.py
@@ -1,18 +1,31 @@
 from __future__ import annotations
 
+import json
 import modal
 import os
+from typing import Mapping
 
 from policyengine_household_api.modal_release._image_setup import (
     snapshot_tax_benefit_systems,
 )
 
 
+COUNTRY_PACKAGE_DISTRIBUTIONS = {
+    "uk": "policyengine_uk",
+    "us": "policyengine_us",
+}
+PACKAGE_VERSIONS_ENV = "HOUSEHOLD_MODAL_PACKAGE_VERSIONS_JSON"
+
+
 def household_api_worker_image() -> modal.Image:
+    image = modal.Image.debian_slim(python_version="3.13").uv_sync(
+        ".", frozen=True
+    )
+    package_specs = country_package_install_specs()
+    if package_specs:
+        image = image.pip_install(*package_specs)
     return (
-        modal.Image.debian_slim(python_version="3.13")
-        .uv_sync(".", frozen=True)
-        .add_local_python_source("policyengine_household_api", copy=True)
+        image.add_local_python_source("policyengine_household_api", copy=True)
         .add_local_dir("config", remote_path="/app/config", copy=True)
         .run_function(snapshot_tax_benefit_systems)
     )
@@ -34,3 +47,39 @@ def household_api_secret() -> modal.Secret:
     return modal.Secret.from_name(
         os.getenv("HOUSEHOLD_MODAL_SECRET_NAME", "household-api")
     )
+
+
+def country_package_install_specs(
+    package_versions: Mapping[str, str] | None = None,
+) -> list[str]:
+    versions = (
+        dict(package_versions)
+        if package_versions is not None
+        else deployment_package_versions_from_env()
+    )
+    return [
+        f"{COUNTRY_PACKAGE_DISTRIBUTIONS[country]}=={versions[country]}"
+        for country in sorted(COUNTRY_PACKAGE_DISTRIBUTIONS)
+        if versions.get(country)
+    ]
+
+
+def deployment_package_versions_from_env() -> dict[str, str]:
+    raw_value = os.getenv(PACKAGE_VERSIONS_ENV)
+    if not raw_value:
+        return {}
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"{PACKAGE_VERSIONS_ENV} must contain JSON object data"
+        ) from e
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"{PACKAGE_VERSIONS_ENV} must be a JSON object")
+    return {
+        country: version
+        for country, version in parsed.items()
+        if country in COUNTRY_PACKAGE_DISTRIBUTIONS
+        and isinstance(version, str)
+        and version
+    }

--- a/policyengine_household_api/modal_release/manifest.py
+++ b/policyengine_household_api/modal_release/manifest.py
@@ -17,12 +17,33 @@ from policyengine_household_api.modal_release.release_config import (
 )
 
 
-MANIFEST_SCHEMA_VERSION = 2
-SUPPORTED_MANIFEST_SCHEMA_VERSIONS = {1, MANIFEST_SCHEMA_VERSION}
+MANIFEST_SCHEMA_VERSION = 1
 MANIFEST_DICT_NAME = "household-api-release-manifest"
 MANIFEST_DICT_KEY = "manifest"
 APP_NAME_PREFIX = "policyengine-household-api"
 RELEASE_PACKAGE_VERSION_COUNTRIES = ("uk", "us")
+APP_REFERENCE_KEYS = {
+    "app_name",
+    "package_versions",
+    "deployed_at",
+    "analytics_migration_minimum_revision",
+    "analytics_database_revision",
+}
+RETIRED_APP_REFERENCE_KEYS = APP_REFERENCE_KEYS | {
+    "retired_at",
+    "retirement_reason",
+}
+APP_REFERENCE_REQUIRED_KEYS = {
+    "app_name",
+    "package_versions",
+    "deployed_at",
+}
+MANIFEST_KEYS = {
+    "schema_version",
+    "current",
+    "frontier",
+    "retired",
+}
 
 
 @dataclass(frozen=True)
@@ -55,17 +76,20 @@ def current_timestamp() -> str:
 
 
 def current_package_versions() -> dict[str, str]:
-    return _release_package_versions(COUNTRY_PACKAGE_VERSIONS)
+    return _release_package_versions_from_mapping(COUNTRY_PACKAGE_VERSIONS)
 
 
 def build_app_name(
     package_versions: Mapping[str, str] | None = None,
 ) -> str:
-    versions = package_versions or current_package_versions()
+    versions = (
+        _canonical_release_package_versions(package_versions)
+        if package_versions is not None
+        else _canonical_release_package_versions(current_package_versions())
+    )
     version_slug = "-".join(
         f"{country}{_slugify_version(versions[country])}"
         for country in RELEASE_PACKAGE_VERSION_COUNTRIES
-        if country in versions
     )
     return f"{APP_NAME_PREFIX}-{version_slug}"
 
@@ -77,8 +101,10 @@ def build_app_reference(
     deployed_at: str | None = None,
     analytics_database_revision: str | None = None,
 ) -> dict[str, Any]:
-    versions = _release_package_versions(
-        package_versions or current_package_versions()
+    versions = _canonical_release_package_versions(
+        package_versions
+        if package_versions is not None
+        else current_package_versions()
     )
     reference = AppReference(
         app_name=app_name or build_app_name(versions),
@@ -101,38 +127,36 @@ def empty_manifest() -> dict[str, Any]:
     }
 
 
-def normalize_manifest(manifest: Mapping[str, Any] | None) -> dict[str, Any]:
-    if not manifest:
+def validate_manifest(manifest: Mapping[str, Any] | None) -> dict[str, Any]:
+    if manifest is None:
         return empty_manifest()
+    if not isinstance(manifest, Mapping):
+        raise ValueError("Modal manifest must be a mapping")
 
-    normalized = deepcopy(dict(manifest))
-    normalized.setdefault("schema_version", MANIFEST_SCHEMA_VERSION)
-    normalized.setdefault("current", None)
-    normalized.setdefault("frontier", None)
-    normalized.setdefault("retired", [])
+    validated = deepcopy(dict(manifest))
+    _validate_manifest_keys(validated)
 
-    if normalized["schema_version"] not in SUPPORTED_MANIFEST_SCHEMA_VERSIONS:
+    if validated.get("schema_version") != MANIFEST_SCHEMA_VERSION:
         raise ValueError(
             "Unsupported household API Modal manifest schema version: "
-            f"{normalized['schema_version']}"
+            f"{validated.get('schema_version')}"
         )
-    normalized["schema_version"] = MANIFEST_SCHEMA_VERSION
 
-    normalized["current"] = _normalize_app_reference(normalized.get("current"))
-    normalized["frontier"] = _normalize_app_reference(
-        normalized.get("frontier")
-    )
-    if normalized["retired"] is None:
-        normalized["retired"] = []
-    if not isinstance(normalized["retired"], list):
+    validated["current"] = _validate_app_reference(validated["current"])
+    validated["frontier"] = _validate_app_reference(validated["frontier"])
+    if not isinstance(validated["retired"], list):
         raise ValueError("Modal manifest `retired` field must be a list")
-    normalized["retired"] = [
-        normalized_entry
-        for app in normalized["retired"]
-        if (normalized_entry := _normalize_app_reference(app)) is not None
-    ]
+    retired = []
+    for app in validated["retired"]:
+        validated_entry = _validate_app_reference(
+            app,
+            allow_retirement_metadata=True,
+        )
+        if validated_entry is not None:
+            retired.append(validated_entry)
+    validated["retired"] = retired
 
-    return normalized
+    return validated
 
 
 def apply_release_config(
@@ -142,7 +166,7 @@ def apply_release_config(
     new_app: Mapping[str, Any] | None = None,
     timestamp: str | None = None,
 ) -> dict[str, Any]:
-    next_manifest = normalize_manifest(manifest)
+    next_manifest = validate_manifest(manifest)
     retired = list(next_manifest["retired"])
     retired_at = timestamp or current_timestamp()
 
@@ -184,7 +208,7 @@ def apply_release_config(
         next_manifest["frontier"] = None
 
     next_manifest["retired"] = retired
-    return next_manifest
+    return validate_manifest(next_manifest)
 
 
 def cleanup_app_names_for_target(
@@ -193,12 +217,12 @@ def cleanup_app_names_for_target(
     *,
     previous_manifest: Mapping[str, Any] | None = None,
 ) -> list[str]:
-    normalized = normalize_manifest(manifest)
+    validated = validate_manifest(manifest)
     active_app_names = {
         app["app_name"]
         for app in (
-            normalized.get("current"),
-            normalized.get("frontier"),
+            validated.get("current"),
+            validated.get("frontier"),
         )
         if isinstance(app, dict) and app.get("app_name")
     }
@@ -208,7 +232,7 @@ def cleanup_app_names_for_target(
     if target == CleanupTarget.RETIRED:
         names = [
             app["app_name"]
-            for app in normalized.get("retired", [])
+            for app in validated.get("retired", [])
             if isinstance(app, dict) and app.get("app_name")
         ]
         return _unique_app_names(
@@ -216,7 +240,7 @@ def cleanup_app_names_for_target(
         )
 
     if previous_manifest is not None:
-        previous = normalize_manifest(previous_manifest)
+        previous = validate_manifest(previous_manifest)
         previous_channel = previous.get(target.value)
         if not previous_channel:
             return []
@@ -228,7 +252,7 @@ def cleanup_app_names_for_target(
             )
         return [app_name] if app_name else []
 
-    channel = normalized.get(target.value)
+    channel = validated.get(target.value)
     if not channel:
         return []
     app_name = channel.get("app_name")
@@ -242,11 +266,11 @@ def cleanup_app_names_for_target(
 def active_app_deployments(
     manifest: Mapping[str, Any],
 ) -> list[dict[str, Any]]:
-    normalized = normalize_manifest(manifest)
+    validated = validate_manifest(manifest)
     deployments_by_name: dict[str, dict[str, str]] = {}
 
     for channel in ("current", "frontier"):
-        app_reference = normalized.get(channel)
+        app_reference = validated.get(channel)
         if not app_reference:
             continue
         app_name = app_reference.get("app_name")
@@ -283,41 +307,30 @@ def prune_cleaned_retired_apps(
     manifest: Mapping[str, Any],
     app_names: set[str],
 ) -> dict[str, Any]:
-    normalized = normalize_manifest(manifest)
-    normalized["retired"] = [
+    validated = validate_manifest(manifest)
+    validated["retired"] = [
         app
-        for app in normalized["retired"]
+        for app in validated["retired"]
         if not isinstance(app, dict) or app.get("app_name") not in app_names
     ]
-    return normalized
+    return validated
 
 
 def rewrite_manifest_for_storage(
     manifest: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
-    normalized = normalize_manifest(manifest)
-    active_app_names = {
-        app["app_name"]
-        for app in (
-            normalized.get("current"),
-            normalized.get("frontier"),
-        )
-        if isinstance(app, dict) and app.get("app_name")
+    if manifest is None:
+        return empty_manifest()
+    if not isinstance(manifest, Mapping):
+        raise ValueError("Modal manifest must be a mapping")
+
+    rewritten = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "current": _rewrite_legacy_app_reference(manifest.get("current")),
+        "frontier": _rewrite_legacy_app_reference(manifest.get("frontier")),
+        "retired": [],
     }
-    seen_retired_app_names: set[str] = set()
-    retired = []
-
-    for app in normalized["retired"]:
-        app_name = app.get("app_name") if isinstance(app, dict) else None
-        if not app_name or app_name in active_app_names:
-            continue
-        if app_name in seen_retired_app_names:
-            continue
-        seen_retired_app_names.add(app_name)
-        retired.append(app)
-
-    normalized["retired"] = retired
-    return normalized
+    return validate_manifest(rewritten)
 
 
 def rewrite_existing_manifest_for_storage(
@@ -354,18 +367,52 @@ def _retire_entry(
     return retired + [retired_entry]
 
 
-def _normalize_app_reference(entry: Any) -> dict[str, Any] | None:
-    if not entry:
+def _validate_app_reference(
+    entry: Any,
+    *,
+    allow_retirement_metadata: bool = False,
+) -> dict[str, Any] | None:
+    if entry is None:
         return None
     if not isinstance(entry, Mapping):
         raise ValueError("Modal manifest app references must be mappings")
 
-    normalized = deepcopy(dict(entry))
-    normalized.pop("source_commit", None)
-    normalized["package_versions"] = _release_package_versions(
-        normalized.get("package_versions", {})
+    validated = deepcopy(dict(entry))
+    _validate_app_reference_keys(
+        validated,
+        allow_retirement_metadata=allow_retirement_metadata,
     )
-    return normalized
+    _validate_required_string(validated, "app_name")
+    _validate_required_string(validated, "deployed_at")
+    validated["package_versions"] = _canonical_release_package_versions(
+        validated["package_versions"]
+    )
+    return validated
+
+
+def _rewrite_legacy_app_reference(entry: Any) -> dict[str, Any] | None:
+    if entry is None:
+        return None
+    if not isinstance(entry, Mapping):
+        raise ValueError("Modal manifest app references must be mappings")
+
+    package_versions = _release_package_versions_from_mapping(
+        entry.get("package_versions", {})
+    )
+    rewritten = {
+        "app_name": entry.get("app_name"),
+        "package_versions": _canonical_release_package_versions(
+            package_versions
+        ),
+        "deployed_at": entry.get("deployed_at"),
+    }
+    for key in (
+        "analytics_migration_minimum_revision",
+        "analytics_database_revision",
+    ):
+        if entry.get(key):
+            rewritten[key] = entry[key]
+    return _validate_app_reference(rewritten)
 
 
 def _unique_app_names(app_names) -> list[str]:
@@ -384,7 +431,7 @@ def _slugify_version(version: str) -> str:
     return slug or "unknown"
 
 
-def _release_package_versions(
+def _release_package_versions_from_mapping(
     package_versions: Mapping[str, str],
 ) -> dict[str, str]:
     if not isinstance(package_versions, Mapping):
@@ -398,13 +445,21 @@ def _release_package_versions(
     }
 
 
-def _required_release_package_versions(
+def _canonical_release_package_versions(
     package_versions: Mapping[str, str],
-    *,
-    app_name: str,
-    channel: str,
 ) -> dict[str, str]:
-    versions = _release_package_versions(package_versions)
+    versions = _release_package_versions_from_mapping(package_versions)
+    unexpected_countries = [
+        country
+        for country in package_versions
+        if country not in RELEASE_PACKAGE_VERSION_COUNTRIES
+    ]
+    if unexpected_countries:
+        unexpected = ", ".join(sorted(unexpected_countries))
+        raise ValueError(
+            "Modal manifest `package_versions` contains unsupported "
+            f"country key(s): {unexpected}"
+        )
     missing_countries = [
         country
         for country in RELEASE_PACKAGE_VERSION_COUNTRIES
@@ -413,7 +468,66 @@ def _required_release_package_versions(
     if missing_countries:
         missing = ", ".join(missing_countries)
         raise ValueError(
-            f"Active Modal app `{app_name}` in `{channel}` must declare "
-            f"release package version(s): {missing}"
+            "Modal manifest `package_versions` must declare release "
+            f"package version(s): {missing}"
         )
     return versions
+
+
+def _required_release_package_versions(
+    package_versions: Mapping[str, str],
+    *,
+    app_name: str,
+    channel: str,
+) -> dict[str, str]:
+    try:
+        return _canonical_release_package_versions(package_versions)
+    except ValueError as e:
+        raise ValueError(
+            f"Active Modal app `{app_name}` in `{channel}` must declare "
+            "canonical release package versions"
+        ) from e
+
+
+def _validate_manifest_keys(manifest: Mapping[str, Any]) -> None:
+    missing_keys = sorted(MANIFEST_KEYS - set(manifest))
+    if missing_keys:
+        keys = ", ".join(missing_keys)
+        raise ValueError(f"Modal manifest is missing required key(s): {keys}")
+
+    unsupported_keys = sorted(set(manifest) - MANIFEST_KEYS)
+    if unsupported_keys:
+        keys = ", ".join(unsupported_keys)
+        raise ValueError(f"Modal manifest contains unsupported key(s): {keys}")
+
+
+def _validate_app_reference_keys(
+    entry: Mapping[str, Any],
+    *,
+    allow_retirement_metadata: bool,
+) -> None:
+    allowed_keys = (
+        RETIRED_APP_REFERENCE_KEYS
+        if allow_retirement_metadata
+        else APP_REFERENCE_KEYS
+    )
+    unsupported_keys = sorted(set(entry) - allowed_keys)
+    if unsupported_keys:
+        keys = ", ".join(unsupported_keys)
+        raise ValueError(
+            f"Modal manifest app reference contains unsupported key(s): {keys}"
+        )
+
+    missing_keys = sorted(APP_REFERENCE_REQUIRED_KEYS - set(entry))
+    if missing_keys:
+        keys = ", ".join(missing_keys)
+        raise ValueError(
+            f"Modal manifest app reference is missing required key(s): {keys}"
+        )
+
+
+def _validate_required_string(entry: Mapping[str, Any], key: str) -> None:
+    if not isinstance(entry.get(key), str) or not entry[key]:
+        raise ValueError(
+            f"Modal manifest app reference `{key}` must be a non-empty string"
+        )

--- a/policyengine_household_api/modal_release/manifest.py
+++ b/policyengine_household_api/modal_release/manifest.py
@@ -334,6 +334,7 @@ def rewrite_existing_manifest_for_storage(
             "Cannot rewrite a Modal release manifest without an active "
             "`current` or `frontier` app"
         )
+    active_app_deployments(rewritten_manifest)
     return rewritten_manifest
 
 

--- a/policyengine_household_api/modal_release/manifest.py
+++ b/policyengine_household_api/modal_release/manifest.py
@@ -252,8 +252,10 @@ def active_app_deployments(
         app_name = app_reference.get("app_name")
         if not app_name:
             continue
-        package_versions = _release_package_versions(
-            app_reference.get("package_versions", {})
+        package_versions = _required_release_package_versions(
+            app_reference.get("package_versions", {}),
+            app_name=app_name,
+            channel=channel,
         )
         if (
             app_name in deployments_by_name
@@ -318,6 +320,23 @@ def rewrite_manifest_for_storage(
     return normalized
 
 
+def rewrite_existing_manifest_for_storage(
+    manifest: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if not manifest:
+        raise ValueError("Cannot rewrite a missing Modal release manifest")
+
+    rewritten_manifest = rewrite_manifest_for_storage(manifest)
+    if not rewritten_manifest.get("current") and not rewritten_manifest.get(
+        "frontier"
+    ):
+        raise ValueError(
+            "Cannot rewrite a Modal release manifest without an active "
+            "`current` or `frontier` app"
+        )
+    return rewritten_manifest
+
+
 def _retire_entry(
     retired: list[dict[str, Any]],
     entry: Mapping[str, Any] | None,
@@ -367,8 +386,33 @@ def _slugify_version(version: str) -> str:
 def _release_package_versions(
     package_versions: Mapping[str, str],
 ) -> dict[str, str]:
+    if not isinstance(package_versions, Mapping):
+        raise ValueError("Modal manifest `package_versions` must be a mapping")
     return {
-        country: package_versions[country]
+        country: version
         for country in RELEASE_PACKAGE_VERSION_COUNTRIES
         if country in package_versions
+        and isinstance(version := package_versions[country], str)
+        and version
     }
+
+
+def _required_release_package_versions(
+    package_versions: Mapping[str, str],
+    *,
+    app_name: str,
+    channel: str,
+) -> dict[str, str]:
+    versions = _release_package_versions(package_versions)
+    missing_countries = [
+        country
+        for country in RELEASE_PACKAGE_VERSION_COUNTRIES
+        if country not in versions
+    ]
+    if missing_countries:
+        missing = ", ".join(missing_countries)
+        raise ValueError(
+            f"Active Modal app `{app_name}` in `{channel}` must declare "
+            f"release package version(s): {missing}"
+        )
+    return versions

--- a/policyengine_household_api/modal_release/manifest.py
+++ b/policyengine_household_api/modal_release/manifest.py
@@ -17,7 +17,8 @@ from policyengine_household_api.modal_release.release_config import (
 )
 
 
-MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 2
+SUPPORTED_MANIFEST_SCHEMA_VERSIONS = {1, MANIFEST_SCHEMA_VERSION}
 MANIFEST_DICT_NAME = "household-api-release-manifest"
 MANIFEST_DICT_KEY = "manifest"
 APP_NAME_PREFIX = "policyengine-household-api"
@@ -29,7 +30,6 @@ class AppReference:
     app_name: str
     package_versions: dict[str, str]
     deployed_at: str
-    source_commit: str | None = None
     analytics_migration_minimum_revision: str | None = None
     analytics_database_revision: str | None = None
 
@@ -39,8 +39,6 @@ class AppReference:
             "package_versions": dict(self.package_versions),
             "deployed_at": self.deployed_at,
         }
-        if self.source_commit:
-            data["source_commit"] = self.source_commit
         if self.analytics_migration_minimum_revision:
             data["analytics_migration_minimum_revision"] = (
                 self.analytics_migration_minimum_revision
@@ -76,7 +74,6 @@ def build_app_reference(
     *,
     app_name: str | None = None,
     package_versions: Mapping[str, str] | None = None,
-    source_commit: str | None = None,
     deployed_at: str | None = None,
     analytics_database_revision: str | None = None,
 ) -> dict[str, Any]:
@@ -87,7 +84,6 @@ def build_app_reference(
         app_name=app_name or build_app_name(versions),
         package_versions=versions,
         deployed_at=deployed_at or current_timestamp(),
-        source_commit=source_commit,
         analytics_migration_minimum_revision=(
             ANALYTICS_ALEMBIC_MINIMUM_REVISION
         ),
@@ -115,15 +111,26 @@ def normalize_manifest(manifest: Mapping[str, Any] | None) -> dict[str, Any]:
     normalized.setdefault("frontier", None)
     normalized.setdefault("retired", [])
 
-    if normalized["schema_version"] != MANIFEST_SCHEMA_VERSION:
+    if normalized["schema_version"] not in SUPPORTED_MANIFEST_SCHEMA_VERSIONS:
         raise ValueError(
             "Unsupported household API Modal manifest schema version: "
             f"{normalized['schema_version']}"
         )
+    normalized["schema_version"] = MANIFEST_SCHEMA_VERSION
+
+    normalized["current"] = _normalize_app_reference(normalized.get("current"))
+    normalized["frontier"] = _normalize_app_reference(
+        normalized.get("frontier")
+    )
     if normalized["retired"] is None:
         normalized["retired"] = []
     if not isinstance(normalized["retired"], list):
         raise ValueError("Modal manifest `retired` field must be a list")
+    normalized["retired"] = [
+        normalized_entry
+        for app in normalized["retired"]
+        if (normalized_entry := _normalize_app_reference(app)) is not None
+    ]
 
     return normalized
 
@@ -204,7 +211,9 @@ def cleanup_app_names_for_target(
             for app in normalized.get("retired", [])
             if isinstance(app, dict) and app.get("app_name")
         ]
-        return [name for name in names if name not in active_app_names]
+        return _unique_app_names(
+            name for name in names if name not in active_app_names
+        )
 
     if previous_manifest is not None:
         previous = normalize_manifest(previous_manifest)
@@ -230,6 +239,44 @@ def cleanup_app_names_for_target(
     return [app_name] if app_name else []
 
 
+def active_app_deployments(
+    manifest: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    normalized = normalize_manifest(manifest)
+    deployments_by_name: dict[str, dict[str, str]] = {}
+
+    for channel in ("current", "frontier"):
+        app_reference = normalized.get(channel)
+        if not app_reference:
+            continue
+        app_name = app_reference.get("app_name")
+        if not app_name:
+            continue
+        package_versions = _release_package_versions(
+            app_reference.get("package_versions", {})
+        )
+        if (
+            app_name in deployments_by_name
+            and deployments_by_name[app_name] != package_versions
+        ):
+            raise ValueError(
+                f"Active Modal app `{app_name}` has conflicting package "
+                "versions in current/frontier manifest entries"
+            )
+        deployments_by_name[app_name] = package_versions
+
+    if not deployments_by_name:
+        raise ValueError("No active Modal household API apps are configured")
+
+    return [
+        {
+            "app_name": app_name,
+            "package_versions": package_versions,
+        }
+        for app_name, package_versions in deployments_by_name.items()
+    ]
+
+
 def prune_cleaned_retired_apps(
     manifest: Mapping[str, Any],
     app_names: set[str],
@@ -240,6 +287,34 @@ def prune_cleaned_retired_apps(
         for app in normalized["retired"]
         if not isinstance(app, dict) or app.get("app_name") not in app_names
     ]
+    return normalized
+
+
+def rewrite_manifest_for_storage(
+    manifest: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    normalized = normalize_manifest(manifest)
+    active_app_names = {
+        app["app_name"]
+        for app in (
+            normalized.get("current"),
+            normalized.get("frontier"),
+        )
+        if isinstance(app, dict) and app.get("app_name")
+    }
+    seen_retired_app_names: set[str] = set()
+    retired = []
+
+    for app in normalized["retired"]:
+        app_name = app.get("app_name") if isinstance(app, dict) else None
+        if not app_name or app_name in active_app_names:
+            continue
+        if app_name in seen_retired_app_names:
+            continue
+        seen_retired_app_names.add(app_name)
+        retired.append(app)
+
+    normalized["retired"] = retired
     return normalized
 
 
@@ -257,6 +332,31 @@ def _retire_entry(
     retired_entry["retired_at"] = retired_at
     retired_entry["retirement_reason"] = reason
     return retired + [retired_entry]
+
+
+def _normalize_app_reference(entry: Any) -> dict[str, Any] | None:
+    if not entry:
+        return None
+    if not isinstance(entry, Mapping):
+        raise ValueError("Modal manifest app references must be mappings")
+
+    normalized = deepcopy(dict(entry))
+    normalized.pop("source_commit", None)
+    normalized["package_versions"] = _release_package_versions(
+        normalized.get("package_versions", {})
+    )
+    return normalized
+
+
+def _unique_app_names(app_names) -> list[str]:
+    seen = set()
+    unique_names = []
+    for app_name in app_names:
+        if app_name in seen:
+            continue
+        seen.add(app_name)
+        unique_names.append(app_name)
+    return unique_names
 
 
 def _slugify_version(version: str) -> str:

--- a/policyengine_household_api/modal_release/rewrite_manifest.py
+++ b/policyengine_household_api/modal_release/rewrite_manifest.py
@@ -10,7 +10,7 @@ import modal
 from policyengine_household_api.modal_release.manifest import (
     MANIFEST_DICT_KEY,
     MANIFEST_DICT_NAME,
-    rewrite_manifest_for_storage,
+    rewrite_existing_manifest_for_storage,
 )
 
 
@@ -18,18 +18,23 @@ def main() -> None:
     args = _parse_args()
     manifest_dict = modal.Dict.from_name(
         MANIFEST_DICT_NAME,
-        create_if_missing=True,
+        create_if_missing=False,
         environment_name=args.modal_environment,
     )
-    rewritten_manifest = rewrite_manifest_for_storage(
-        manifest_dict.get(MANIFEST_DICT_KEY)
-    )
-    manifest_dict[MANIFEST_DICT_KEY] = rewritten_manifest
+    rewritten_manifest = rewrite_modal_manifest(manifest_dict)
 
     if args.manifest_output:
         _write_json(Path(args.manifest_output), rewritten_manifest)
 
     print(json.dumps(rewritten_manifest, indent=2, sort_keys=True))
+
+
+def rewrite_modal_manifest(manifest_dict) -> dict[str, Any]:
+    rewritten_manifest = rewrite_existing_manifest_for_storage(
+        manifest_dict.get(MANIFEST_DICT_KEY)
+    )
+    manifest_dict[MANIFEST_DICT_KEY] = rewritten_manifest
+    return rewritten_manifest
 
 
 def _parse_args() -> argparse.Namespace:

--- a/policyengine_household_api/modal_release/rewrite_manifest.py
+++ b/policyengine_household_api/modal_release/rewrite_manifest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import modal
+
+from policyengine_household_api.modal_release.manifest import (
+    MANIFEST_DICT_KEY,
+    MANIFEST_DICT_NAME,
+    rewrite_manifest_for_storage,
+)
+
+
+def main() -> None:
+    args = _parse_args()
+    manifest_dict = modal.Dict.from_name(
+        MANIFEST_DICT_NAME,
+        create_if_missing=True,
+        environment_name=args.modal_environment,
+    )
+    rewritten_manifest = rewrite_manifest_for_storage(
+        manifest_dict.get(MANIFEST_DICT_KEY)
+    )
+    manifest_dict[MANIFEST_DICT_KEY] = rewritten_manifest
+
+    if args.manifest_output:
+        _write_json(Path(args.manifest_output), rewritten_manifest)
+
+    print(json.dumps(rewritten_manifest, indent=2, sort_keys=True))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Rewrite the household API Modal release manifest."
+    )
+    parser.add_argument("--modal-environment", required=True)
+    parser.add_argument("--manifest-output")
+    return parser.parse_args()
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/policyengine_household_api/modal_release/update_manifest.py
+++ b/policyengine_household_api/modal_release/update_manifest.py
@@ -13,7 +13,7 @@ from policyengine_household_api.modal_release.manifest import (
     apply_release_config,
     build_app_reference,
     cleanup_app_names_for_target,
-    normalize_manifest,
+    validate_manifest,
 )
 from policyengine_household_api.modal_release.release_config import (
     ModalReleaseConfig,
@@ -32,7 +32,7 @@ def main() -> None:
         create_if_missing=True,
         environment_name=args.modal_environment,
     )
-    current_manifest = normalize_manifest(manifest_dict.get(MANIFEST_DICT_KEY))
+    current_manifest = validate_manifest(manifest_dict.get(MANIFEST_DICT_KEY))
 
     new_app = None
     if config.deploys_new_app:

--- a/policyengine_household_api/modal_release/update_manifest.py
+++ b/policyengine_household_api/modal_release/update_manifest.py
@@ -38,7 +38,6 @@ def main() -> None:
     if config.deploys_new_app:
         new_app = build_app_reference(
             app_name=args.new_app_name,
-            source_commit=args.source_commit,
             analytics_database_revision=args.analytics_database_revision,
         )
 
@@ -72,7 +71,6 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--config-json", required=True)
     parser.add_argument("--new-app-name")
-    parser.add_argument("--source-commit")
     parser.add_argument("--analytics-database-revision")
     parser.add_argument("--modal-environment")
     parser.add_argument("--cleanup-output")

--- a/tests/unit/modal_release/test_gateway.py
+++ b/tests/unit/modal_release/test_gateway.py
@@ -1,9 +1,15 @@
 import json
 
 from flask import Response
+import modal
+import pytest
 
 from policyengine_household_api.modal_release.gateway import (
     create_gateway_app,
+    load_modal_manifest,
+)
+from policyengine_household_api.modal_release.manifest import (
+    MANIFEST_SCHEMA_VERSION,
 )
 
 
@@ -231,3 +237,33 @@ def test_country_versions_rejects_unsupported_country():
     assert response.status_code == 404
     assert not worker_requests
     assert response.get_json()["message"] == "Unsupported country `zz`"
+
+
+def test_load_modal_manifest_does_not_create_missing_dict(monkeypatch):
+    calls = []
+
+    def from_name(name, *, create_if_missing):
+        calls.append((name, create_if_missing))
+        raise modal.exception.NotFoundError("not found")
+
+    monkeypatch.setattr(modal.Dict, "from_name", from_name)
+
+    manifest = load_modal_manifest()
+
+    assert calls == [("household-api-release-manifest", False)]
+    assert manifest == {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "current": None,
+        "frontier": None,
+        "retired": [],
+    }
+
+
+def test_load_modal_manifest_preserves_unexpected_modal_errors(monkeypatch):
+    def from_name(name, *, create_if_missing):
+        raise modal.exception.AuthError("auth failed")
+
+    monkeypatch.setattr(modal.Dict, "from_name", from_name)
+
+    with pytest.raises(modal.exception.AuthError):
+        load_modal_manifest()

--- a/tests/unit/modal_release/test_gateway.py
+++ b/tests/unit/modal_release/test_gateway.py
@@ -18,12 +18,12 @@ def _manifest():
         "schema_version": 1,
         "current": {
             "app_name": "current-app",
-            "package_versions": {"us": "1.0.0"},
+            "package_versions": {"uk": "2.31.0", "us": "1.0.0"},
             "deployed_at": "2026-01-01T00:00:00+00:00",
         },
         "frontier": {
             "app_name": "frontier-app",
-            "package_versions": {"us": "2.0.0"},
+            "package_versions": {"uk": "2.31.0", "us": "2.0.0"},
             "deployed_at": "2026-01-02T00:00:00+00:00",
         },
         "retired": [],

--- a/tests/unit/modal_release/test_manifest.py
+++ b/tests/unit/modal_release/test_manifest.py
@@ -9,6 +9,7 @@ from policyengine_household_api.modal_release.manifest import (
     cleanup_app_names_for_target,
     current_package_versions,
     normalize_manifest,
+    rewrite_existing_manifest_for_storage,
     rewrite_manifest_for_storage,
 )
 from policyengine_household_api.modal_release import (
@@ -292,6 +293,21 @@ def test_active_app_deployments_rejects_conflicting_active_app_versions():
         active_app_deployments(manifest)
 
 
+def test_active_app_deployments_requires_release_package_versions():
+    manifest = {
+        "schema_version": 2,
+        "current": {
+            **_app("current-app"),
+            "package_versions": {"us": "1.691.1"},
+        },
+        "frontier": None,
+        "retired": [],
+    }
+
+    with pytest.raises(ValueError, match="must declare"):
+        active_app_deployments(manifest)
+
+
 def test_rewrite_manifest_removes_active_and_duplicate_retired_apps():
     manifest = {
         "schema_version": 1,
@@ -312,3 +328,20 @@ def test_rewrite_manifest_removes_active_and_duplicate_retired_apps():
         "old-app",
         "older-app",
     ]
+
+
+def test_rewrite_existing_manifest_rejects_missing_manifest():
+    with pytest.raises(ValueError, match="missing Modal release manifest"):
+        rewrite_existing_manifest_for_storage(None)
+
+
+def test_rewrite_existing_manifest_rejects_manifest_without_active_apps():
+    manifest = {
+        "schema_version": 1,
+        "current": None,
+        "frontier": None,
+        "retired": [_app("old-app")],
+    }
+
+    with pytest.raises(ValueError, match="without an active"):
+        rewrite_existing_manifest_for_storage(manifest)

--- a/tests/unit/modal_release/test_manifest.py
+++ b/tests/unit/modal_release/test_manifest.py
@@ -1,11 +1,15 @@
 import pytest
 
 from policyengine_household_api.modal_release.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    active_app_deployments,
     apply_release_config,
     build_app_reference,
     build_app_name,
     cleanup_app_names_for_target,
     current_package_versions,
+    normalize_manifest,
+    rewrite_manifest_for_storage,
 )
 from policyengine_household_api.modal_release import (
     manifest as manifest_module,
@@ -158,6 +162,7 @@ def test_app_reference_includes_analytics_migration_metadata():
 
     assert app["analytics_migration_minimum_revision"] == "20260512_0003"
     assert app["analytics_database_revision"] == "20260512_0003"
+    assert "source_commit" not in app
 
 
 def test_app_reference_only_records_release_package_versions():
@@ -204,3 +209,106 @@ def test_current_package_versions_only_includes_us_and_uk(monkeypatch):
     )
 
     assert current_package_versions() == {"uk": "2.31.0", "us": "1.691.1"}
+
+
+def test_normalize_manifest_upgrades_legacy_manifest_and_removes_source_commit():
+    manifest = {
+        "schema_version": 1,
+        "current": {
+            **_app("current-app"),
+            "source_commit": "abc123",
+            "package_versions": {
+                "uk": "2.31.0",
+                "us": "1.691.1",
+                "ca": "0.96.3",
+            },
+        },
+        "frontier": None,
+        "retired": [
+            {
+                **_app("old-app"),
+                "source_commit": "def456",
+                "package_versions": {
+                    "uk": "2.31.0",
+                    "us": "1.690.0",
+                    "ng": "0.5.1",
+                },
+            }
+        ],
+    }
+
+    normalized = normalize_manifest(manifest)
+
+    assert normalized["schema_version"] == MANIFEST_SCHEMA_VERSION
+    assert "source_commit" not in normalized["current"]
+    assert normalized["current"]["package_versions"] == {
+        "uk": "2.31.0",
+        "us": "1.691.1",
+    }
+    assert "source_commit" not in normalized["retired"][0]
+    assert normalized["retired"][0]["package_versions"] == {
+        "uk": "2.31.0",
+        "us": "1.690.0",
+    }
+
+
+def test_active_app_deployments_deduplicates_matching_active_app_names():
+    manifest = {
+        "schema_version": 2,
+        "current": {
+            **_app("shared-app"),
+            "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+        },
+        "frontier": {
+            **_app("shared-app"),
+            "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+        },
+        "retired": [],
+    }
+
+    assert active_app_deployments(manifest) == [
+        {
+            "app_name": "shared-app",
+            "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+        }
+    ]
+
+
+def test_active_app_deployments_rejects_conflicting_active_app_versions():
+    manifest = {
+        "schema_version": 2,
+        "current": {
+            **_app("shared-app"),
+            "package_versions": {"uk": "2.31.0", "us": "1.690.0"},
+        },
+        "frontier": {
+            **_app("shared-app"),
+            "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+        },
+        "retired": [],
+    }
+
+    with pytest.raises(ValueError, match="conflicting package versions"):
+        active_app_deployments(manifest)
+
+
+def test_rewrite_manifest_removes_active_and_duplicate_retired_apps():
+    manifest = {
+        "schema_version": 1,
+        "current": _app("current-app"),
+        "frontier": _app("frontier-app"),
+        "retired": [
+            _app("current-app"),
+            _app("old-app"),
+            _app("old-app"),
+            _app("older-app"),
+        ],
+    }
+
+    rewritten = rewrite_manifest_for_storage(manifest)
+
+    assert rewritten["schema_version"] == MANIFEST_SCHEMA_VERSION
+    assert [app["app_name"] for app in rewritten["retired"]] == [
+        "old-app",
+        "older-app",
+    ]

--- a/tests/unit/modal_release/test_manifest.py
+++ b/tests/unit/modal_release/test_manifest.py
@@ -8,9 +8,9 @@ from policyengine_household_api.modal_release.manifest import (
     build_app_name,
     cleanup_app_names_for_target,
     current_package_versions,
-    normalize_manifest,
     rewrite_existing_manifest_for_storage,
     rewrite_manifest_for_storage,
+    validate_manifest,
 )
 from policyengine_household_api.modal_release import (
     manifest as manifest_module,
@@ -22,10 +22,10 @@ from policyengine_household_api.modal_release.release_config import (
 )
 
 
-def _app(name):
+def _app(name, *, uk="2.31.0", us="1.691.1"):
     return {
         "app_name": name,
-        "package_versions": {"us": "1.0.0"},
+        "package_versions": {"uk": uk, "us": us},
         "deployed_at": "2026-01-01T00:00:00+00:00",
     }
 
@@ -156,7 +156,7 @@ def test_previous_active_cleanup_refuses_still_active_app():
 def test_app_reference_includes_analytics_migration_metadata():
     app = build_app_reference(
         app_name="worker-app",
-        package_versions={"us": "1.0.0"},
+        package_versions={"uk": "2.31.0", "us": "1.691.1"},
         deployed_at="2026-01-01T00:00:00+00:00",
         analytics_database_revision="20260512_0003",
     )
@@ -166,20 +166,17 @@ def test_app_reference_includes_analytics_migration_metadata():
     assert "source_commit" not in app
 
 
-def test_app_reference_only_records_release_package_versions():
-    app = build_app_reference(
-        app_name="worker-app",
-        package_versions={
-            "uk": "2.31.0",
-            "us": "1.691.1",
-            "ca": "0.96.3",
-            "ng": "0.5.1",
-            "il": "0.1.0",
-        },
-        deployed_at="2026-01-01T00:00:00+00:00",
-    )
-
-    assert app["package_versions"] == {"uk": "2.31.0", "us": "1.691.1"}
+def test_app_reference_rejects_unsupported_package_version_keys():
+    with pytest.raises(ValueError, match="unsupported country key"):
+        build_app_reference(
+            app_name="worker-app",
+            package_versions={
+                "uk": "2.31.0",
+                "us": "1.691.1",
+                "ca": "0.96.3",
+            },
+            deployed_at="2026-01-01T00:00:00+00:00",
+        )
 
 
 def test_app_name_only_includes_us_and_uk_package_versions():
@@ -187,13 +184,21 @@ def test_app_name_only_includes_us_and_uk_package_versions():
         {
             "uk": "2.31.0",
             "us": "1.691.1",
-            "ca": "0.96.3",
-            "ng": "0.5.1",
-            "il": "0.1.0",
         }
     )
 
     assert app_name == "policyengine-household-api-uk2-31-0-us1-691-1"
+
+
+def test_app_name_rejects_unsupported_package_version_keys():
+    with pytest.raises(ValueError, match="unsupported country key"):
+        build_app_name(
+            {
+                "uk": "2.31.0",
+                "us": "1.691.1",
+                "ca": "0.96.3",
+            }
+        )
 
 
 def test_current_package_versions_only_includes_us_and_uk(monkeypatch):
@@ -212,12 +217,26 @@ def test_current_package_versions_only_includes_us_and_uk(monkeypatch):
     assert current_package_versions() == {"uk": "2.31.0", "us": "1.691.1"}
 
 
-def test_normalize_manifest_upgrades_legacy_manifest_and_removes_source_commit():
+def test_validate_manifest_rejects_legacy_app_reference_fields():
     manifest = {
         "schema_version": 1,
         "current": {
             **_app("current-app"),
             "source_commit": "abc123",
+        },
+        "frontier": None,
+        "retired": [],
+    }
+
+    with pytest.raises(ValueError, match="unsupported key"):
+        validate_manifest(manifest)
+
+
+def test_validate_manifest_rejects_unsupported_package_version_keys():
+    manifest = {
+        "schema_version": 1,
+        "current": {
+            **_app("current-app"),
             "package_versions": {
                 "uk": "2.31.0",
                 "us": "1.691.1",
@@ -225,37 +244,46 @@ def test_normalize_manifest_upgrades_legacy_manifest_and_removes_source_commit()
             },
         },
         "frontier": None,
-        "retired": [
-            {
-                **_app("old-app"),
-                "source_commit": "def456",
-                "package_versions": {
-                    "uk": "2.31.0",
-                    "us": "1.690.0",
-                    "ng": "0.5.1",
-                },
-            }
-        ],
+        "retired": [],
     }
 
-    normalized = normalize_manifest(manifest)
+    with pytest.raises(ValueError, match="unsupported country key"):
+        validate_manifest(manifest)
 
-    assert normalized["schema_version"] == MANIFEST_SCHEMA_VERSION
-    assert "source_commit" not in normalized["current"]
-    assert normalized["current"]["package_versions"] == {
-        "uk": "2.31.0",
-        "us": "1.691.1",
+
+def test_validate_manifest_rejects_unsupported_schema_version():
+    manifest = {
+        "schema_version": 2,
+        "current": _app("current-app"),
+        "frontier": None,
+        "retired": [],
     }
-    assert "source_commit" not in normalized["retired"][0]
-    assert normalized["retired"][0]["package_versions"] == {
-        "uk": "2.31.0",
-        "us": "1.690.0",
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        validate_manifest(manifest)
+
+
+def test_validate_manifest_rejects_missing_top_level_keys():
+    with pytest.raises(ValueError, match="missing required key"):
+        validate_manifest({"schema_version": 1})
+
+
+def test_validate_manifest_rejects_unsupported_top_level_keys():
+    manifest = {
+        "schema_version": 1,
+        "current": _app("current-app"),
+        "frontier": None,
+        "retired": [],
+        "source_commit": "abc123",
     }
+
+    with pytest.raises(ValueError, match="unsupported key"):
+        validate_manifest(manifest)
 
 
 def test_active_app_deployments_deduplicates_matching_active_app_names():
     manifest = {
-        "schema_version": 2,
+        "schema_version": 1,
         "current": {
             **_app("shared-app"),
             "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
@@ -277,7 +305,7 @@ def test_active_app_deployments_deduplicates_matching_active_app_names():
 
 def test_active_app_deployments_rejects_conflicting_active_app_versions():
     manifest = {
-        "schema_version": 2,
+        "schema_version": 1,
         "current": {
             **_app("shared-app"),
             "package_versions": {"uk": "2.31.0", "us": "1.690.0"},
@@ -295,7 +323,7 @@ def test_active_app_deployments_rejects_conflicting_active_app_versions():
 
 def test_active_app_deployments_requires_release_package_versions():
     manifest = {
-        "schema_version": 2,
+        "schema_version": 1,
         "current": {
             **_app("current-app"),
             "package_versions": {"us": "1.691.1"},
@@ -308,26 +336,40 @@ def test_active_app_deployments_requires_release_package_versions():
         active_app_deployments(manifest)
 
 
-def test_rewrite_manifest_removes_active_and_duplicate_retired_apps():
+def test_rewrite_manifest_uses_legacy_current_and_frontier_values():
     manifest = {
         "schema_version": 1,
-        "current": _app("current-app"),
-        "frontier": _app("frontier-app"),
+        "current": {
+            **_app("current-app"),
+            "source_commit": "abc123",
+            "package_versions": {
+                "uk": "2.31.0",
+                "us": "1.691.1",
+                "ca": "0.96.3",
+            },
+        },
+        "frontier": {
+            **_app("frontier-app", us="1.692.0"),
+            "package_versions": {
+                "uk": "2.31.0",
+                "us": "1.692.0",
+                "ng": "0.5.1",
+            },
+        },
         "retired": [
             _app("current-app"),
             _app("old-app"),
-            _app("old-app"),
-            _app("older-app"),
         ],
     }
 
     rewritten = rewrite_manifest_for_storage(manifest)
 
-    assert rewritten["schema_version"] == MANIFEST_SCHEMA_VERSION
-    assert [app["app_name"] for app in rewritten["retired"]] == [
-        "old-app",
-        "older-app",
-    ]
+    assert rewritten == {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "current": _app("current-app"),
+        "frontier": _app("frontier-app", us="1.692.0"),
+        "retired": [],
+    }
 
 
 def test_rewrite_existing_manifest_rejects_missing_manifest():

--- a/tests/unit/modal_release/test_rewrite_manifest.py
+++ b/tests/unit/modal_release/test_rewrite_manifest.py
@@ -1,0 +1,44 @@
+import pytest
+
+from policyengine_household_api.modal_release.manifest import (
+    MANIFEST_DICT_KEY,
+)
+from policyengine_household_api.modal_release.rewrite_manifest import (
+    rewrite_modal_manifest,
+)
+
+
+def test_rewrite_modal_manifest_rejects_missing_manifest_without_writing():
+    manifest_dict = {}
+
+    with pytest.raises(ValueError, match="missing Modal release manifest"):
+        rewrite_modal_manifest(manifest_dict)
+
+    assert MANIFEST_DICT_KEY not in manifest_dict
+
+
+def test_rewrite_modal_manifest_writes_rewritten_manifest():
+    manifest_dict = {
+        MANIFEST_DICT_KEY: {
+            "schema_version": 1,
+            "current": {
+                "app_name": "current-app",
+                "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+                "deployed_at": "2026-01-01T00:00:00+00:00",
+            },
+            "frontier": None,
+            "retired": [
+                {
+                    "app_name": "current-app",
+                    "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+                    "deployed_at": "2026-01-01T00:00:00+00:00",
+                }
+            ],
+        }
+    }
+
+    rewritten = rewrite_modal_manifest(manifest_dict)
+
+    assert rewritten["schema_version"] == 2
+    assert rewritten["retired"] == []
+    assert manifest_dict[MANIFEST_DICT_KEY] == rewritten

--- a/tests/unit/modal_release/test_rewrite_manifest.py
+++ b/tests/unit/modal_release/test_rewrite_manifest.py
@@ -42,3 +42,22 @@ def test_rewrite_modal_manifest_writes_rewritten_manifest():
     assert rewritten["schema_version"] == 2
     assert rewritten["retired"] == []
     assert manifest_dict[MANIFEST_DICT_KEY] == rewritten
+
+
+def test_rewrite_modal_manifest_rejects_missing_active_package_versions_without_writing():
+    original_manifest = {
+        "schema_version": 1,
+        "current": {
+            "app_name": "current-app",
+            "package_versions": {"us": "1.691.1"},
+            "deployed_at": "2026-01-01T00:00:00+00:00",
+        },
+        "frontier": None,
+        "retired": [],
+    }
+    manifest_dict = {MANIFEST_DICT_KEY: original_manifest}
+
+    with pytest.raises(ValueError, match="must declare"):
+        rewrite_modal_manifest(manifest_dict)
+
+    assert manifest_dict[MANIFEST_DICT_KEY] == original_manifest

--- a/tests/unit/modal_release/test_rewrite_manifest.py
+++ b/tests/unit/modal_release/test_rewrite_manifest.py
@@ -23,13 +23,26 @@ def test_rewrite_modal_manifest_writes_rewritten_manifest():
             "schema_version": 1,
             "current": {
                 "app_name": "current-app",
-                "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+                "source_commit": "abc123",
+                "package_versions": {
+                    "uk": "2.31.0",
+                    "us": "1.691.1",
+                    "ca": "0.96.3",
+                },
                 "deployed_at": "2026-01-01T00:00:00+00:00",
             },
-            "frontier": None,
+            "frontier": {
+                "app_name": "frontier-app",
+                "package_versions": {
+                    "uk": "2.31.0",
+                    "us": "1.692.0",
+                    "ng": "0.5.1",
+                },
+                "deployed_at": "2026-01-02T00:00:00+00:00",
+            },
             "retired": [
                 {
-                    "app_name": "current-app",
+                    "app_name": "old-app",
                     "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
                     "deployed_at": "2026-01-01T00:00:00+00:00",
                 }
@@ -39,7 +52,20 @@ def test_rewrite_modal_manifest_writes_rewritten_manifest():
 
     rewritten = rewrite_modal_manifest(manifest_dict)
 
-    assert rewritten["schema_version"] == 2
+    assert rewritten == {
+        "schema_version": 1,
+        "current": {
+            "app_name": "current-app",
+            "package_versions": {"uk": "2.31.0", "us": "1.691.1"},
+            "deployed_at": "2026-01-01T00:00:00+00:00",
+        },
+        "frontier": {
+            "app_name": "frontier-app",
+            "package_versions": {"uk": "2.31.0", "us": "1.692.0"},
+            "deployed_at": "2026-01-02T00:00:00+00:00",
+        },
+        "retired": [],
+    }
     assert rewritten["retired"] == []
     assert manifest_dict[MANIFEST_DICT_KEY] == rewritten
 

--- a/tests/unit/modal_release/test_worker_app.py
+++ b/tests/unit/modal_release/test_worker_app.py
@@ -2,6 +2,12 @@ import importlib
 
 import pytest
 
+from policyengine_household_api.modal_release.images import (
+    PACKAGE_VERSIONS_ENV,
+    country_package_install_specs,
+    deployment_package_versions_from_env,
+)
+
 
 pytestmark = pytest.mark.usefixtures("worker_app")
 
@@ -44,3 +50,37 @@ def test_worker_function_options_do_not_keep_workers_warm_without_env(
 
     with pytest.raises(RuntimeError, match="MODAL_ENVIRONMENT"):
         worker_function_options(modal_environment=None)
+
+
+def test_country_package_install_specs_use_release_package_versions_only():
+    assert country_package_install_specs(
+        {
+            "uk": "2.31.0",
+            "us": "1.691.1",
+            "ca": "0.96.3",
+        }
+    ) == [
+        "policyengine_uk==2.31.0",
+        "policyengine_us==1.691.1",
+    ]
+
+
+def test_deployment_package_versions_from_env(monkeypatch):
+    monkeypatch.setenv(
+        PACKAGE_VERSIONS_ENV,
+        '{"uk":"2.31.0","us":"1.691.1","ca":"0.96.3"}',
+    )
+
+    assert deployment_package_versions_from_env() == {
+        "uk": "2.31.0",
+        "us": "1.691.1",
+    }
+
+
+def test_deployment_package_versions_from_env_rejects_non_object(
+    monkeypatch,
+):
+    monkeypatch.setenv(PACKAGE_VERSIONS_ENV, '["us"]')
+
+    with pytest.raises(RuntimeError, match="JSON object"):
+        deployment_package_versions_from_env()

--- a/uv.lock
+++ b/uv.lock
@@ -2292,7 +2292,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-household-api"
-version = "0.19.6"
+version = "0.19.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Fixes #1529

## Summary

- Treat PR-body `modal_release` YAML as the canonical signal for current/frontier release operations.
- Use code-only deploy mode when the finalized versioning commit has no Modal release YAML: redeploy active manifest workers and gateway without mutating the manifest.
- Remove `source_commit` from manifest references and add a manifest rewrite command for cleaning existing Modal manifests.
- Preserve each active manifest app's US/UK package versions during code-only worker redeploys.
- Make retired app cleanup tolerate Modal's already-stopped response.

## Testing

- `uv run --extra dev pytest -vv --timeout=150 -rP .github/scripts/test_resolve_modal_release_config.py .github/scripts/test_modal_deploy_release.py .github/scripts/test_modal_cleanup_apps.py tests/unit/modal_release/test_manifest.py tests/unit/modal_release/test_worker_app.py .github/scripts/test_check_modal_release_body.py` (passed before final formatting)
- `ruff check .github/scripts/resolve_modal_release_config.py .github/scripts/modal_active_worker_apps.py .github/scripts/test_resolve_modal_release_config.py .github/scripts/test_modal_deploy_release.py .github/scripts/test_modal_cleanup_apps.py policyengine_household_api/modal_release/manifest.py policyengine_household_api/modal_release/update_manifest.py policyengine_household_api/modal_release/rewrite_manifest.py policyengine_household_api/modal_release/images.py tests/unit/modal_release/test_manifest.py tests/unit/modal_release/test_worker_app.py`
- `bash -n .github/scripts/modal-deploy-release.sh .github/scripts/modal-cleanup-apps.sh`
- `make format-check`

Note: `make format-check` printed the local Docker daemon warning while Make expanded Docker helper variables, but `ruff format --check .` completed successfully. Per request, I did not rerun pytest after formatting.