### PR TITLE
Confirm Modal app cleanup in CI

### DIFF
--- a/.github/scripts/modal-cleanup-apps.sh
+++ b/.github/scripts/modal-cleanup-apps.sh
@@ -16,7 +16,7 @@ for app_name in payload.get("app_names", []):
   if [[ -z "${app_name}" ]]; then
     continue
   fi
-  if ! output="$(uv run modal app stop --env "${environment}" "${app_name}" 2>&1)"; then
+  if ! output="$(uv run modal app stop --yes --env "${environment}" "${app_name}" 2>&1)"; then
     echo "${output}"
     if [[ "${output}" == *"already stopped"* ]]; then
       continue

--- a/.github/scripts/test_modal_cleanup_apps.py
+++ b/.github/scripts/test_modal_cleanup_apps.py
@@ -4,6 +4,45 @@ import os
 import subprocess
 
 
+def test_modal_cleanup_confirms_app_stop_in_noninteractive_ci(tmp_path):
+    cleanup_file = tmp_path / "cleanup.json"
+    cleanup_file.write_text('{"app_names":["old-app"]}\n')
+    args_file = tmp_path / "uv-args.txt"
+    _write_fake_uv(
+        tmp_path,
+        exit_code=0,
+        output="Stopped.",
+        args_file=args_file,
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            ".github/scripts/modal-cleanup-apps.sh",
+            str(cleanup_file),
+        ],
+        capture_output=True,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "MODAL_ENVIRONMENT": "testing",
+        },
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert args_file.read_text().splitlines() == [
+        "run",
+        "modal",
+        "app",
+        "stop",
+        "--yes",
+        "--env",
+        "testing",
+        "old-app",
+    ]
+
+
 def test_modal_cleanup_treats_already_stopped_app_as_success(tmp_path):
     cleanup_file = tmp_path / "cleanup.json"
     cleanup_file.write_text('{"app_names":["old-app"]}\n')
@@ -52,10 +91,23 @@ def test_modal_cleanup_fails_on_other_stop_errors(tmp_path):
     assert "Permission denied" in result.stdout
 
 
-def _write_fake_uv(tmp_path, *, exit_code: int, output: str) -> None:
+def _write_fake_uv(
+    tmp_path,
+    *,
+    exit_code: int,
+    output: str,
+    args_file=None,
+) -> None:
     uv = tmp_path / "uv"
+    args_capture = (
+        f"""printf '%s\\n' "$@" > "{args_file}"
+"""
+        if args_file is not None
+        else ""
+    )
     uv.write_text(
         f"""#!/usr/bin/env bash
+{args_capture}\
 echo "{output}" >&2
 exit {exit_code}
 """

--- a/changelog.d/1537.fixed.md
+++ b/changelog.d/1537.fixed.md
@@ -1,0 +1,1 @@
+Make Modal retired-app cleanup non-interactive in CI.


### PR DESCRIPTION
Fixes #1537

## Summary

- Pass `--yes` to `modal app stop` during Modal retired-app cleanup so GitHub Actions does not block on an interactive confirmation prompt.
- Add a regression test that verifies the cleanup script invokes `uv run modal app stop --yes --env ...`.
- Add a Towncrier fragment for the cleanup fix.

## Validation

- `uv run pytest .github/scripts/test_modal_cleanup_apps.py`
- `make format-check`
- `uv run pytest -vv --timeout=150 -rP .github/scripts tests/to_refactor tests/unit`

Note: `make test` failed locally before running tests because the non-uv pytest entrypoint did not have `pytest-timeout` available for `--timeout=150`; the equivalent uv-backed command passed. `make format-check` also prints a Docker daemon warning from Makefile evaluation on this machine, then Ruff completes successfully.