### PR TITLE
Require active Modal release channels before deploy

### DIFF
--- a/.github/scripts/modal-deploy-release.sh
+++ b/.github/scripts/modal-deploy-release.sh
@@ -7,6 +7,7 @@ output_file="${GITHUB_OUTPUT:-}"
 modal_extract_versions_script="${MODAL_EXTRACT_VERSIONS_SCRIPT:-.github/scripts/modal_extract_versions.py}"
 modal_sync_secrets_script="${MODAL_SYNC_SECRETS_SCRIPT:-.github/scripts/modal-sync-secrets.sh}"
 modal_active_worker_apps_script="${MODAL_ACTIVE_WORKER_APPS_SCRIPT:-.github/scripts/modal_active_worker_apps.py}"
+modal_require_active_channels_script="${MODAL_REQUIRE_ACTIVE_CHANNELS_SCRIPT:-.github/scripts/modal_require_active_channels.py}"
 modal_cleanup_apps_script="${MODAL_CLEANUP_APPS_SCRIPT:-.github/scripts/modal-cleanup-apps.sh}"
 modal_get_url_script="${MODAL_GET_URL_SCRIPT:-.github/scripts/modal-get-url.sh}"
 
@@ -68,6 +69,9 @@ case "${deploy_mode}" in
     exit 1
     ;;
 esac
+
+uv run python "${modal_require_active_channels_script}" \
+  --modal-environment "${modal_environment}"
 
 uv run alembic upgrade head
 analytics_database_revision="$(

