### PR TITLE
Warm Cloud Run fallback workers before the forced-fallback staging test

### DIFF
--- a/.github/scripts/cloud-run-warm-workers.sh
+++ b/.github/scripts/cloud-run-warm-workers.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Warm the private Cloud Run fallback workers before the forced-fallback test.
+#
+# The workers run at min-instances=0, so the first request triggers a cold
+# start (image pull + container boot + full app import) that can take minutes
+# and exceed the deployed-test read timeout. This pings each worker's liveness
+# endpoint and waits for it to come up so the test step exercises warm workers.
+#
+# The workers are private (--no-allow-unauthenticated), so an unauthenticated
+# request is rejected at the front door without starting a container; we send
+# an IAM identity token so the request actually reaches the worker and triggers
+# the cold start.
+#
+# Best-effort: this never exits non-zero. A worker that cannot be warmed only
+# emits a warning; the deployed test step remains the gate.
+set -uo pipefail
+
+gcloud_bin="${GCLOUD_BIN:-gcloud}"
+curl_bin="${CURL_BIN:-curl}"
+
+project="${GOOGLE_CLOUD_PROJECT:-}"
+region="${HOUSEHOLD_CLOUD_RUN_REGION:-us-central1}"
+gateway_service="${CLOUD_RUN_GATEWAY_SERVICE:-}"
+channels="${HOUSEHOLD_CLOUD_RUN_WARM_CHANNELS:-current frontier}"
+total_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_TIMEOUT_SECONDS:-300}"
+attempt_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_ATTEMPT_TIMEOUT_SECONDS:-120}"
+
+if [ -z "${project}" ] || [ -z "${gateway_service}" ]; then
+  echo "::warning::GOOGLE_CLOUD_PROJECT and CLOUD_RUN_GATEWAY_SERVICE are required to warm workers; skipping."
+  exit 0
+fi
+
+worker_prefix="${gateway_service%-gateway}"
+
+warm_worker() {
+  local service="$1"
+  local url token code deadline
+  url="$(
+    "${gcloud_bin}" run services describe "${service}" \
+      --region "${region}" \
+      --project "${project}" \
+      --format='value(status.url)' 2>/dev/null || true
+  )"
+  if [ -z "${url}" ]; then
+    echo "::warning::Could not resolve URL for ${service}; skipping warm-up."
+    return 0
+  fi
+
+  token="$(
+    "${gcloud_bin}" auth print-identity-token --audiences="${url}" \
+      2>/dev/null || true
+  )"
+  if [ -z "${token}" ]; then
+    echo "::warning::Could not mint identity token for ${service}; skipping warm-up."
+    return 0
+  fi
+
+  echo "Warming ${service} via ${url}/liveness_check (up to ${total_timeout}s)..."
+  deadline=$(( $(date +%s) + total_timeout ))
+  while :; do
+    code="$(
+      "${curl_bin}" -sS -o /dev/null -w '%{http_code}' \
+        --max-time "${attempt_timeout}" \
+        -H "Authorization: Bearer ${token}" \
+        "${url}/liveness_check" || true
+    )"
+    case "${code}" in
+      2*)
+        echo "${service} is warm (HTTP ${code})."
+        return 0
+        ;;
+      401 | 403)
+        echo "::warning::${service} rejected the warm-up request (HTTP ${code}); the worker was not warmed."
+        return 0
+        ;;
+    esac
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+      echo "::warning::${service} did not respond within ${total_timeout}s; continuing to tests anyway."
+      return 0
+    fi
+    sleep 5
+  done
+}
+
+read -ra warm_channels <<< "${channels}"
+pids=()
+for channel in "${warm_channels[@]}"; do
+  warm_worker "${worker_prefix}-${channel}-worker" &
+  pids+=("$!")
+done
+wait "${pids[@]}"
+exit 0

--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -382,6 +382,12 @@ jobs:
             --update-env-vars HOUSEHOLD_FAILOVER_FORCE_BACKEND=cloud_run \
             --quiet
 
+      - name: Warm Cloud Run fallback workers
+        # Cold-start the min-instances=0 fallback workers before the test so it
+        # doesn't time out waiting on the first request. Best-effort; the test
+        # step is the gate. See the script for details.
+        run: bash .github/scripts/cloud-run-warm-workers.sh
+
       - name: Run deployed fallback tests
         run: |
           bash .github/scripts/run-deployed-tests-for-modal-route.sh \

--- a/changelog.d/1555.fixed.md
+++ b/changelog.d/1555.fixed.md
@@ -1,0 +1,1 @@
+Warmed the Cloud Run fallback workers before the forced-fallback staging test so it no longer times out on `min-instances=0` cold starts.


### PR DESCRIPTION
Fixes #1555

## Summary

The `Forced Cloud Run fallback test against staging` job times out because the fallback workers run at `min-instances=0`: the first forced-fallback request cold-starts a worker (image pull + container boot + full app import), measured at ~90–205s against staging, which blows past the deployed-test 90s read timeout. Every request returned HTTP 200 — the worker is healthy, just slow on cold start — so it's pure cold-start latency, not an error.

This adds a `Warm Cloud Run fallback workers` step before the test that, for each fallback worker (`current` and `frontier`, in parallel):
- resolves the worker URL and mints an IAM identity token (the workers are private, so an unauthenticated liveness request is rejected at the front door *without* starting a container — a valid token is required to actually trigger the cold start),
- polls `GET /liveness_check` until it returns `2xx`, waiting up to 5 minutes,
- is **best-effort** — it never fails the job (warns instead); the test step stays the gate.

So the test step now exercises warm workers.

## Out of scope

This makes the test reliable but does not change the underlying cold-start latency; a real Modal outage would still brown out for ~1.5–3.5 minutes while fallback workers spin up. Reducing that (startup CPU boost, smaller worker image, or `min-instances=1` during an active cutover) is a separate follow-up before any production traffic cutover.

## Testing

- `make format-check` (whole repo) — pass
- `python -c "import yaml; ..."` — workflow parses; step order is `Force → Warm → Run tests → Restore`
- `bash -n` on the embedded warm-up script — clean
- Workflow-only change (no Python touched); the real validation is the next release run's forced-fallback job. `make test` not re-run locally for this YAML-only change — relying on PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)