### PR TITLE
Set Modal worker concurrency to 5 and cap autoscale at 100

### DIFF
--- a/changelog.d/1533.changed.md
+++ b/changelog.d/1533.changed.md
@@ -1,0 +1,1 @@
+Enable Modal `allow_concurrent_inputs=5` (5x warm-pool capacity, no new container cost) and cap autoscale at `max_containers=100` to prevent runaway scaling.

--- a/changelog.d/1533.changed.md
+++ b/changelog.d/1533.changed.md
@@ -1,1 +1,1 @@
-Enable Modal `allow_concurrent_inputs=5` (5x warm-pool capacity, no new container cost) and cap autoscale at `max_containers=100` to prevent runaway scaling.
+Enable Modal `@modal.concurrent(max_inputs=5, target_inputs=4)` (5x warm-pool capacity, autoscaler aims for 80% steady-state utilisation, no new container cost) and cap autoscale at `max_containers=100` to prevent runaway scaling.

--- a/policyengine_household_api/modal_release/worker_app.py
+++ b/policyengine_household_api/modal_release/worker_app.py
@@ -46,6 +46,19 @@ def worker_function_options(
         "timeout": 180,
         "scaledown_window": 300,
         "enable_memory_snapshot": True,
+        # Each container processes up to 5 requests in parallel. With ~3s of
+        # CPU per request on a 1-core container, 5-way sharing gives ~15s
+        # wall-time per request when fully saturated. Multiplies effective
+        # warm-pool capacity 5x with no additional container cost: the same
+        # always-warm containers handle 5x the simultaneous load.
+        "allow_concurrent_inputs": 5,
+        # Hard cap on autoscale. Without this Modal is bounded only by the
+        # workspace quota, so a runaway traffic spike (or a buggy partner
+        # client) could scale to hundreds of containers and rack up cost.
+        # 100 covers any realistic partner burst we expect today (peak 100
+        # concurrent x 5 inputs = 500 in-flight) while keeping accidents
+        # bounded.
+        "max_containers": 100,
     }
     if environment == "main":
         options["min_containers"] = 3

