### PR TITLE
Enable Modal custom domain for household API gateway

### DIFF
--- a/.github/scripts/modal-custom-domain-smoke.sh
+++ b/.github/scripts/modal-custom-domain-smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+modal_environment="${MODAL_ENVIRONMENT:-main}"
+modal_get_url_script="${MODAL_GET_URL_SCRIPT:-.github/scripts/modal-get-url.sh}"
+custom_domain_url="${HOUSEHOLD_MODAL_GATEWAY_CUSTOM_DOMAIN_URL:-https://household.api.policyengine.org}"
+
+if [ "${modal_environment}" != "main" ]; then
+  echo "Skipping custom-domain smoke check outside the main Modal environment."
+  exit 0
+fi
+
+gateway_url="$(bash "${modal_get_url_script}")"
+custom_domain_url="${custom_domain_url%/}"
+gateway_url="${gateway_url%/}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+gateway_versions="${tmpdir}/gateway-versions.json"
+custom_versions="${tmpdir}/custom-domain-versions.json"
+
+echo "Checking generated Modal gateway at ${gateway_url}"
+curl -fsS "${gateway_url}/liveness_check" >/dev/null
+curl -fsS "${gateway_url}/versions/us" > "${gateway_versions}"
+
+echo "Checking production custom domain at ${custom_domain_url}"
+curl -fsS "${custom_domain_url}/liveness_check" >/dev/null
+curl -fsS "${custom_domain_url}/versions/us" > "${custom_versions}"
+
+python - "${gateway_versions}" "${custom_versions}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+
+def load_versions(path: str, label: str) -> dict[str, str]:
+    try:
+        data = json.loads(Path(path).read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"{label} /versions/us did not return JSON: {e}")
+
+    if not isinstance(data, dict):
+        sys.exit(f"{label} /versions/us returned a non-object JSON value")
+    return data
+
+
+gateway_versions = load_versions(sys.argv[1], "Generated Modal gateway")
+custom_versions = load_versions(sys.argv[2], "Custom domain")
+
+if gateway_versions != custom_versions:
+    sys.exit(
+        "Custom domain /versions/us does not match the generated Modal "
+        f"gateway. generated={gateway_versions!r} custom={custom_versions!r}"
+    )
+
+print("Custom domain points at the deployed Modal gateway.")
+PY

