### PR TITLE
Make deployed-test response headers case-insensitive (Cloud Run HTTP/2)

### DIFF
--- a/changelog.d/1553.fixed.md
+++ b/changelog.d/1553.fixed.md
@@ -1,0 +1,1 @@
+Made deployed-test response header lookups case-insensitive so Cloud Run (HTTP/2) integration tests no longer fail on the lowercased `X-PolicyEngine-Backend` header.

--- a/tests/deployed/conftest.py
+++ b/tests/deployed/conftest.py
@@ -16,6 +16,28 @@ ROUTE_MODE_ENV_VAR = "HOUSEHOLD_API_ROUTE_MODE"
 DEFAULT_TIMEOUT_SECONDS = 90
 
 
+class CaseInsensitiveHeaders(dict):
+    """Response headers with case-insensitive lookups.
+
+    Cloud Run serves responses over HTTP/2, which lowercases all header names,
+    while Modal serves HTTP/1.1 with the original casing. Normalising keys keeps
+    assertions such as ``headers["X-PolicyEngine-Backend"]`` working regardless
+    of which gateway answered.
+    """
+
+    def __init__(self, items=()):
+        super().__init__((key.lower(), value) for key, value in items)
+
+    def __getitem__(self, key: str):
+        return super().__getitem__(key.lower())
+
+    def __contains__(self, key: object) -> bool:
+        return isinstance(key, str) and super().__contains__(key.lower())
+
+    def get(self, key: str, default=None):
+        return super().get(key.lower(), default)
+
+
 @dataclass
 class DeployedResponse:
     status_code: int
@@ -77,13 +99,13 @@ class DeployedApiClient:
             ) as response:
                 return DeployedResponse(
                     status_code=response.status,
-                    headers=dict(response.headers.items()),
+                    headers=CaseInsensitiveHeaders(response.headers.items()),
                     text=response.read().decode("utf-8"),
                 )
         except error.HTTPError as exc:
             return DeployedResponse(
                 status_code=exc.code,
-                headers=dict(exc.headers.items()),
+                headers=CaseInsensitiveHeaders(exc.headers.items()),
                 text=exc.read().decode("utf-8"),
             )
 


### PR DESCRIPTION
Fixes #1553

## Summary

The Cloud Run failover staging integration tests failed with `KeyError: 'X-PolicyEngine-Backend'` even though requests returned HTTP 200 with the correct backend and calculation output. Cloud Run serves over **HTTP/2, which lowercases all response header names**; the deployed-test harness (`tests/deployed/conftest.py`) flattened headers into a case-sensitive `dict` (`dict(response.headers.items())`) and looked them up by the mixed-case name. Modal serves HTTP/1.1 (case preserved), so the equivalent Modal integration tests passed.

This stores response headers in a `CaseInsensitiveHeaders` mapping (lowercases keys on store and lookup) at both construction sites, so `headers["X-PolicyEngine-Backend"]` resolves against both gateways. The gateway is unchanged — it already sets all four `X-PolicyEngine-*` headers correctly (verified against the live staging gateway; they're simply lowercased by HTTP/2).

## Testing

- `make format-check` (whole repo) — pass
- `make test` (via `uv run --frozen`, covering `.github/scripts tests/to_refactor tests/unit`) — 536 passed
- Behavior check of `CaseInsensitiveHeaders` for HTTP/2 (lowercase) and HTTP/1.1 (mixed-case) inputs; missing keys still raise `KeyError`
- `make test-with-auth` not run locally (no Auth0 config) — relying on PR CI

The deployed integration tests that surface this bug run in the release pipeline against a live Cloud Run gateway, so the end-to-end validation is the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)