--- a/policyengine_household_api/modal_release/worker_app.py
+++ b/policyengine_household_api/modal_release/worker_app.py
@@ -46,12 +46,6 @@ def worker_function_options(
         "timeout": 180,
         "scaledown_window": 300,
         "enable_memory_snapshot": True,
-        # Each container processes up to 5 requests in parallel. With ~3s of
-        # CPU per request on a 1-core container, 5-way sharing gives ~15s
-        # wall-time per request when fully saturated. Multiplies effective
-        # warm-pool capacity 5x with no additional container cost: the same
-        # always-warm containers handle 5x the simultaneous load.
-        "allow_concurrent_inputs": 5,
         # Hard cap on autoscale. Without this Modal is bounded only by the
         # workspace quota, so a runaway traffic spike (or a buggy partner
         # client) could scale to hundreds of containers and rack up cost.
@@ -67,7 +61,21 @@ def worker_function_options(
     return options
 
 
+def worker_concurrency_options() -> dict[str, int]:
+    # Each container processes up to 5 requests in parallel (`max_inputs`).
+    # With ~3s of CPU per request on a 1-core container, 5-way sharing gives
+    # ~15s wall-time per request when fully saturated. Multiplies effective
+    # warm-pool capacity 5x with no additional container cost.
+    #
+    # `target_inputs=4` is the autoscaler's steady-state goal: keep average
+    # utilisation at 80% so each container retains one free slot to absorb
+    # single-request spikes without waiting on a cold start. Containers still
+    # burst up to `max_inputs=5` under load before queueing.
+    return {"max_inputs": 5, "target_inputs": 4}
+
+
 @app.cls(**worker_function_options())
+@modal.concurrent(**worker_concurrency_options())
 class HouseholdWorker:
     """Worker class for handling household API requests.
 

--- a/tests/unit/modal_release/test_worker_app.py
+++ b/tests/unit/modal_release/test_worker_app.py
@@ -84,19 +84,30 @@ def test_household_worker_exposes_post_snapshot_reset_hook(worker_app):
     assert hasattr(worker_cls, "reset_post_snapshot_state")
 
 
-def test_worker_function_options_allow_concurrent_inputs_in_all_envs(
-    worker_app,
-):
+def test_worker_concurrency_options_set_max_inputs(worker_app):
     """Each container processes up to 5 requests in parallel. Keeping this
     consistent across environments ensures staging behavior mirrors
     production so concurrency-related issues surface in staging tests."""
+    assert worker_app.worker_concurrency_options()["max_inputs"] == 5
+
+
+def test_worker_concurrency_options_set_target_inputs(worker_app):
+    """`target_inputs=4` keeps the autoscaler aiming for 80% steady-state
+    utilisation, so each container retains a free slot to absorb a
+    single-request spike without waiting on a cold start."""
+    assert worker_app.worker_concurrency_options()["target_inputs"] == 4
+
+
+def test_worker_function_options_do_not_use_deprecated_concurrency_kwarg(
+    worker_app,
+):
     for environment in ("main", "staging", "testing"):
         options = worker_app.worker_function_options(
             modal_environment=environment
         )
-        assert options["allow_concurrent_inputs"] == 5, (
-            f"allow_concurrent_inputs must be 5 in `{environment}` so each "
-            "container handles 5 concurrent requests"
+        assert "allow_concurrent_inputs" not in options, (
+            "`allow_concurrent_inputs` is deprecated; use "
+            f"`@modal.concurrent` for `{environment}` worker concurrency"
         )
 
 

--- a/tests/unit/modal_release/test_worker_app.py
+++ b/tests/unit/modal_release/test_worker_app.py
@@ -84,6 +84,37 @@ def test_household_worker_exposes_post_snapshot_reset_hook(worker_app):
     assert hasattr(worker_cls, "reset_post_snapshot_state")
 
 
+def test_worker_function_options_allow_concurrent_inputs_in_all_envs(
+    worker_app,
+):
+    """Each container processes up to 5 requests in parallel. Keeping this
+    consistent across environments ensures staging behavior mirrors
+    production so concurrency-related issues surface in staging tests."""
+    for environment in ("main", "staging", "testing"):
+        options = worker_app.worker_function_options(
+            modal_environment=environment
+        )
+        assert options["allow_concurrent_inputs"] == 5, (
+            f"allow_concurrent_inputs must be 5 in `{environment}` so each "
+            "container handles 5 concurrent requests"
+        )
+
+
+def test_worker_function_options_max_containers_capped_in_all_envs(
+    worker_app,
+):
+    """A hard ceiling on autoscale prevents runaway scaling from a buggy
+    client or traffic spike from racking up unbounded cost."""
+    for environment in ("main", "staging", "testing"):
+        options = worker_app.worker_function_options(
+            modal_environment=environment
+        )
+        assert options["max_containers"] == 100, (
+            f"max_containers must be 100 in `{environment}` to bound "
+            "autoscale cost"
+        )
+
+
 def test_country_package_install_specs_use_release_package_versions_only():
     assert country_package_install_specs(
         {


### PR DESCRIPTION
Closes #1533

## Summary

Two-setting Modal config tweak that:

1. **Enables `allow_concurrent_inputs=5`** — each warm container now processes up to 5 requests in parallel instead of 1. Multiplies effective warm-pool capacity 5x with no additional always-on container cost.
2. **Caps autoscale at `max_containers=100`** — sanity ceiling against runaway scaling. Today the cap is unbounded (workspace quota only), so a buggy client or traffic spike could rack up unbounded cost.

Both settings apply to every Modal environment (`main`, `staging`, `testing`) so concurrency issues surface in staging before production.

## Why now

PR #1528 (memory snapshots) just shipped and dropped cold-start latency from 50-105s to ~26s. Burst testing in production today (`~/modal_burst_test.py` against the live gateway) confirmed the snapshot is working and surfaced these two cheap optimizations.

## Why concurrent_inputs=5 (and not 1 or 10)

PolicyEngine calculations are CPU-bound (~3s on 1 core). With N requests sharing the same core, each takes roughly N × 3s wall-time:

| `concurrent_inputs` | Per-request latency | Slots per container |
|---:|---:|---:|
| 1 | ~3s | 1 |
| **5** | **~15s** | **5** |
| 8 | ~24s | 8 |

5 is the sweet spot: 5x throughput per container, per-request latency stays within typical partner SLAs (\<20s), 5 PolicyEngine Simulation objects fit comfortably in the 9.6 GiB container memory.

## Capacity before vs after (current `min_containers=3, buffer_containers=2`)

| | Before this PR | After this PR |
|---|---|---|
| Warm slots ready | 5 (1 each on 5 containers) | **25** (5 each on 5 containers) |
| Burst absorbed without cold start | 5 | **25** |
| Per-request latency when slots full | ~3s | ~15s |
| Always-on container cost | unchanged | unchanged |

## Why max_containers=100

During the burst test today, Modal scaled to **36 containers** absorbing a 100-burst — fine for tests, but it demonstrated that with no cap, runaway behavior is possible.

100 covers any realistic burst we expect: 100 concurrent × 5 inputs/container = 500 in-flight, all hitting at once. Plus headroom for traffic-shape variance.

## Files changed

- `policyengine_household_api/modal_release/worker_app.py` — added `allow_concurrent_inputs: 5` and `max_containers: 100` to the base options dict (applies to all environments).
- `tests/unit/modal_release/test_worker_app.py` — two new tests asserting both settings are present in `main`, `staging`, `testing`.
- `changelog.d/1533.changed.md` — Towncrier fragment.

## Out of scope

- Bumping `min_containers` / `buffer_containers`. The Layer 1 change here gives 5x capacity for free; we want to see real partner traffic with the new concurrency setting before deciding whether to also pay for more always-on containers (#1533 discussion).
- Per-CPU-core tuning. Default Modal allocation is 1 core/container, which is what these latency numbers assume.

## Verification plan after merge (staging-first via existing automation)

1. CI auto-deploys to Modal staging.
2. Integration tests against staging pass (they cover current + frontier × channel + exact paths — same as PR #1528).
3. Re-run \`~/modal_burst_test.py --sizes 5,10,20,25,30,50,100\` against staging gateway:
   - Expect burst 5-25 to be all warm with p95 around 15s
   - Expect burst >25 to have a cold tail but each cold still ~26s (snapshot still works)
4. If staging looks good, the same workflow promotes to production.
5. Re-run the same burst test against production for confirmation.

## Risks and mitigations

- **Flask thread-safety**: audited in detail before this PR. Per-request state (test_client per call, Simulation per call, household copy per call) is properly isolated. Shared state (TBS, SQLAlchemy session, Limiter, ResourceProtector) is either read-only or thread-safe by design. SQLAlchemy default pool of 5+10 overflow handles 5 concurrent DB writes easily. See discussion in #1533.
- **Per-request latency increase under load**: documented (~3s → ~15s when slots fully saturated). This is a deliberate trade for 5x capacity.
- **Memory contention**: 5 simultaneous PolicyEngine Simulation objects per container. Each ~50-200 MB working state → ~1 GiB peak. Well within 9.6 GiB container budget.
- **If anything goes wrong**: trivial rollback (delete 2 lines from `worker_app.py`).

## Test plan

- [x] New unit tests pass locally
- [x] `make format-check` clean
- [ ] CI passes on this PR
- [ ] Staging integration tests pass on this PR
- [ ] Burst test against staging shows expected behavior (p95 ~15s for burst≤25)
- [ ] Burst test against production after promotion confirms same