--- a/.github/scripts/test_modal_custom_domain_smoke.py
+++ b/.github/scripts/test_modal_custom_domain_smoke.py
@@ -1,0 +1,141 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+SCRIPT = ".github/scripts/modal-custom-domain-smoke.sh"
+
+
+def test_modal_custom_domain_smoke_passes_when_versions_match(tmp_path):
+    env = _smoke_env(
+        tmp_path,
+        gateway_versions='{"current":"1.691.1","frontier":"1.691.1"}',
+        custom_versions='{"current":"1.691.1","frontier":"1.691.1"}',
+    )
+
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Custom domain points at the deployed Modal gateway." in result.stdout
+    )
+
+
+def test_modal_custom_domain_smoke_fails_when_custom_domain_is_not_gateway(
+    tmp_path,
+):
+    env = _smoke_env(
+        tmp_path,
+        gateway_versions='{"current":"1.691.1","frontier":"1.691.1"}',
+        custom_versions="OK",
+    )
+
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Custom domain /versions/us did not return JSON" in result.stderr
+
+
+def test_modal_custom_domain_smoke_fails_when_versions_differ(tmp_path):
+    env = _smoke_env(
+        tmp_path,
+        gateway_versions='{"current":"1.691.1","frontier":"1.691.1"}',
+        custom_versions='{"current":"1.690.0","frontier":"1.691.1"}',
+    )
+
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "does not match the generated Modal gateway" in result.stderr
+
+
+def test_modal_custom_domain_smoke_skips_non_main_environments(tmp_path):
+    curl_log = tmp_path / "curl.log"
+    env = _smoke_env(
+        tmp_path,
+        gateway_versions='{"current":"1.691.1"}',
+        custom_versions='{"current":"1.691.1"}',
+    )
+    env["MODAL_ENVIRONMENT"] = "staging"
+    env["CURL_LOG"] = str(curl_log)
+
+    result = subprocess.run(
+        ["bash", SCRIPT],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Skipping custom-domain smoke check" in result.stdout
+    assert not curl_log.exists()
+
+
+def _smoke_env(
+    tmp_path: Path,
+    *,
+    gateway_versions: str,
+    custom_versions: str,
+) -> dict[str, str]:
+    get_url_script = tmp_path / "modal-get-url.sh"
+    get_url_script.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "echo https://generated-modal.example\n"
+    )
+    get_url_script.chmod(0o755)
+
+    fake_curl = tmp_path / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+url="${@: -1}"
+if [ -n "${CURL_LOG:-}" ]; then
+  printf '%s\\n' "${url}" >> "${CURL_LOG}"
+fi
+
+case "${url}" in
+  https://generated-modal.example/liveness_check|https://custom-domain.example/liveness_check)
+    echo OK
+    ;;
+  https://generated-modal.example/versions/us)
+    printf '%s\\n' "${GATEWAY_VERSIONS}"
+    ;;
+  https://custom-domain.example/versions/us)
+    printf '%s\\n' "${CUSTOM_VERSIONS}"
+    ;;
+  *)
+    echo "Unexpected URL: ${url}" >&2
+    exit 22
+    ;;
+esac
+"""
+    )
+    fake_curl.chmod(0o755)
+
+    return {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "MODAL_ENVIRONMENT": "main",
+        "MODAL_GET_URL_SCRIPT": str(get_url_script),
+        "HOUSEHOLD_MODAL_GATEWAY_CUSTOM_DOMAIN_URL": (
+            "https://custom-domain.example"
+        ),
+        "GATEWAY_VERSIONS": gateway_versions,
+        "CUSTOM_VERSIONS": custom_versions,
+    }

--- a/.github/scripts/test_resolve_modal_release_config.py
+++ b/.github/scripts/test_resolve_modal_release_config.py
@@ -62,6 +62,27 @@ def test_resolve_release_uses_workflow_dispatch_inputs():
     assert resolved.config.cleanup_target == "frontier"
 
 
+def test_resolve_release_accepts_both_workflow_dispatch_target():
+    resolved = resolve_release_from_event(
+        {
+            "inputs": {
+                "new_app_target": "both",
+                "promote_existing_frontier": "false",
+                "cleanup_target": "retired",
+            }
+        },
+        fetch_pr_body_for_commit=lambda _repository, _sha: None,
+        event_name="workflow_dispatch",
+    )
+
+    assert resolved.should_deploy is True
+    assert resolved.deploy_mode == "release"
+    assert resolved.config is not None
+    assert resolved.config.new_app_target == "both"
+    assert resolved.config.promote_existing_frontier is False
+    assert resolved.config.cleanup_target == "retired"
+
+
 def test_resolve_release_uses_weekly_default_for_empty_workflow_dispatch():
     resolved = resolve_release_from_event(
         {"inputs": {}},

--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -14,6 +14,7 @@ on:
         options:
           - frontier
           - current
+          - both
           - none
       promote_existing_frontier:
         description: "Move the existing frontier worker to current before deploying a new frontier"

--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -265,6 +265,9 @@ jobs:
             '${{ needs.resolve-modal-release-config.outputs.config_json }}' \
             '${{ needs.resolve-modal-release-config.outputs.deploy_mode }}'
 
+      - name: Verify production custom domain
+        run: bash .github/scripts/modal-custom-domain-smoke.sh
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/changelog.d/1533.changed.md
+++ b/changelog.d/1533.changed.md
@@ -1,0 +1,1 @@
+Allow Modal releases to launch the same newly built worker on both `current` and `frontier`.

--- a/changelog.d/1535.added.md
+++ b/changelog.d/1535.added.md
@@ -1,0 +1,1 @@
+Enable the production Modal gateway custom domain and verify it during deployment.

--- a/docs/engineering/skills/modal-release-prs.md
+++ b/docs/engineering/skills/modal-release-prs.md
@@ -24,7 +24,7 @@ modal_release:
 
 Allowed values:
 
-- `new_app_target`: `frontier`, `current`, or `none`
+- `new_app_target`: `frontier`, `current`, `both`, or `none`
 - `promote_existing_frontier`: `true` or `false`
 - `cleanup_target`: `none`, `retired`, `frontier`, or `current`
 
@@ -49,6 +49,20 @@ history. This release shape uses `cleanup_target: retired`, so
 apps in the retired history are stopped after the manifest is updated. Use
 `cleanup_target: none` only when the user explicitly asks to preserve retired
 worker apps after release.
+
+Use this release shape when the newly built worker must become both `current`
+and `frontier` in a single release:
+
+```yaml
+modal_release:
+  new_app_target: both
+  promote_existing_frontier: false
+  cleanup_target: retired
+```
+
+This deploys one new worker app, writes the same app reference into both
+`current` and `frontier`, and moves the previous active workers into the
+manifest's `retired` history.
 
 Do not use PR labels, branch names, model-specific tags, or title prefixes to
 control Modal release behavior. The PR body YAML block is the source of truth.

--- a/policyengine_household_api/modal_release/gateway_app.py
+++ b/policyengine_household_api/modal_release/gateway_app.py
@@ -19,10 +19,45 @@ GATEWAY_WEB_ENDPOINT_LABEL = os.getenv(
     "HOUSEHOLD_MODAL_GATEWAY_WEB_ENDPOINT_LABEL",
     "household-api-gateway",
 )
+GATEWAY_CUSTOM_DOMAIN = "household.api.policyengine.org"
+GATEWAY_CUSTOM_DOMAINS_ENV = "HOUSEHOLD_MODAL_GATEWAY_CUSTOM_DOMAINS"
 
 
-def gateway_wsgi_app_options() -> dict[str, object]:
-    return {"label": GATEWAY_WEB_ENDPOINT_LABEL}
+def gateway_custom_domains(
+    *,
+    modal_environment: str | None = None,
+    custom_domains: str | None = None,
+) -> tuple[str, ...]:
+    if custom_domains is None:
+        custom_domains = os.getenv(GATEWAY_CUSTOM_DOMAINS_ENV)
+
+    if custom_domains is not None:
+        return tuple(
+            domain.strip()
+            for domain in custom_domains.split(",")
+            if domain.strip()
+        )
+
+    environment = modal_environment or os.getenv("MODAL_ENVIRONMENT", "main")
+    if environment == "main":
+        return (GATEWAY_CUSTOM_DOMAIN,)
+
+    return ()
+
+
+def gateway_wsgi_app_options(
+    *,
+    modal_environment: str | None = None,
+    custom_domains: str | None = None,
+) -> dict[str, object]:
+    options: dict[str, object] = {"label": GATEWAY_WEB_ENDPOINT_LABEL}
+    domains = gateway_custom_domains(
+        modal_environment=modal_environment,
+        custom_domains=custom_domains,
+    )
+    if domains:
+        options["custom_domains"] = domains
+    return options
 
 
 app = modal.App(GATEWAY_APP_NAME)

--- a/policyengine_household_api/modal_release/manifest.py
+++ b/policyengine_household_api/modal_release/manifest.py
@@ -207,6 +207,22 @@ def apply_release_config(
         next_manifest["current"] = deepcopy(dict(new_app or {}))
         next_manifest["frontier"] = None
 
+    elif config.new_app_target == NewAppTarget.BOTH:
+        retired = _retire_entry(
+            retired,
+            next_manifest.get("current"),
+            retired_at=retired_at,
+            reason="replaced-current",
+        )
+        retired = _retire_entry(
+            retired,
+            next_manifest.get("frontier"),
+            retired_at=retired_at,
+            reason="replaced-frontier",
+        )
+        next_manifest["current"] = deepcopy(dict(new_app or {}))
+        next_manifest["frontier"] = deepcopy(dict(new_app or {}))
+
     next_manifest["retired"] = retired
     return validate_manifest(next_manifest)
 

--- a/policyengine_household_api/modal_release/release_config.py
+++ b/policyengine_household_api/modal_release/release_config.py
@@ -38,6 +38,7 @@ class ModalReleaseConfigError(ValueError):
 class NewAppTarget(StrEnum):
     FRONTIER = "frontier"
     CURRENT = "current"
+    BOTH = "both"
     NONE = "none"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "policyengine_canada==0.96.3",
     "policyengine-ng==0.5.1",
     "policyengine-il==0.1.0",
-    "policyengine_uk==2.31.0",
+    "policyengine_uk==2.88.18",
     "policyengine_us==1.691.1",
     "pyjwt",
     "pyyaml>=6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "inflect",
     "joserfc>=1.6.0",
     "modal>=1.3.0",
-    "policyengine-core>=3.26.5",
+    "policyengine-core>=3.26.0,<3.26.8",
     "policyengine_canada==0.96.3",
     "policyengine-ng==0.5.1",
     "policyengine-il==0.1.0",

--- a/tests/unit/modal_release/test_gateway_app.py
+++ b/tests/unit/modal_release/test_gateway_app.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 from policyengine_household_api.modal_release.gateway_app import (
     GATEWAY_APP_NAME,
+    GATEWAY_CUSTOM_DOMAIN,
     GATEWAY_WEB_ENDPOINT_LABEL,
+    gateway_custom_domains,
     gateway_wsgi_app_options,
 )
 
@@ -13,8 +15,31 @@ def test_gateway_web_endpoint_label_is_short_and_stable():
     assert GATEWAY_WEB_ENDPOINT_LABEL == "household-api-gateway"
 
 
-def test_gateway_wsgi_app_options_do_not_register_custom_domains():
-    assert gateway_wsgi_app_options() == {"label": GATEWAY_WEB_ENDPOINT_LABEL}
+def test_gateway_wsgi_app_options_registers_production_custom_domain():
+    assert gateway_wsgi_app_options(modal_environment="main") == {
+        "label": GATEWAY_WEB_ENDPOINT_LABEL,
+        "custom_domains": (GATEWAY_CUSTOM_DOMAIN,),
+    }
+
+
+def test_gateway_wsgi_app_options_do_not_register_staging_custom_domains():
+    assert gateway_wsgi_app_options(modal_environment="staging") == {
+        "label": GATEWAY_WEB_ENDPOINT_LABEL
+    }
+
+
+def test_gateway_custom_domain_override_supports_multiple_domains():
+    assert gateway_custom_domains(
+        modal_environment="staging",
+        custom_domains=" api.example.org, secondary.example.org ",
+    ) == ("api.example.org", "secondary.example.org")
+
+
+def test_gateway_custom_domain_override_can_disable_domains():
+    assert gateway_wsgi_app_options(
+        modal_environment="main",
+        custom_domains="",
+    ) == {"label": GATEWAY_WEB_ENDPOINT_LABEL}
 
 
 def test_gateway_web_endpoint_label_fits_modal_hostname_limit():

--- a/tests/unit/modal_release/test_manifest.py
+++ b/tests/unit/modal_release/test_manifest.py
@@ -84,6 +84,43 @@ def test_direct_current_release_retires_current_and_frontier():
     ]
 
 
+def test_both_release_sets_current_and_frontier_to_new_app():
+    manifest = {
+        "schema_version": 1,
+        "current": _app("current-app", us="1.690.0"),
+        "frontier": _app("frontier-app"),
+        "retired": [],
+    }
+    config = ModalReleaseConfig(
+        new_app_target=NewAppTarget.BOTH,
+        promote_existing_frontier=False,
+        cleanup_target=CleanupTarget.RETIRED,
+    )
+    new_app = _app("new-shared-app", uk="2.88.18")
+
+    updated = apply_release_config(
+        manifest,
+        config,
+        new_app=new_app,
+        timestamp="2026-01-02T00:00:00+00:00",
+    )
+
+    assert updated["current"] == new_app
+    assert updated["frontier"] == new_app
+    assert [app["app_name"] for app in updated["retired"]] == [
+        "current-app",
+        "frontier-app",
+    ]
+    assert [app["retirement_reason"] for app in updated["retired"]] == [
+        "replaced-current",
+        "replaced-frontier",
+    ]
+    assert cleanup_app_names_for_target(
+        updated,
+        CleanupTarget.RETIRED,
+    ) == ["current-app", "frontier-app"]
+
+
 def test_retired_cleanup_excludes_active_apps():
     manifest = {
         "schema_version": 1,

--- a/tests/unit/modal_release/test_release_config.py
+++ b/tests/unit/modal_release/test_release_config.py
@@ -29,6 +29,22 @@ def test_parse_modal_release_config_from_fenced_yaml():
     assert config.promote_existing_frontier is True
 
 
+def test_parse_accepts_both_target_without_promotion():
+    config = parse_modal_release_config_from_body(
+        """
+```yaml
+modal_release:
+  new_app_target: both
+  promote_existing_frontier: false
+  cleanup_target: retired
+```
+"""
+    )
+
+    assert config.new_app_target == NewAppTarget.BOTH
+    assert config.promote_existing_frontier is False
+
+
 def test_parse_rejects_missing_config():
     with pytest.raises(ModalReleaseConfigError, match="modal_release"):
         parse_modal_release_config_from_body("## Summary\n")
@@ -51,6 +67,20 @@ def test_parse_rejects_invalid_promotion_combination():
 ```yaml
 modal_release:
   new_app_target: current
+  promote_existing_frontier: true
+  cleanup_target: none
+```
+"""
+        )
+
+
+def test_parse_rejects_both_target_with_promotion():
+    with pytest.raises(ModalReleaseConfigError, match="may only be true"):
+        parse_modal_release_config_from_body(
+            """
+```yaml
+modal_release:
+  new_app_target: both
   promote_existing_frontier: true
   cleanup_target: none
 ```

--- a/uv.lock
+++ b/uv.lock
@@ -2357,7 +2357,7 @@ requires-dist = [
     { name = "joserfc", specifier = ">=1.6.0" },
     { name = "modal", specifier = ">=1.3.0" },
     { name = "policyengine-canada", specifier = "==0.96.3" },
-    { name = "policyengine-core", specifier = ">=3.26.5" },
+    { name = "policyengine-core", specifier = ">=3.26.0,<3.26.8" },
     { name = "policyengine-il", specifier = "==0.1.0" },
     { name = "policyengine-ng", specifier = "==0.5.1" },
     { name = "policyengine-uk", specifier = "==2.88.18" },

--- a/uv.lock
+++ b/uv.lock
@@ -2300,7 +2300,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-household-api"
-version = "0.19.9"
+version = "0.19.10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2360,7 +2360,7 @@ requires-dist = [
     { name = "policyengine-core", specifier = ">=3.26.5" },
     { name = "policyengine-il", specifier = "==0.1.0" },
     { name = "policyengine-ng", specifier = "==0.5.1" },
-    { name = "policyengine-uk", specifier = "==2.31.0" },
+    { name = "policyengine-uk", specifier = "==2.88.18" },
     { name = "policyengine-us", specifier = "==1.691.1" },
     { name = "pydantic" },
     { name = "pyjwt" },
@@ -2402,15 +2402,17 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.31.0"
+version = "2.88.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
     { name = "policyengine-core" },
+    { name = "pydantic" },
+    { name = "tables" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/2e/c39f20f3e308ceed53ea76a699390d960a1074c065119429664aede6957a/policyengine_uk-2.31.0.tar.gz", hash = "sha256:0ab0a2bf7995eb34c6a04b456f843c31bbfbac01194953689eb79ca26a6c34a9", size = 1044067, upload-time = "2025-06-09T15:27:29.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/0b/f651ab70a52f68fce3e9e3acf3d82cc98b5a29c9adc2f5640f4431cc5ae9/policyengine_uk-2.88.18.tar.gz", hash = "sha256:35b2dac76a9450d747e6f45981ad4c7ffa43c9e9f205b1ce2bfd25cc5e1920e5", size = 1187371, upload-time = "2026-05-17T14:18:22.624Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/c9/e86d8f172c310352b26f81a6c25ad56d4f1ebc5c9c62e6ab09e4b20bffa1/policyengine_uk-2.31.0-py3-none-any.whl", hash = "sha256:dc95a5a6e5120893a069e69bd276f3ebd4004ef59e0e8b20c36b8a1349830a00", size = 1576810, upload-time = "2025-06-09T15:27:26.893Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/94/96ae35fc97cfbb1a160f737afac6d85ff04b76588b138ffc883411d1dc57/policyengine_uk-2.88.18-py3-none-any.whl", hash = "sha256:ab086392cdcd27a10601ec2bbfead4abf6ea64682a046b2c7231bb465a504a34", size = 1915114, upload-time = "2026-05-17T14:18:21.091Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #1535

## Modal release config

This PR updates a release-significant country package version and should deploy the newly built worker to both active channels:

```yaml
modal_release:
  new_app_target: both
  promote_existing_frontier: false
  cleanup_target: retired
```

## Summary

- Register `household.api.policyengine.org` as the default Modal gateway custom domain in the `main` environment only.
- Keep staging/testing on Modal-generated URLs unless `HOUSEHOLD_MODAL_GATEWAY_CUSTOM_DOMAINS` explicitly overrides the domain list.
- Add a production deploy smoke check that compares `/versions/us` from the generated Modal gateway URL and the custom domain, so deploy fails until Modal domain registration and Squarespace DNS are correct.
- Add support for `new_app_target: both` so a release can update `current` and `frontier` to the same newly built worker.
- Bump `policyengine_uk` to `2.88.18`.

## Testing

- `python -m pytest .github/scripts/test_modal_custom_domain_smoke.py tests/unit/modal_release/test_gateway_app.py -q`
- `python -m pytest .github/scripts/test_resolve_modal_release_config.py .github/scripts/test_modal_custom_domain_smoke.py tests/unit/modal_release/test_release_config.py tests/unit/modal_release/test_manifest.py tests/unit/modal_release/test_gateway_app.py -q`
- `make format-check`
- `ruff check policyengine_household_api/modal_release/gateway_app.py tests/unit/modal_release/test_gateway_app.py .github/scripts/test_modal_custom_domain_smoke.py`

## Deployment note

The first production deploy with this change is expected to fail until `household.api.policyengine.org` is registered/validated in Modal and DNS points to the Modal gateway.