### PR TITLE
Warm Modal worker before gateway tests and raise gateway Modal timeout to 90s

### DIFF
--- a/.github/scripts/cloud-run-warm-modal-via-gateway.sh
+++ b/.github/scripts/cloud-run-warm-modal-via-gateway.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Warm the Modal worker behind the Cloud Run gateway before the gateway's
+# Modal-primary integration tests.
+#
+# The Modal workers scale to zero shortly after a deploy, so the first
+# /us/calculate routed through the gateway pays a cold start (container boot +
+# country model load) that can exceed the gateway's Modal request timeout and
+# return 503. This sends a real authenticated calculate through the gateway for
+# the channel under test and waits until it returns 200, so the test step then
+# exercises a warm worker over the same path it asserts on.
+#
+# It must be a full authenticated calculate (not a liveness ping): the cold cost
+# is loading the country model on the first real calculation, so a cheap request
+# would warm the container but not the calculation path the tests exercise.
+#
+# Best-effort: this never exits non-zero. A worker that cannot be warmed only
+# emits a warning; the deployed test step remains the gate.
+set -uo pipefail
+
+channel="${1:?Usage: cloud-run-warm-modal-via-gateway.sh CHANNEL}"
+curl_bin="${CURL_BIN:-curl}"
+
+base_url="${HOUSEHOLD_API_BASE_URL:-}"
+auth_token="${HOUSEHOLD_API_AUTH_TOKEN:-}"
+total_timeout="${HOUSEHOLD_GATEWAY_WARM_TIMEOUT_SECONDS:-300}"
+attempt_timeout="${HOUSEHOLD_GATEWAY_WARM_ATTEMPT_TIMEOUT_SECONDS:-120}"
+
+if [ -z "${base_url}" ] || [ -z "${auth_token}" ]; then
+  echo "::warning::HOUSEHOLD_API_BASE_URL and HOUSEHOLD_API_AUTH_TOKEN are required to warm the gateway; skipping."
+  exit 0
+fi
+
+url="${base_url%/}/us/calculate"
+
+# Minimal but valid US calculation. The "version" field is read by the gateway
+# to route to the channel under test (channel-name routing), then stripped
+# before the request reaches the worker.
+body="$(
+  cat <<JSON
+{"version":"${channel}","household":{"people":{"parent":{"age":{"2026":35},"employment_income":{"2026":60000}},"child":{"age":{"2026":6}}},"tax_units":{"tax_unit":{"members":["parent","child"],"ctc":{"2026":null}}},"spm_units":{"spm_unit":{"members":["parent","child"]}},"households":{"household":{"members":["parent","child"],"state_name":{"2026":"AZ"}}}}}
+JSON
+)"
+
+echo "Warming Modal ${channel} worker through ${url} (up to ${total_timeout}s)..."
+deadline=$(( $(date +%s) + total_timeout ))
+while :; do
+  code="$(
+    "${curl_bin}" -sS -o /dev/null -w '%{http_code}' \
+      --max-time "${attempt_timeout}" \
+      -X POST \
+      -H "Authorization: Bearer ${auth_token}" \
+      -H "Content-Type: application/json" \
+      -d "${body}" \
+      "${url}" || true
+  )"
+  case "${code}" in
+    2*)
+      echo "Modal ${channel} worker is warm (HTTP ${code})."
+      exit 0
+      ;;
+  esac
+  if [ "$(date +%s)" -ge "${deadline}" ]; then
+    echo "::warning::Modal ${channel} worker did not return 2xx within ${total_timeout}s (last HTTP ${code:-none}); continuing to tests anyway."
+    exit 0
+  fi
+  echo "Modal ${channel} not warm yet (HTTP ${code:-timeout}); retrying..."
+  sleep 5
+done

--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -323,6 +323,14 @@ jobs:
           AUTH0_TEST_TOKEN_SCOPES: ${{ secrets.AUTH0_TEST_TOKEN_SCOPES }}
         run: python .github/scripts/fetch_auth0_test_token.py
 
+      - name: Warm Modal worker through the gateway
+        # The Modal workers scale to zero shortly after a deploy, so the first
+        # calculate routed through the gateway pays a cold start that can exceed
+        # the gateway's Modal request timeout and 503. Warm the channel under
+        # test first so the test step exercises a warm worker. Best-effort; the
+        # test step remains the gate. See the script for details.
+        run: bash .github/scripts/cloud-run-warm-modal-via-gateway.sh "${{ matrix.channel }}"
+
       - name: Run deployed integration tests for route
         run: |
           bash .github/scripts/run-deployed-tests-for-modal-route.sh \