--- a/.github/scripts/modal_require_active_channels.py
+++ b/.github/scripts/modal_require_active_channels.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+import modal
+from modal.exception import NotFoundError
+
+from policyengine_household_api.modal_release.manifest import (
+    MANIFEST_DICT_KEY,
+    MANIFEST_DICT_NAME,
+    require_active_current_and_frontier,
+)
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        manifest_dict = modal.Dict.from_name(
+            MANIFEST_DICT_NAME,
+            create_if_missing=False,
+            environment_name=args.modal_environment,
+        )
+    except NotFoundError:
+        print(
+            "Modal release manifest is missing; both `current` and "
+            "`frontier` must be configured before deploying.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        require_active_current_and_frontier(
+            manifest_dict.get(MANIFEST_DICT_KEY)
+        )
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    print("Modal release manifest has active `current` and `frontier` apps.")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail unless the Modal release manifest has both active channels."
+        )
+    )
+    parser.add_argument("--modal-environment", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_modal_deploy_release.py
+++ b/.github/scripts/test_modal_deploy_release.py
@@ -56,6 +56,7 @@ def test_modal_deploy_release_code_mode_deploys_manifest_apps_only(tmp_path):
 
     assert result.returncode == 0, result.stderr
     log = log_path.read_text()
+    assert "modal_require_active_channels.py" in log
     assert "DEPLOY_APP=current-app" in log
     assert 'VERSIONS={"uk":"2.31.0","us":"1.690.0"}' in log
     assert "DEPLOY_APP=frontier-app" in log
@@ -92,10 +93,45 @@ def test_modal_deploy_release_release_mode_updates_manifest_and_cleans(
 
     assert result.returncode == 0, result.stderr
     log = log_path.read_text()
+    assert "modal_require_active_channels.py" in log
     assert "DEPLOY_APP=release-app" in log
     assert "-m policyengine_household_api.modal_release.update_manifest" in log
     assert "--source-commit" not in log
     assert "cleanup-called" in log
+
+
+def test_modal_deploy_release_fails_before_deploy_when_channels_missing(
+    tmp_path,
+):
+    log_path = tmp_path / "uv.log"
+    env = _deploy_env(tmp_path, log_path)
+    env["REQUIRE_ACTIVE_CHANNELS_RC"] = "1"
+    _write_fake_uv(tmp_path, log_path, active_apps_tsv="")
+
+    result = subprocess.run(
+        [
+            "bash",
+            ".github/scripts/modal-deploy-release.sh",
+            (
+                '{"new_app_target":"frontier",'
+                '"promote_existing_frontier":true,'
+                '"cleanup_target":"retired"}'
+            ),
+            "release",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    log = log_path.read_text()
+    assert "modal_require_active_channels.py" in log
+    assert "DEPLOY_APP=release-app" not in log
+    assert (
+        "-m policyengine_household_api.modal_release.update_manifest"
+        not in log
+    )
 
 
 def _deploy_env(tmp_path: Path, log_path: Path) -> dict[str, str]:
@@ -147,6 +183,15 @@ echo "$*" >> "${{UV_LOG}}"
 
 if [[ "$*" == *"policyengine_household_api.modal_release.analytics_revision"* ]]; then
   echo "20260512_0003"
+  exit 0
+fi
+
+if [[ "$*" == *"modal_require_active_channels.py"* ]]; then
+  echo "require-active-channels" >> "{log_path}"
+  if [[ "${{REQUIRE_ACTIVE_CHANNELS_RC:-0}}" != "0" ]]; then
+    echo "Modal release manifest must configure both current and frontier" >&2
+    exit "${{REQUIRE_ACTIVE_CHANNELS_RC}}"
+  fi
   exit 0
 fi
 

--- a/changelog.d/1545.fixed.md
+++ b/changelog.d/1545.fixed.md
@@ -1,0 +1,1 @@
+Fail Modal deployments early when the release manifest is missing either the `current` or `frontier` channel.

--- a/policyengine_household_api/modal_release/manifest.py
+++ b/policyengine_household_api/modal_release/manifest.py
@@ -282,13 +282,11 @@ def cleanup_app_names_for_target(
 def active_app_deployments(
     manifest: Mapping[str, Any],
 ) -> list[dict[str, Any]]:
-    validated = validate_manifest(manifest)
+    validated = require_active_current_and_frontier(manifest)
     deployments_by_name: dict[str, dict[str, str]] = {}
 
     for channel in ("current", "frontier"):
         app_reference = validated.get(channel)
-        if not app_reference:
-            continue
         app_name = app_reference.get("app_name")
         if not app_name:
             continue
@@ -307,9 +305,6 @@ def active_app_deployments(
             )
         deployments_by_name[app_name] = package_versions
 
-    if not deployments_by_name:
-        raise ValueError("No active Modal household API apps are configured")
-
     return [
         {
             "app_name": app_name,
@@ -317,6 +312,23 @@ def active_app_deployments(
         }
         for app_name, package_versions in deployments_by_name.items()
     ]
+
+
+def require_active_current_and_frontier(
+    manifest: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    validated = validate_manifest(manifest)
+    missing_channels = [
+        f"`{channel}`"
+        for channel in ("current", "frontier")
+        if not validated.get(channel)
+    ]
+    if missing_channels:
+        raise ValueError(
+            "Modal release manifest must configure both `current` and "
+            f"`frontier`; missing {', '.join(missing_channels)}"
+        )
+    return validated
 
 
 def prune_cleaned_retired_apps(

--- a/tests/unit/modal_release/test_manifest.py
+++ b/tests/unit/modal_release/test_manifest.py
@@ -11,6 +11,7 @@ from policyengine_household_api.modal_release.manifest import (
     build_app_name,
     cleanup_app_names_for_target,
     current_package_versions,
+    require_active_current_and_frontier,
     rewrite_existing_manifest_for_storage,
     rewrite_manifest_for_storage,
     validate_manifest,
@@ -364,6 +365,41 @@ def test_active_app_deployments_rejects_conflicting_active_app_versions():
         active_app_deployments(manifest)
 
 
+def test_require_active_current_and_frontier_rejects_missing_current():
+    manifest = {
+        "schema_version": 1,
+        "current": None,
+        "frontier": _app("frontier-app"),
+        "retired": [],
+    }
+
+    with pytest.raises(ValueError, match="missing `current`"):
+        require_active_current_and_frontier(manifest)
+
+
+def test_require_active_current_and_frontier_rejects_missing_frontier():
+    manifest = {
+        "schema_version": 1,
+        "current": _app("current-app"),
+        "frontier": None,
+        "retired": [],
+    }
+
+    with pytest.raises(ValueError, match="missing `frontier`"):
+        require_active_current_and_frontier(manifest)
+
+
+def test_require_active_current_and_frontier_accepts_both_channels():
+    manifest = {
+        "schema_version": 1,
+        "current": _app("current-app"),
+        "frontier": _app("frontier-app"),
+        "retired": [],
+    }
+
+    assert require_active_current_and_frontier(manifest) == manifest
+
+
 def test_active_app_deployments_requires_release_package_versions():
     manifest = {
         "schema_version": 1,
@@ -371,7 +407,7 @@ def test_active_app_deployments_requires_release_package_versions():
             **_app("current-app"),
             "package_versions": {"us": "1.691.1"},
         },
-        "frontier": None,
+        "frontier": _app("frontier-app"),
         "retired": [],
     }
 


### PR DESCRIPTION
Fixes #1545

## Summary

- add a Modal release-manifest preflight that requires both `current` and `frontier`
- run that preflight before deployment work in `modal-deploy-release.sh`
- enforce the same invariant in manifest deployment helpers and focused tests

## Tests

- `uv run pytest tests/unit/modal_release/test_manifest.py .github/scripts/test_modal_deploy_release.py`
- `uv run ruff check .github/scripts/modal_require_active_channels.py .github/scripts/test_modal_deploy_release.py policyengine_household_api/modal_release/manifest.py tests/unit/modal_release/test_manifest.py`
- `uv run ruff format --check .github/scripts/modal_require_active_channels.py .github/scripts/test_modal_deploy_release.py policyengine_household_api/modal_release/manifest.py tests/unit/modal_release/test_manifest.py`