### PR TITLE
Use uv for Modal package overlays

### DIFF
--- a/changelog.d/1531.fixed.md
+++ b/changelog.d/1531.fixed.md
@@ -1,0 +1,1 @@
+Use uv-compatible package overlays for Modal code-only worker deploys.

--- a/policyengine_household_api/modal_release/images.py
+++ b/policyengine_household_api/modal_release/images.py
@@ -23,7 +23,7 @@ def household_api_worker_image() -> modal.Image:
     )
     package_specs = country_package_install_specs()
     if package_specs:
-        image = image.pip_install(*package_specs)
+        image = image.uv_pip_install(*package_specs)
     return (
         image.add_local_python_source("policyengine_household_api", copy=True)
         .add_local_dir("config", remote_path="/app/config", copy=True)

--- a/tests/unit/modal_release/test_image_setup.py
+++ b/tests/unit/modal_release/test_image_setup.py
@@ -1,6 +1,59 @@
 from policyengine_household_api.modal_release import _image_setup
 
 
+def test_worker_image_uses_uv_for_package_version_overlays(monkeypatch):
+    from policyengine_household_api.modal_release import images
+
+    calls = []
+
+    class FakeImage:
+        def uv_sync(self, *args, **kwargs):
+            calls.append(("uv_sync", args, kwargs))
+            return self
+
+        def uv_pip_install(self, *packages):
+            calls.append(("uv_pip_install", packages, {}))
+            return self
+
+        def pip_install(self, *packages):
+            raise AssertionError(
+                f"worker image should use uv_pip_install, got {packages}"
+            )
+
+        def add_local_python_source(self, *args, **kwargs):
+            calls.append(("add_local_python_source", args, kwargs))
+            return self
+
+        def add_local_dir(self, *args, **kwargs):
+            calls.append(("add_local_dir", args, kwargs))
+            return self
+
+        def run_function(self, *args, **kwargs):
+            calls.append(("run_function", args, kwargs))
+            return self
+
+    def debian_slim(*args, **kwargs):
+        calls.append(("debian_slim", args, kwargs))
+        return FakeImage()
+
+    monkeypatch.setenv(
+        images.PACKAGE_VERSIONS_ENV,
+        '{"uk":"2.31.0","us":"1.691.1"}',
+    )
+    monkeypatch.setattr(images.modal.Image, "debian_slim", debian_slim)
+
+    images.household_api_worker_image()
+
+    assert (
+        "uv_pip_install",
+        (
+            "policyengine_uk==2.31.0",
+            "policyengine_us==1.691.1",
+        ),
+        {},
+    ) in calls
+
+
 def test_snapshot_tax_benefit_systems_preloads_all_country_packages(
     monkeypatch,
 ):


### PR DESCRIPTION
Fixes #1531

## Summary

- Replace the Modal worker image package-version overlay from `pip_install` to `uv_pip_install` so it works after `uv_sync` creates the uv-managed environment.
- Add regression coverage that the worker image package overlay path uses Modal's uv-native install layer.

## Testing

- `uv run pytest tests/unit/modal_release/test_image_setup.py tests/unit/modal_release/test_worker_app.py`
- `uv run ruff check policyengine_household_api/modal_release/images.py tests/unit/modal_release/test_image_setup.py tests/unit/modal_release/test_worker_app.py`
- `uv run ruff format --check policyengine_household_api/modal_release/images.py tests/unit/modal_release/test_image_setup.py tests/unit/modal_release/test_worker_app.py`