--- a/changelog.d/1560.fixed.md
+++ b/changelog.d/1560.fixed.md
@@ -1,0 +1,1 @@
+Raise the Cloud Run gateway's Modal request timeout to 90 seconds so a cold Modal worker's first calculation is no longer cut off and returned as a 503, and warm the Modal worker through the gateway before the staging gateway integration tests so they exercise a warm backend.

--- a/policyengine_household_api/failover/cloud_run_gateway.py
+++ b/policyengine_household_api/failover/cloud_run_gateway.py
@@ -65,7 +65,10 @@ MODAL_STATUS_CHECK_MIN_INTERVAL_SECONDS = 60
 MODAL_MIN_OPEN_SECONDS = 60.0
 MODAL_RECOVERY_SUCCESSES = 3
 MANIFEST_CACHE_SECONDS = 30
-MODAL_REQUEST_TIMEOUT_SECONDS = 30.0
+# Long enough to absorb a cold Modal worker's first response (container boot +
+# country model load), which can take tens of seconds, without converting a
+# slow-but-healthy calculation into a 503. Probe/canary timeouts stay short.
+MODAL_REQUEST_TIMEOUT_SECONDS = 90.0
 MODAL_PROBE_TIMEOUT_SECONDS = 5.0
 MODAL_CANARY_TIMEOUT_SECONDS = 5.0
 CLOUD_RUN_WORKER_TIMEOUT_SECONDS = 180.0


### PR DESCRIPTION
Fixes #1560

## Problem

The four **Integration tests against Cloud Run staging** jobs fail when they route `POST /us/calculate` through the Cloud Run gateway: the gateway returns `503 backend_unavailable` (`x-policyengine-backend: none`) while `x-policyengine-primary-state: healthy`. Direct-Modal tests and gateway-served endpoints (`/liveness_check`, `/versions`, …) pass.

Root cause (full evidence in #1560): staging Modal workers run at `min_containers=0`/`scaledown_window=300`, so they go cold ~5 min after the direct-Modal tests. The gateway caps each proxied Modal call at `MODAL_REQUEST_TIMEOUT_SECONDS = 30s`; a cold worker's first calculation (one-time country-model load — ~74s locally, a snapshot restore on Modal but still tens of seconds) exceeds 30s, so the gateway times out and 503s. Failover is canary-gated and Modal's canary stayed healthy, so the gateway correctly did not fail over — it just 503'd the slow calls. In the same window the gateway served its own routes in ~3ms while blocking 30s on the Modal hop, so the latency is the Modal worker, not the gateway. Once warm, the calculation is ~0.07s (~3.7s end-to-end through the gateway).

## Changes

- **Raise the gateway's Modal request timeout to 90s** (`MODAL_REQUEST_TIMEOUT_SECONDS`, applied to staging and prod via the shared default). 90s sits far above the worst realistic cold restore and ~25× above a warm call, without being high enough to mask a genuine hang. Probe/canary timeouts are unchanged.
- **Pre-warm the worker before the staging gateway integration tests.** New best-effort script `.github/scripts/cloud-run-warm-modal-via-gateway.sh` sends an authenticated `/us/calculate` through the gateway for the channel under test and waits for a 200; wired in as a step before the test run. It must be a real calculate (not a liveness ping): the cold cost is the model load on the first calculation, and the gateway serves its own liveness locally without touching Modal. The script never fails the build — the test step stays the gate.

Production Modal workers are already kept warm (`min_containers=3`, `buffer_containers=2`, `scaledown_window=600`), so this primarily hardens staging-after-deploy and gives a small production cushion for the first post-idle request on a low-traffic channel. No change to Modal worker keep-warm config.

This stays within the documented Cloud Run failover exception: it does not change how the Modal gateway serves current/frontier traffic, and Modal remains primary. No `policyengine_us`/`policyengine_uk` version change, so no `modal_release` block.

## Verification

- New warm script validated on bash 3.2 (warm / cold-then-warm / missing-env), and its request JSON parses.
- `make format-check` clean; failover unit suite (47) passes; warm-path behavior measured (warm calc ~0.07s; cold model load ~74s).
