### PR TITLE
Return 422 for inactive exact version selectors

### DIFF
--- a/.github/scripts/cloud_run_failover_channels.py
+++ b/.github/scripts/cloud_run_failover_channels.py
@@ -8,7 +8,6 @@ from typing import Any, Mapping
 import modal
 
 from policyengine_household_api.failover.manifest import (
-    FAILOVER_CHANNELS,
     build_failover_manifest,
 )
 from policyengine_household_api.modal_release.manifest import (
@@ -16,6 +15,7 @@ from policyengine_household_api.modal_release.manifest import (
     MANIFEST_DICT_NAME,
     require_active_current_and_frontier,
 )
+from policyengine_household_api.version_config import ACTIVE_RELEASE_CHANNELS
 
 
 def active_failover_channels(
@@ -23,7 +23,7 @@ def active_failover_channels(
 ) -> list[dict[str, Any]]:
     manifest = require_active_current_and_frontier(modal_manifest)
     channels = []
-    for channel in FAILOVER_CHANNELS:
+    for channel in ACTIVE_RELEASE_CHANNELS:
         reference = manifest[channel]
         channels.append(
             {
@@ -55,7 +55,7 @@ def parse_worker_urls(values: list[str] | None) -> dict[str, str]:
         channel, separator, url = value.partition("=")
         if separator != "=" or not channel or not url:
             raise ValueError("--worker-url values must use CHANNEL=URL format")
-        if channel not in FAILOVER_CHANNELS:
+        if channel not in ACTIVE_RELEASE_CHANNELS:
             raise ValueError(f"Unsupported failover channel: {channel}")
         if channel in worker_urls:
             raise ValueError(f"Duplicate worker URL for channel: {channel}")

--- a/.github/scripts/test_cloud_run_failover_channels.py
+++ b/.github/scripts/test_cloud_run_failover_channels.py
@@ -75,7 +75,7 @@ def test_build_manifest_for_worker_urls_preserves_modal_metadata():
     )
 
 
-def test_build_manifest_for_worker_urls_preserves_retired_metadata():
+def test_build_manifest_for_worker_urls_omits_retired_metadata():
     module = _load_script_module()
     modal_manifest = _modal_manifest()
     modal_manifest["retired"] = [
@@ -97,15 +97,7 @@ def test_build_manifest_for_worker_urls_preserves_retired_metadata():
         },
     )
 
-    assert manifest["retired"] == [
-        {
-            "modal_app_name": "modal-retired",
-            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
-            "deployed_at": "2025-12-25T00:00:00+00:00",
-            "retired_at": "2026-01-01T00:00:00+00:00",
-            "retirement_reason": "replaced-current",
-        }
-    ]
+    assert "retired" not in manifest
 
 
 def test_parse_worker_urls_rejects_bad_values():

--- a/.github/scripts/test_cloud_run_failover_channels.py
+++ b/.github/scripts/test_cloud_run_failover_channels.py
@@ -75,6 +75,39 @@ def test_build_manifest_for_worker_urls_preserves_modal_metadata():
     )
 
 
+def test_build_manifest_for_worker_urls_preserves_retired_metadata():
+    module = _load_script_module()
+    modal_manifest = _modal_manifest()
+    modal_manifest["retired"] = [
+        {
+            "app_name": "modal-retired",
+            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
+            "deployed_at": "2025-12-25T00:00:00+00:00",
+            "retired_at": "2026-01-01T00:00:00+00:00",
+            "retirement_reason": "replaced-current",
+        }
+    ]
+
+    manifest = module.build_manifest_for_worker_urls(
+        environment="staging",
+        modal_manifest=modal_manifest,
+        worker_urls={
+            "current": "https://current.run.app",
+            "frontier": "https://frontier.run.app",
+        },
+    )
+
+    assert manifest["retired"] == [
+        {
+            "modal_app_name": "modal-retired",
+            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
+            "deployed_at": "2025-12-25T00:00:00+00:00",
+            "retired_at": "2026-01-01T00:00:00+00:00",
+            "retirement_reason": "replaced-current",
+        }
+    ]
+
+
 def test_parse_worker_urls_rejects_bad_values():
     module = _load_script_module()
 

--- a/changelog.d/version-routing-422.changed.md
+++ b/changelog.d/version-routing-422.changed.md
@@ -1,0 +1,1 @@
+Return 422 responses when calculate requests specify deprecated or unsupported exact package versions.

--- a/policyengine_household_api/failover/cloud_run_gateway.py
+++ b/policyengine_household_api/failover/cloud_run_gateway.py
@@ -36,7 +36,6 @@ from policyengine_household_api.failover.request_limits import (
     max_content_length_bytes,
 )
 from policyengine_household_api.modal_release.gateway import (
-    GatewayResolutionError,
     VERSIONED_ENDPOINTS,
     _country_and_endpoint,
     _extract_requested_version,
@@ -44,6 +43,7 @@ from policyengine_household_api.modal_release.gateway import (
     _request_payload,
     _response_from_dispatch_result,
 )
+from policyengine_household_api.version_routing import VersionRoutingError
 
 
 LOGGER = logging.getLogger(__name__)
@@ -487,7 +487,7 @@ def create_gateway_app(
             )
         except FailoverManifestUnavailable as exc:
             return _gateway_unavailable_response(str(exc))
-        except (FailoverRoutingError, GatewayResolutionError) as exc:
+        except (FailoverRoutingError, VersionRoutingError) as exc:
             return _json_error(
                 str(exc),
                 getattr(exc, "status_code", 400),

--- a/policyengine_household_api/failover/cloud_run_gateway.py
+++ b/policyengine_household_api/failover/cloud_run_gateway.py
@@ -488,7 +488,14 @@ def create_gateway_app(
         except FailoverManifestUnavailable as exc:
             return _gateway_unavailable_response(str(exc))
         except (FailoverRoutingError, GatewayResolutionError) as exc:
-            return _json_error(str(exc), 400)
+            return _json_error(
+                str(exc),
+                getattr(exc, "status_code", 400),
+                code=getattr(exc, "code", None),
+                requested_version=getattr(exc, "requested_version", None),
+                country_id=getattr(exc, "country_id", None),
+                available_versions=getattr(exc, "available_versions", None),
+            )
 
     return app
 

--- a/policyengine_household_api/failover/manifest.py
+++ b/policyengine_household_api/failover/manifest.py
@@ -22,11 +22,21 @@ CHANNEL_OPTIONAL_KEYS = {
     "analytics_database_revision",
 }
 CHANNEL_KEYS = CHANNEL_REQUIRED_KEYS | CHANNEL_OPTIONAL_KEYS
+RETIRED_REQUIRED_KEYS = {
+    "modal_app_name",
+    "package_versions",
+}
+RETIRED_OPTIONAL_KEYS = CHANNEL_OPTIONAL_KEYS | {
+    "retired_at",
+    "retirement_reason",
+}
+RETIRED_KEYS = RETIRED_REQUIRED_KEYS | RETIRED_OPTIONAL_KEYS
 MANIFEST_KEYS = {
     "schema_version",
     "environment",
     "generated_at",
     "channels",
+    "retired",
 }
 
 
@@ -52,7 +62,67 @@ class FailoverManifestReadError(FailoverManifestUnavailable):
 
 
 class FailoverRoutingError(FailoverManifestError):
-    pass
+    status_code: int = 400
+    code: str | None = None
+    requested_version: str | None = None
+    country_id: str | None = None
+    available_versions: dict[str, str] | None = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+        requested_version: str | None = None,
+        country_id: str | None = None,
+        available_versions: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+        self.code = code
+        self.requested_version = requested_version
+        self.country_id = country_id
+        self.available_versions = available_versions
+
+
+class UnsupportedFailoverVersionError(FailoverRoutingError):
+    def __init__(
+        self,
+        *,
+        country_id: str,
+        requested_version: str,
+        available_versions: dict[str, str],
+    ) -> None:
+        super().__init__(
+            f"No active failover channel serves `{country_id}` package "
+            f"version `{requested_version}`",
+            status_code=422,
+            code="unsupported_version",
+            requested_version=requested_version,
+            country_id=country_id,
+            available_versions=available_versions,
+        )
+
+
+class DeprecatedFailoverVersionError(FailoverRoutingError):
+    def __init__(
+        self,
+        *,
+        country_id: str,
+        requested_version: str,
+        available_versions: dict[str, str],
+    ) -> None:
+        super().__init__(
+            f"Household API `{country_id}` package version "
+            f"`{requested_version}` is deprecated",
+            status_code=422,
+            code="deprecated_version",
+            requested_version=requested_version,
+            country_id=country_id,
+            available_versions=available_versions,
+        )
 
 
 def current_timestamp() -> str:
@@ -96,6 +166,9 @@ def validate_failover_manifest(
                 reference,
             )
     validated["channels"] = validated_channels
+    validated["retired"] = _validate_retired_references(
+        validated.get("retired", []),
+    )
     return validated
 
 
@@ -124,12 +197,15 @@ def build_failover_manifest(
                 channel_reference[key] = value
         channels[channel] = channel_reference
 
+    retired = _retired_references(modal_manifest.get("retired", []))
+
     return validate_failover_manifest(
         {
             "schema_version": FAILOVER_MANIFEST_SCHEMA_VERSION,
             "environment": environment,
             "generated_at": generated_at or current_timestamp(),
             "channels": channels,
+            "retired": retired,
         }
     )
 
@@ -164,9 +240,18 @@ def resolve_failover_channel_for_request(
         if reference["package_versions"].get(country_id) == requested:
             return _resolved_channel(channel, requested, reference)
 
-    raise FailoverRoutingError(
-        f"No active failover channel serves `{country_id}` package "
-        f"version `{requested}`"
+    available_versions = _available_versions(channels, country_id)
+    if _retired_version_exists(validated["retired"], country_id, requested):
+        raise DeprecatedFailoverVersionError(
+            country_id=country_id,
+            requested_version=requested,
+            available_versions=available_versions,
+        )
+
+    raise UnsupportedFailoverVersionError(
+        country_id=country_id,
+        requested_version=requested,
+        available_versions=available_versions,
     )
 
 
@@ -230,17 +315,55 @@ def _validate_channel_reference(
         raise FailoverManifestError(
             f"Failover channel `{channel}` package_versions must be a mapping"
         )
-    validated["package_versions"] = {
-        country: version
-        for country, version in package_versions.items()
-        if isinstance(country, str)
-        and isinstance(version, str)
-        and country
-        and version
-    }
+    validated["package_versions"] = _package_versions(package_versions)
     if not validated["package_versions"]:
         raise FailoverManifestError(
             f"Failover channel `{channel}` has no package versions"
+        )
+    return validated
+
+
+def _validate_retired_references(references: Any) -> list[dict[str, Any]]:
+    if not isinstance(references, list):
+        raise FailoverManifestError("Failover manifest retired is invalid")
+
+    retired = []
+    for reference in references:
+        retired.append(_validate_retired_reference(reference))
+    return retired
+
+
+def _validate_retired_reference(reference: Any) -> dict[str, Any]:
+    if not isinstance(reference, Mapping):
+        raise FailoverManifestError(
+            "Failover retired channel must be a mapping"
+        )
+
+    validated = deepcopy(dict(reference))
+    _validate_keys(validated, RETIRED_KEYS, "Failover retired channel")
+    missing = RETIRED_REQUIRED_KEYS - validated.keys()
+    if missing:
+        raise FailoverManifestError(
+            f"Failover retired channel is missing: {sorted(missing)}"
+        )
+
+    if (
+        not isinstance(validated["modal_app_name"], str)
+        or not validated["modal_app_name"]
+    ):
+        raise FailoverManifestError(
+            "Failover retired channel has invalid `modal_app_name`"
+        )
+
+    package_versions = validated["package_versions"]
+    if not isinstance(package_versions, Mapping):
+        raise FailoverManifestError(
+            "Failover retired channel package_versions must be a mapping"
+        )
+    validated["package_versions"] = _package_versions(package_versions)
+    if not validated["package_versions"]:
+        raise FailoverManifestError(
+            "Failover retired channel has no package versions"
         )
     return validated
 
@@ -255,6 +378,71 @@ def _validate_keys(
         raise FailoverManifestError(
             f"{label} contains unsupported keys: {sorted(extra)}"
         )
+
+
+def _available_versions(
+    channels: Mapping[str, dict[str, Any] | None],
+    country_id: str,
+) -> dict[str, str]:
+    available_versions = {}
+    for channel in FAILOVER_CHANNELS:
+        reference = channels.get(channel)
+        if not reference:
+            continue
+        package_version = reference["package_versions"].get(country_id)
+        if package_version:
+            available_versions[channel] = package_version
+    return available_versions
+
+
+def _retired_version_exists(
+    references: list[dict[str, Any]],
+    country_id: str,
+    requested_version: str,
+) -> bool:
+    for reference in references:
+        if reference["package_versions"].get(country_id) == requested_version:
+            return True
+    return False
+
+
+def _retired_references(references: Any) -> list[dict[str, Any]]:
+    retired = []
+    if not isinstance(references, list):
+        return retired
+
+    for reference in references:
+        if not isinstance(reference, Mapping):
+            continue
+        modal_app_name = reference.get("app_name")
+        if not isinstance(modal_app_name, str) or not modal_app_name:
+            continue
+        package_versions = _package_versions(
+            reference.get("package_versions", {}),
+        )
+        if not package_versions:
+            continue
+        retired_reference = {
+            "modal_app_name": modal_app_name,
+            "package_versions": package_versions,
+        }
+        for key in RETIRED_OPTIONAL_KEYS:
+            value = reference.get(key)
+            if value:
+                retired_reference[key] = value
+        retired.append(retired_reference)
+    return retired
+
+
+def _package_versions(package_versions: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        country: version
+        for country, version in package_versions.items()
+        if isinstance(country, str)
+        and isinstance(version, str)
+        and country
+        and version
+    }
 
 
 def _resolved_channel(

--- a/policyengine_household_api/failover/manifest.py
+++ b/policyengine_household_api/failover/manifest.py
@@ -5,11 +5,20 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
+from policyengine_household_api.version_routing import (
+    DeprecatedVersionError,
+    UnsupportedVersionError,
+    VERSION_CHANNELS,
+    active_versions_for_country,
+    package_versions_from_mapping,
+    retired_version_exists,
+)
+
 
 FAILOVER_MANIFEST_SCHEMA_VERSION = 1
 FAILOVER_MANIFEST_BUCKET_ENV = "HOUSEHOLD_FAILOVER_MANIFEST_BUCKET"
 FAILOVER_MANIFEST_BLOB_ENV = "HOUSEHOLD_FAILOVER_MANIFEST_BLOB"
-FAILOVER_CHANNELS = ("current", "frontier")
+FAILOVER_CHANNELS = VERSION_CHANNELS
 
 CHANNEL_REQUIRED_KEYS = {
     "modal_app_name",
@@ -62,67 +71,7 @@ class FailoverManifestReadError(FailoverManifestUnavailable):
 
 
 class FailoverRoutingError(FailoverManifestError):
-    status_code: int = 400
-    code: str | None = None
-    requested_version: str | None = None
-    country_id: str | None = None
-    available_versions: dict[str, str] | None = None
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        status_code: int | None = None,
-        code: str | None = None,
-        requested_version: str | None = None,
-        country_id: str | None = None,
-        available_versions: dict[str, str] | None = None,
-    ) -> None:
-        super().__init__(message)
-        if status_code is not None:
-            self.status_code = status_code
-        self.code = code
-        self.requested_version = requested_version
-        self.country_id = country_id
-        self.available_versions = available_versions
-
-
-class UnsupportedFailoverVersionError(FailoverRoutingError):
-    def __init__(
-        self,
-        *,
-        country_id: str,
-        requested_version: str,
-        available_versions: dict[str, str],
-    ) -> None:
-        super().__init__(
-            f"No active failover channel serves `{country_id}` package "
-            f"version `{requested_version}`",
-            status_code=422,
-            code="unsupported_version",
-            requested_version=requested_version,
-            country_id=country_id,
-            available_versions=available_versions,
-        )
-
-
-class DeprecatedFailoverVersionError(FailoverRoutingError):
-    def __init__(
-        self,
-        *,
-        country_id: str,
-        requested_version: str,
-        available_versions: dict[str, str],
-    ) -> None:
-        super().__init__(
-            f"Household API `{country_id}` package version "
-            f"`{requested_version}` is deprecated",
-            status_code=422,
-            code="deprecated_version",
-            requested_version=requested_version,
-            country_id=country_id,
-            available_versions=available_versions,
-        )
+    pass
 
 
 def current_timestamp() -> str:
@@ -240,18 +189,23 @@ def resolve_failover_channel_for_request(
         if reference["package_versions"].get(country_id) == requested:
             return _resolved_channel(channel, requested, reference)
 
-    available_versions = _available_versions(channels, country_id)
-    if _retired_version_exists(validated["retired"], country_id, requested):
-        raise DeprecatedFailoverVersionError(
+    available_versions = active_versions_for_country(
+        channels,
+        country_id,
+        FAILOVER_CHANNELS,
+    )
+    if retired_version_exists(validated["retired"], country_id, requested):
+        raise DeprecatedVersionError(
             country_id=country_id,
             requested_version=requested,
             available_versions=available_versions,
         )
 
-    raise UnsupportedFailoverVersionError(
+    raise UnsupportedVersionError(
         country_id=country_id,
         requested_version=requested,
         available_versions=available_versions,
+        active_target_label="failover channel",
     )
 
 
@@ -315,7 +269,9 @@ def _validate_channel_reference(
         raise FailoverManifestError(
             f"Failover channel `{channel}` package_versions must be a mapping"
         )
-    validated["package_versions"] = _package_versions(package_versions)
+    validated["package_versions"] = package_versions_from_mapping(
+        package_versions
+    )
     if not validated["package_versions"]:
         raise FailoverManifestError(
             f"Failover channel `{channel}` has no package versions"
@@ -360,7 +316,9 @@ def _validate_retired_reference(reference: Any) -> dict[str, Any]:
         raise FailoverManifestError(
             "Failover retired channel package_versions must be a mapping"
         )
-    validated["package_versions"] = _package_versions(package_versions)
+    validated["package_versions"] = package_versions_from_mapping(
+        package_versions
+    )
     if not validated["package_versions"]:
         raise FailoverManifestError(
             "Failover retired channel has no package versions"
@@ -380,32 +338,6 @@ def _validate_keys(
         )
 
 
-def _available_versions(
-    channels: Mapping[str, dict[str, Any] | None],
-    country_id: str,
-) -> dict[str, str]:
-    available_versions = {}
-    for channel in FAILOVER_CHANNELS:
-        reference = channels.get(channel)
-        if not reference:
-            continue
-        package_version = reference["package_versions"].get(country_id)
-        if package_version:
-            available_versions[channel] = package_version
-    return available_versions
-
-
-def _retired_version_exists(
-    references: list[dict[str, Any]],
-    country_id: str,
-    requested_version: str,
-) -> bool:
-    for reference in references:
-        if reference["package_versions"].get(country_id) == requested_version:
-            return True
-    return False
-
-
 def _retired_references(references: Any) -> list[dict[str, Any]]:
     retired = []
     if not isinstance(references, list):
@@ -417,7 +349,7 @@ def _retired_references(references: Any) -> list[dict[str, Any]]:
         modal_app_name = reference.get("app_name")
         if not isinstance(modal_app_name, str) or not modal_app_name:
             continue
-        package_versions = _package_versions(
+        package_versions = package_versions_from_mapping(
             reference.get("package_versions", {}),
         )
         if not package_versions:
@@ -432,17 +364,6 @@ def _retired_references(references: Any) -> list[dict[str, Any]]:
                 retired_reference[key] = value
         retired.append(retired_reference)
     return retired
-
-
-def _package_versions(package_versions: Mapping[str, Any]) -> dict[str, str]:
-    return {
-        country: version
-        for country, version in package_versions.items()
-        if isinstance(country, str)
-        and isinstance(version, str)
-        and country
-        and version
-    }
 
 
 def _resolved_channel(

--- a/policyengine_household_api/failover/manifest.py
+++ b/policyengine_household_api/failover/manifest.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
+from policyengine_household_api.version_config import ACTIVE_RELEASE_CHANNELS
 from policyengine_household_api.version_routing import (
     UnsupportedVersionError,
-    VERSION_CHANNELS,
     active_versions_for_country,
     package_versions_from_mapping,
 )
@@ -16,7 +16,6 @@ from policyengine_household_api.version_routing import (
 FAILOVER_MANIFEST_SCHEMA_VERSION = 1
 FAILOVER_MANIFEST_BUCKET_ENV = "HOUSEHOLD_FAILOVER_MANIFEST_BUCKET"
 FAILOVER_MANIFEST_BLOB_ENV = "HOUSEHOLD_FAILOVER_MANIFEST_BLOB"
-FAILOVER_CHANNELS = VERSION_CHANNELS
 
 CHANNEL_REQUIRED_KEYS = {
     "modal_app_name",
@@ -93,7 +92,7 @@ def validate_failover_manifest(
         raise FailoverManifestError("Failover manifest channels are invalid")
 
     validated_channels = {}
-    for channel in FAILOVER_CHANNELS:
+    for channel in ACTIVE_RELEASE_CHANNELS:
         reference = channels.get(channel)
         if reference is None:
             validated_channels[channel] = None
@@ -114,7 +113,7 @@ def build_failover_manifest(
     generated_at: str | None = None,
 ) -> dict[str, Any]:
     channels: dict[str, dict[str, Any] | None] = {}
-    for channel in FAILOVER_CHANNELS:
+    for channel in ACTIVE_RELEASE_CHANNELS:
         modal_reference = modal_manifest.get(channel)
         if not modal_reference:
             channels[channel] = None
@@ -151,7 +150,7 @@ def resolve_failover_channel_for_request(
     requested = requested_version or "current"
     channels = validated["channels"]
 
-    if requested in FAILOVER_CHANNELS:
+    if requested in ACTIVE_RELEASE_CHANNELS:
         reference = channels.get(requested)
         if not reference:
             raise FailoverManifestUnavailable(
@@ -164,7 +163,7 @@ def resolve_failover_channel_for_request(
             "Exact package version routing requires a country endpoint"
         )
 
-    for channel in FAILOVER_CHANNELS:
+    for channel in ACTIVE_RELEASE_CHANNELS:
         reference = channels.get(channel)
         if not reference:
             continue
@@ -174,7 +173,7 @@ def resolve_failover_channel_for_request(
     available_versions = active_versions_for_country(
         channels,
         country_id,
-        FAILOVER_CHANNELS,
+        ACTIVE_RELEASE_CHANNELS,
     )
     raise UnsupportedVersionError(
         country_id=country_id,
@@ -197,7 +196,7 @@ def public_versions_view(manifest: Mapping[str, Any]) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "schema_version": validated["schema_version"],
     }
-    for channel in FAILOVER_CHANNELS:
+    for channel in ACTIVE_RELEASE_CHANNELS:
         reference = validated["channels"].get(channel)
         payload[channel] = (
             _public_channel_view(reference) if reference else None

--- a/policyengine_household_api/failover/manifest.py
+++ b/policyengine_household_api/failover/manifest.py
@@ -6,12 +6,10 @@ from datetime import datetime, timezone
 from typing import Any, Mapping
 
 from policyengine_household_api.version_routing import (
-    DeprecatedVersionError,
     UnsupportedVersionError,
     VERSION_CHANNELS,
     active_versions_for_country,
     package_versions_from_mapping,
-    retired_version_exists,
 )
 
 
@@ -31,21 +29,11 @@ CHANNEL_OPTIONAL_KEYS = {
     "analytics_database_revision",
 }
 CHANNEL_KEYS = CHANNEL_REQUIRED_KEYS | CHANNEL_OPTIONAL_KEYS
-RETIRED_REQUIRED_KEYS = {
-    "modal_app_name",
-    "package_versions",
-}
-RETIRED_OPTIONAL_KEYS = CHANNEL_OPTIONAL_KEYS | {
-    "retired_at",
-    "retirement_reason",
-}
-RETIRED_KEYS = RETIRED_REQUIRED_KEYS | RETIRED_OPTIONAL_KEYS
 MANIFEST_KEYS = {
     "schema_version",
     "environment",
     "generated_at",
     "channels",
-    "retired",
 }
 
 
@@ -115,9 +103,6 @@ def validate_failover_manifest(
                 reference,
             )
     validated["channels"] = validated_channels
-    validated["retired"] = _validate_retired_references(
-        validated.get("retired", []),
-    )
     return validated
 
 
@@ -146,15 +131,12 @@ def build_failover_manifest(
                 channel_reference[key] = value
         channels[channel] = channel_reference
 
-    retired = _retired_references(modal_manifest.get("retired", []))
-
     return validate_failover_manifest(
         {
             "schema_version": FAILOVER_MANIFEST_SCHEMA_VERSION,
             "environment": environment,
             "generated_at": generated_at or current_timestamp(),
             "channels": channels,
-            "retired": retired,
         }
     )
 
@@ -194,13 +176,6 @@ def resolve_failover_channel_for_request(
         country_id,
         FAILOVER_CHANNELS,
     )
-    if retired_version_exists(validated["retired"], country_id, requested):
-        raise DeprecatedVersionError(
-            country_id=country_id,
-            requested_version=requested,
-            available_versions=available_versions,
-        )
-
     raise UnsupportedVersionError(
         country_id=country_id,
         requested_version=requested,
@@ -279,53 +254,6 @@ def _validate_channel_reference(
     return validated
 
 
-def _validate_retired_references(references: Any) -> list[dict[str, Any]]:
-    if not isinstance(references, list):
-        raise FailoverManifestError("Failover manifest retired is invalid")
-
-    retired = []
-    for reference in references:
-        retired.append(_validate_retired_reference(reference))
-    return retired
-
-
-def _validate_retired_reference(reference: Any) -> dict[str, Any]:
-    if not isinstance(reference, Mapping):
-        raise FailoverManifestError(
-            "Failover retired channel must be a mapping"
-        )
-
-    validated = deepcopy(dict(reference))
-    _validate_keys(validated, RETIRED_KEYS, "Failover retired channel")
-    missing = RETIRED_REQUIRED_KEYS - validated.keys()
-    if missing:
-        raise FailoverManifestError(
-            f"Failover retired channel is missing: {sorted(missing)}"
-        )
-
-    if (
-        not isinstance(validated["modal_app_name"], str)
-        or not validated["modal_app_name"]
-    ):
-        raise FailoverManifestError(
-            "Failover retired channel has invalid `modal_app_name`"
-        )
-
-    package_versions = validated["package_versions"]
-    if not isinstance(package_versions, Mapping):
-        raise FailoverManifestError(
-            "Failover retired channel package_versions must be a mapping"
-        )
-    validated["package_versions"] = package_versions_from_mapping(
-        package_versions
-    )
-    if not validated["package_versions"]:
-        raise FailoverManifestError(
-            "Failover retired channel has no package versions"
-        )
-    return validated
-
-
 def _validate_keys(
     mapping: Mapping[str, Any],
     allowed: set[str],
@@ -336,34 +264,6 @@ def _validate_keys(
         raise FailoverManifestError(
             f"{label} contains unsupported keys: {sorted(extra)}"
         )
-
-
-def _retired_references(references: Any) -> list[dict[str, Any]]:
-    retired = []
-    if not isinstance(references, list):
-        return retired
-
-    for reference in references:
-        if not isinstance(reference, Mapping):
-            continue
-        modal_app_name = reference.get("app_name")
-        if not isinstance(modal_app_name, str) or not modal_app_name:
-            continue
-        package_versions = package_versions_from_mapping(
-            reference.get("package_versions", {}),
-        )
-        if not package_versions:
-            continue
-        retired_reference = {
-            "modal_app_name": modal_app_name,
-            "package_versions": package_versions,
-        }
-        for key in RETIRED_OPTIONAL_KEYS:
-            value = reference.get(key)
-            if value:
-                retired_reference[key] = value
-        retired.append(retired_reference)
-    return retired
 
 
 def _resolved_channel(

--- a/policyengine_household_api/modal_release/gateway.py
+++ b/policyengine_household_api/modal_release/gateway.py
@@ -17,6 +17,14 @@ from policyengine_household_api.modal_release.routing_metadata import (
     MODAL_ROUTING_PAYLOAD_KEY,
     modal_routing_payload,
 )
+from policyengine_household_api.version_routing import (
+    DeprecatedVersionError,
+    UnsupportedVersionError,
+    VERSION_CHANNELS,
+    VersionRoutingError,
+    active_versions_for_country,
+    retired_version_exists,
+)
 
 
 VERSIONED_ENDPOINTS = {"calculate", "calculate_demo"}
@@ -29,68 +37,8 @@ class ResolvedApp:
     channel: str
 
 
-class GatewayResolutionError(ValueError):
-    status_code: int = 400
-    code: str | None = None
-    requested_version: str | None = None
-    country_id: str | None = None
-    available_versions: dict[str, str] | None = None
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        status_code: int | None = None,
-        code: str | None = None,
-        requested_version: str | None = None,
-        country_id: str | None = None,
-        available_versions: dict[str, str] | None = None,
-    ) -> None:
-        super().__init__(message)
-        if status_code is not None:
-            self.status_code = status_code
-        self.code = code
-        self.requested_version = requested_version
-        self.country_id = country_id
-        self.available_versions = available_versions
-
-
-class UnsupportedVersionError(GatewayResolutionError):
-    def __init__(
-        self,
-        *,
-        country_id: str,
-        requested_version: str,
-        available_versions: dict[str, str],
-    ) -> None:
-        super().__init__(
-            f"No active household API app serves `{country_id}` package "
-            f"version `{requested_version}`",
-            status_code=422,
-            code="unsupported_version",
-            requested_version=requested_version,
-            country_id=country_id,
-            available_versions=available_versions,
-        )
-
-
-class DeprecatedVersionError(GatewayResolutionError):
-    def __init__(
-        self,
-        *,
-        country_id: str,
-        requested_version: str,
-        available_versions: dict[str, str],
-    ) -> None:
-        super().__init__(
-            f"Household API `{country_id}` package version "
-            f"`{requested_version}` is deprecated",
-            status_code=422,
-            code="deprecated_version",
-            requested_version=requested_version,
-            country_id=country_id,
-            available_versions=available_versions,
-        )
+class GatewayResolutionError(VersionRoutingError):
+    pass
 
 
 def create_gateway_app(
@@ -129,7 +77,7 @@ def create_gateway_app(
 
         manifest = validate_manifest(load_manifest())
         country_versions = {}
-        for channel in ("current", "frontier"):
+        for channel in VERSION_CHANNELS:
             app_reference = manifest.get(channel)
             if not app_reference:
                 continue
@@ -166,7 +114,7 @@ def create_gateway_app(
                 resolved_app.app_name,
                 _request_payload(path, body, resolved_app),
             )
-        except GatewayResolutionError as e:
+        except VersionRoutingError as e:
             return _json_error(
                 str(e),
                 e.status_code,
@@ -218,7 +166,7 @@ def resolve_app_for_request(
             "Exact package version routing requires a country endpoint"
         )
 
-    for channel in ("current", "frontier"):
+    for channel in VERSION_CHANNELS:
         app_reference = manifest.get(channel)
         if not app_reference:
             continue
@@ -230,8 +178,10 @@ def resolve_app_for_request(
                 channel=channel,
             )
 
-    available_versions = _available_versions(manifest, country_id)
-    if _retired_version_exists(manifest, country_id, requested):
+    available_versions = active_versions_for_country(manifest, country_id)
+    if retired_version_exists(
+        manifest.get("retired", []), country_id, requested
+    ):
         raise DeprecatedVersionError(
             country_id=country_id,
             requested_version=requested,
@@ -242,6 +192,7 @@ def resolve_app_for_request(
         country_id=country_id,
         requested_version=requested,
         available_versions=available_versions,
+        active_target_label="household API app",
     )
 
 
@@ -330,36 +281,6 @@ def _response_from_dispatch_result(result: dict[str, Any]) -> Response:
         status=int(result["status_code"]),
         headers=list(result.get("headers") or []),
     )
-
-
-def _available_versions(
-    manifest: dict[str, Any],
-    country_id: str,
-) -> dict[str, str]:
-    available_versions = {}
-    for channel in ("current", "frontier"):
-        app_reference = manifest.get(channel)
-        if not app_reference:
-            continue
-        package_version = app_reference["package_versions"].get(country_id)
-        if package_version:
-            available_versions[channel] = package_version
-    return available_versions
-
-
-def _retired_version_exists(
-    manifest: dict[str, Any],
-    country_id: str,
-    requested_version: str,
-) -> bool:
-    for app_reference in manifest.get("retired", []):
-        if not isinstance(app_reference, dict):
-            continue
-        if app_reference.get("package_versions", {}).get(country_id) == (
-            requested_version
-        ):
-            return True
-    return False
 
 
 def _json_error(

--- a/policyengine_household_api/modal_release/gateway.py
+++ b/policyengine_household_api/modal_release/gateway.py
@@ -17,9 +17,9 @@ from policyengine_household_api.modal_release.routing_metadata import (
     MODAL_ROUTING_PAYLOAD_KEY,
     modal_routing_payload,
 )
+from policyengine_household_api.version_config import ACTIVE_RELEASE_CHANNELS
 from policyengine_household_api.version_routing import (
     UnsupportedVersionError,
-    VERSION_CHANNELS,
     VersionRoutingError,
     active_versions_for_country,
 )
@@ -75,7 +75,7 @@ def create_gateway_app(
 
         manifest = validate_manifest(load_manifest())
         country_versions = {}
-        for channel in VERSION_CHANNELS:
+        for channel in ACTIVE_RELEASE_CHANNELS:
             app_reference = manifest.get(channel)
             if not app_reference:
                 continue
@@ -164,7 +164,7 @@ def resolve_app_for_request(
             "Exact package version routing requires a country endpoint"
         )
 
-    for channel in VERSION_CHANNELS:
+    for channel in ACTIVE_RELEASE_CHANNELS:
         app_reference = manifest.get(channel)
         if not app_reference:
             continue

--- a/policyengine_household_api/modal_release/gateway.py
+++ b/policyengine_household_api/modal_release/gateway.py
@@ -30,7 +30,67 @@ class ResolvedApp:
 
 
 class GatewayResolutionError(ValueError):
-    pass
+    status_code: int = 400
+    code: str | None = None
+    requested_version: str | None = None
+    country_id: str | None = None
+    available_versions: dict[str, str] | None = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+        requested_version: str | None = None,
+        country_id: str | None = None,
+        available_versions: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+        self.code = code
+        self.requested_version = requested_version
+        self.country_id = country_id
+        self.available_versions = available_versions
+
+
+class UnsupportedVersionError(GatewayResolutionError):
+    def __init__(
+        self,
+        *,
+        country_id: str,
+        requested_version: str,
+        available_versions: dict[str, str],
+    ) -> None:
+        super().__init__(
+            f"No active household API app serves `{country_id}` package "
+            f"version `{requested_version}`",
+            status_code=422,
+            code="unsupported_version",
+            requested_version=requested_version,
+            country_id=country_id,
+            available_versions=available_versions,
+        )
+
+
+class DeprecatedVersionError(GatewayResolutionError):
+    def __init__(
+        self,
+        *,
+        country_id: str,
+        requested_version: str,
+        available_versions: dict[str, str],
+    ) -> None:
+        super().__init__(
+            f"Household API `{country_id}` package version "
+            f"`{requested_version}` is deprecated",
+            status_code=422,
+            code="deprecated_version",
+            requested_version=requested_version,
+            country_id=country_id,
+            available_versions=available_versions,
+        )
 
 
 def create_gateway_app(
@@ -107,7 +167,14 @@ def create_gateway_app(
                 _request_payload(path, body, resolved_app),
             )
         except GatewayResolutionError as e:
-            return _json_error(str(e), 400)
+            return _json_error(
+                str(e),
+                e.status_code,
+                code=e.code,
+                requested_version=e.requested_version,
+                country_id=e.country_id,
+                available_versions=e.available_versions,
+            )
 
     return app
 
@@ -163,9 +230,18 @@ def resolve_app_for_request(
                 channel=channel,
             )
 
-    raise GatewayResolutionError(
-        f"No active household API app serves `{country_id}` package "
-        f"version `{requested}`"
+    available_versions = _available_versions(manifest, country_id)
+    if _retired_version_exists(manifest, country_id, requested):
+        raise DeprecatedVersionError(
+            country_id=country_id,
+            requested_version=requested,
+            available_versions=available_versions,
+        )
+
+    raise UnsupportedVersionError(
+        country_id=country_id,
+        requested_version=requested,
+        available_versions=available_versions,
     )
 
 
@@ -256,7 +332,54 @@ def _response_from_dispatch_result(result: dict[str, Any]) -> Response:
     )
 
 
-def _json_error(message: str, status: int) -> Response:
-    response = jsonify({"status": "error", "message": message})
+def _available_versions(
+    manifest: dict[str, Any],
+    country_id: str,
+) -> dict[str, str]:
+    available_versions = {}
+    for channel in ("current", "frontier"):
+        app_reference = manifest.get(channel)
+        if not app_reference:
+            continue
+        package_version = app_reference["package_versions"].get(country_id)
+        if package_version:
+            available_versions[channel] = package_version
+    return available_versions
+
+
+def _retired_version_exists(
+    manifest: dict[str, Any],
+    country_id: str,
+    requested_version: str,
+) -> bool:
+    for app_reference in manifest.get("retired", []):
+        if not isinstance(app_reference, dict):
+            continue
+        if app_reference.get("package_versions", {}).get(country_id) == (
+            requested_version
+        ):
+            return True
+    return False
+
+
+def _json_error(
+    message: str,
+    status: int,
+    *,
+    code: str | None = None,
+    requested_version: str | None = None,
+    country_id: str | None = None,
+    available_versions: dict[str, str] | None = None,
+) -> Response:
+    payload: dict[str, Any] = {"status": "error", "message": message}
+    if code is not None:
+        payload["code"] = code
+    if requested_version is not None:
+        payload["requested_version"] = requested_version
+    if country_id is not None:
+        payload["country_id"] = country_id
+    if available_versions is not None:
+        payload["available_versions"] = available_versions
+    response = jsonify(payload)
     response.status_code = status
     return response

--- a/policyengine_household_api/modal_release/gateway.py
+++ b/policyengine_household_api/modal_release/gateway.py
@@ -147,7 +147,7 @@ def resolve_app_for_request(
 ) -> ResolvedApp:
     requested = requested_version or "current"
 
-    if requested in {"current", "frontier"}:
+    if requested in ACTIVE_RELEASE_CHANNELS:
         app_reference = manifest.get(requested)
         if not app_reference:
             raise GatewayResolutionError(

--- a/policyengine_household_api/modal_release/gateway.py
+++ b/policyengine_household_api/modal_release/gateway.py
@@ -18,12 +18,10 @@ from policyengine_household_api.modal_release.routing_metadata import (
     modal_routing_payload,
 )
 from policyengine_household_api.version_routing import (
-    DeprecatedVersionError,
     UnsupportedVersionError,
     VERSION_CHANNELS,
     VersionRoutingError,
     active_versions_for_country,
-    retired_version_exists,
 )
 
 
@@ -179,15 +177,6 @@ def resolve_app_for_request(
             )
 
     available_versions = active_versions_for_country(manifest, country_id)
-    if retired_version_exists(
-        manifest.get("retired", []), country_id, requested
-    ):
-        raise DeprecatedVersionError(
-            country_id=country_id,
-            requested_version=requested,
-            available_versions=available_versions,
-        )
-
     raise UnsupportedVersionError(
         country_id=country_id,
         requested_version=requested,

--- a/policyengine_household_api/openapi_spec.yaml
+++ b/policyengine_household_api/openapi_spec.yaml
@@ -669,6 +669,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthErrorResponse"
+        422:
+          description: The requested exact package version is not active or has been deprecated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VersionRoutingErrorResponse"
+              examples:
+                unsupported_version:
+                  summary: Exact package version is not active
+                  value:
+                    status: error
+                    code: unsupported_version
+                    message: "No active household API app serves `us` package version `9.9.9`"
+                    requested_version: "9.9.9"
+                    country_id: us
+                    available_versions:
+                      current: "1.0.0"
+                      frontier: "2.0.0"
+                deprecated_version:
+                  summary: Exact package version has been retired
+                  value:
+                    status: error
+                    code: deprecated_version
+                    message: "Household API `us` package version `0.9.0` is deprecated"
+                    requested_version: "0.9.0"
+                    country_id: us
+                    available_versions:
+                      current: "1.0.0"
+                      frontier: "2.0.0"
         500:
           description: Error calculating household under policy.
           content:
@@ -1126,6 +1155,9 @@ components:
           type: object
           description: Optional policy reform object passed through to the country model.
           additionalProperties: true
+        version:
+          type: string
+          description: Optional API version selector. Omit this field to use the current release, pass current or frontier to select an active release channel, or pass an exact active country package version.
       additionalProperties: false
     Household:
       type: object
@@ -1289,6 +1321,36 @@ components:
           type: array
           description: Field-level or variable-level validation messages.
           items:
+            type: string
+    VersionRoutingErrorResponse:
+      type: object
+      required:
+        - status
+        - code
+        - message
+        - requested_version
+        - country_id
+        - available_versions
+      properties:
+        status:
+          type: string
+          enum:
+            - error
+        code:
+          type: string
+          enum:
+            - unsupported_version
+            - deprecated_version
+        message:
+          type: string
+        requested_version:
+          type: string
+        country_id:
+          type: string
+        available_versions:
+          type: object
+          description: Active package versions for the requested country, keyed by release channel.
+          additionalProperties:
             type: string
     AuthErrorResponse:
       type: object

--- a/policyengine_household_api/openapi_spec.yaml
+++ b/policyengine_household_api/openapi_spec.yaml
@@ -670,7 +670,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/AuthErrorResponse"
         422:
-          description: The requested exact package version is not active or has been deprecated.
+          description: The requested exact package version is not active.
           content:
             application/json:
               schema:
@@ -683,17 +683,6 @@ paths:
                     code: unsupported_version
                     message: "No active household API app serves `us` package version `9.9.9`"
                     requested_version: "9.9.9"
-                    country_id: us
-                    available_versions:
-                      current: "1.0.0"
-                      frontier: "2.0.0"
-                deprecated_version:
-                  summary: Exact package version has been retired
-                  value:
-                    status: error
-                    code: deprecated_version
-                    message: "Household API `us` package version `0.9.0` is deprecated"
-                    requested_version: "0.9.0"
                     country_id: us
                     available_versions:
                       current: "1.0.0"
@@ -1340,7 +1329,6 @@ components:
           type: string
           enum:
             - unsupported_version
-            - deprecated_version
         message:
           type: string
         requested_version:

--- a/policyengine_household_api/version_config.py
+++ b/policyengine_household_api/version_config.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+
+ACTIVE_RELEASE_CHANNELS = ("current", "frontier")

--- a/policyengine_household_api/version_routing.py
+++ b/policyengine_household_api/version_routing.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+
+VERSION_CHANNELS = ("current", "frontier")
+
+
+class VersionRoutingError(ValueError):
+    status_code: int = 400
+    code: str | None = None
+    requested_version: str | None = None
+    country_id: str | None = None
+    available_versions: dict[str, str] | None = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+        requested_version: str | None = None,
+        country_id: str | None = None,
+        available_versions: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+        self.code = code
+        self.requested_version = requested_version
+        self.country_id = country_id
+        self.available_versions = available_versions
+
+
+class UnsupportedVersionError(VersionRoutingError):
+    def __init__(
+        self,
+        *,
+        country_id: str,
+        requested_version: str,
+        available_versions: dict[str, str],
+        active_target_label: str,
+    ) -> None:
+        super().__init__(
+            f"No active {active_target_label} serves `{country_id}` package "
+            f"version `{requested_version}`",
+            status_code=422,
+            code="unsupported_version",
+            requested_version=requested_version,
+            country_id=country_id,
+            available_versions=available_versions,
+        )
+
+
+class DeprecatedVersionError(VersionRoutingError):
+    def __init__(
+        self,
+        *,
+        country_id: str,
+        requested_version: str,
+        available_versions: dict[str, str],
+    ) -> None:
+        super().__init__(
+            f"Household API `{country_id}` package version "
+            f"`{requested_version}` is deprecated",
+            status_code=422,
+            code="deprecated_version",
+            requested_version=requested_version,
+            country_id=country_id,
+            available_versions=available_versions,
+        )
+
+
+def active_versions_for_country(
+    channel_references: Mapping[str, Mapping[str, Any] | None],
+    country_id: str,
+    channels: Iterable[str] = VERSION_CHANNELS,
+) -> dict[str, str]:
+    active_versions = {}
+    for channel in channels:
+        reference = channel_references.get(channel)
+        if not reference:
+            continue
+        package_version = reference["package_versions"].get(country_id)
+        if package_version:
+            active_versions[channel] = package_version
+    return active_versions
+
+
+def retired_version_exists(
+    references: Iterable[Mapping[str, Any]],
+    country_id: str,
+    requested_version: str,
+) -> bool:
+    for reference in references:
+        package_versions = reference.get("package_versions", {})
+        if not isinstance(package_versions, Mapping):
+            continue
+        if package_versions.get(country_id) == requested_version:
+            return True
+    return False
+
+
+def package_versions_from_mapping(
+    package_versions: Mapping[str, Any],
+) -> dict[str, str]:
+    return {
+        country: version
+        for country, version in package_versions.items()
+        if isinstance(country, str)
+        and isinstance(version, str)
+        and country
+        and version
+    }

--- a/policyengine_household_api/version_routing.py
+++ b/policyengine_household_api/version_routing.py
@@ -52,25 +52,6 @@ class UnsupportedVersionError(VersionRoutingError):
         )
 
 
-class DeprecatedVersionError(VersionRoutingError):
-    def __init__(
-        self,
-        *,
-        country_id: str,
-        requested_version: str,
-        available_versions: dict[str, str],
-    ) -> None:
-        super().__init__(
-            f"Household API `{country_id}` package version "
-            f"`{requested_version}` is deprecated",
-            status_code=422,
-            code="deprecated_version",
-            requested_version=requested_version,
-            country_id=country_id,
-            available_versions=available_versions,
-        )
-
-
 def active_versions_for_country(
     channel_references: Mapping[str, Mapping[str, Any] | None],
     country_id: str,
@@ -85,20 +66,6 @@ def active_versions_for_country(
         if package_version:
             active_versions[channel] = package_version
     return active_versions
-
-
-def retired_version_exists(
-    references: Iterable[Mapping[str, Any]],
-    country_id: str,
-    requested_version: str,
-) -> bool:
-    for reference in references:
-        package_versions = reference.get("package_versions", {})
-        if not isinstance(package_versions, Mapping):
-            continue
-        if package_versions.get(country_id) == requested_version:
-            return True
-    return False
 
 
 def package_versions_from_mapping(

--- a/policyengine_household_api/version_routing.py
+++ b/policyengine_household_api/version_routing.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping
 
-
-VERSION_CHANNELS = ("current", "frontier")
+from policyengine_household_api.version_config import ACTIVE_RELEASE_CHANNELS
 
 
 class VersionRoutingError(ValueError):
@@ -55,7 +54,7 @@ class UnsupportedVersionError(VersionRoutingError):
 def active_versions_for_country(
     channel_references: Mapping[str, Mapping[str, Any] | None],
     country_id: str,
-    channels: Iterable[str] = VERSION_CHANNELS,
+    channels: Iterable[str] = ACTIVE_RELEASE_CHANNELS,
 ) -> dict[str, str]:
     active_versions = {}
     for channel in channels:

--- a/tests/unit/failover/test_cloud_run_gateway.py
+++ b/tests/unit/failover/test_cloud_run_gateway.py
@@ -711,7 +711,15 @@ def test_exact_package_version_routes_to_matching_channel():
 
 
 def test_versions_endpoint_omits_worker_urls_and_matches_modal_schema():
-    response = _client().get("/versions")
+    manifest = _manifest()
+    manifest["retired"] = [
+        {
+            "modal_app_name": "modal-retired",
+            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
+        }
+    ]
+
+    response = _client(manifest_loader=lambda: manifest).get("/versions")
 
     assert response.status_code == 200
     assert response.get_json() == {
@@ -728,6 +736,9 @@ def test_versions_endpoint_omits_worker_urls_and_matches_modal_schema():
     body = response.get_data(as_text=True)
     assert "cloud_run_worker_url" not in body
     assert "run.app" not in body
+    assert "retired" not in body
+    assert "modal-retired" not in body
+    assert "0.9.0" not in body
 
 
 def test_gateway_rejects_request_body_over_limit(monkeypatch):

--- a/tests/unit/failover/test_cloud_run_gateway.py
+++ b/tests/unit/failover/test_cloud_run_gateway.py
@@ -475,16 +475,8 @@ def test_unknown_exact_package_version_returns_unprocessable_entity():
     }
 
 
-def test_retired_exact_package_version_returns_unprocessable_entity():
-    manifest = _manifest()
-    manifest["retired"] = [
-        {
-            "modal_app_name": "modal-retired",
-            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
-        }
-    ]
-
-    response = _client(manifest_loader=lambda: manifest).post(
+def test_inactive_exact_package_version_returns_unprocessable_entity():
+    response = _client().post(
         "/us/calculate",
         json={"version": "0.9.0", "household": {}},
     )
@@ -493,8 +485,10 @@ def test_retired_exact_package_version_returns_unprocessable_entity():
     assert "Retry-After" not in response.headers
     assert response.get_json() == {
         "status": "error",
-        "code": "deprecated_version",
-        "message": "Household API `us` package version `0.9.0` is deprecated",
+        "code": "unsupported_version",
+        "message": (
+            "No active failover channel serves `us` package version `0.9.0`"
+        ),
         "requested_version": "0.9.0",
         "country_id": "us",
         "available_versions": {"current": "1.0.0", "frontier": "2.0.0"},
@@ -711,15 +705,7 @@ def test_exact_package_version_routes_to_matching_channel():
 
 
 def test_versions_endpoint_omits_worker_urls_and_matches_modal_schema():
-    manifest = _manifest()
-    manifest["retired"] = [
-        {
-            "modal_app_name": "modal-retired",
-            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
-        }
-    ]
-
-    response = _client(manifest_loader=lambda: manifest).get("/versions")
+    response = _client().get("/versions")
 
     assert response.status_code == 200
     assert response.get_json() == {
@@ -737,8 +723,6 @@ def test_versions_endpoint_omits_worker_urls_and_matches_modal_schema():
     assert "cloud_run_worker_url" not in body
     assert "run.app" not in body
     assert "retired" not in body
-    assert "modal-retired" not in body
-    assert "0.9.0" not in body
 
 
 def test_gateway_rejects_request_body_over_limit(monkeypatch):

--- a/tests/unit/failover/test_cloud_run_gateway.py
+++ b/tests/unit/failover/test_cloud_run_gateway.py
@@ -84,9 +84,10 @@ def _client(
     modal_request_timeout_seconds=None,
     modal_probe_timeout_seconds=None,
     modal_canary_timeout_seconds=None,
+    manifest_loader=None,
 ):
     app = create_gateway_app(
-        manifest_loader=_manifest,
+        manifest_loader=manifest_loader or _manifest,
         modal_request=modal_request
         or (lambda app_name, payload: _json_response({"backend": "modal"})),
         modal_health_probe=modal_health_probe or (lambda app_name: None),
@@ -454,15 +455,50 @@ def test_probe_modal_canary_uses_configured_modal_app(monkeypatch):
     }
 
 
-def test_unknown_exact_package_version_stays_bad_request():
+def test_unknown_exact_package_version_returns_unprocessable_entity():
     response = _client().post(
         "/us/calculate",
         json={"version": "9.9.9", "household": {}},
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 422
     assert "Retry-After" not in response.headers
-    assert response.get_json()["status"] == "error"
+    assert response.get_json() == {
+        "status": "error",
+        "code": "unsupported_version",
+        "message": (
+            "No active failover channel serves `us` package version `9.9.9`"
+        ),
+        "requested_version": "9.9.9",
+        "country_id": "us",
+        "available_versions": {"current": "1.0.0", "frontier": "2.0.0"},
+    }
+
+
+def test_retired_exact_package_version_returns_unprocessable_entity():
+    manifest = _manifest()
+    manifest["retired"] = [
+        {
+            "modal_app_name": "modal-retired",
+            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
+        }
+    ]
+
+    response = _client(manifest_loader=lambda: manifest).post(
+        "/us/calculate",
+        json={"version": "0.9.0", "household": {}},
+    )
+
+    assert response.status_code == 422
+    assert "Retry-After" not in response.headers
+    assert response.get_json() == {
+        "status": "error",
+        "code": "deprecated_version",
+        "message": "Household API `us` package version `0.9.0` is deprecated",
+        "requested_version": "0.9.0",
+        "country_id": "us",
+        "available_versions": {"current": "1.0.0", "frontier": "2.0.0"},
+    }
 
 
 def test_non_string_version_stays_bad_request():

--- a/tests/unit/failover/test_failover_manifest.py
+++ b/tests/unit/failover/test_failover_manifest.py
@@ -2,6 +2,7 @@ import pytest
 
 from policyengine_household_api.failover.manifest import (
     FailoverManifestError,
+    FailoverRoutingError,
     build_failover_manifest,
     public_versions_view,
     resolve_failover_channel_for_request,
@@ -49,6 +50,47 @@ def test_build_failover_manifest_from_modal_manifest():
         "deployed_at": "2026-01-01T00:00:00+00:00",
         "analytics_database_revision": "20260519_0004",
     }
+    assert manifest["retired"] == []
+
+
+def test_build_failover_manifest_carries_retired_versions():
+    modal_manifest = _modal_manifest()
+    modal_manifest["retired"] = [
+        {
+            "app_name": "modal-retired",
+            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
+            "deployed_at": "2025-12-25T00:00:00+00:00",
+            "retired_at": "2026-01-01T00:00:00+00:00",
+            "retirement_reason": "replaced-current",
+        }
+    ]
+
+    manifest = build_failover_manifest(
+        environment="staging",
+        modal_manifest=modal_manifest,
+        worker_urls={
+            "current": "https://current.run.app",
+            "frontier": "https://frontier.run.app",
+        },
+        generated_at="2026-06-03T00:00:00+00:00",
+    )
+
+    assert manifest["retired"] == [
+        {
+            "modal_app_name": "modal-retired",
+            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
+            "deployed_at": "2025-12-25T00:00:00+00:00",
+            "retired_at": "2026-01-01T00:00:00+00:00",
+            "retirement_reason": "replaced-current",
+        }
+    ]
+
+
+def test_validates_failover_manifest_without_retired_field():
+    manifest = _manifest()
+    del manifest["retired"]
+
+    assert validate_failover_manifest(manifest)["retired"] == []
 
 
 def test_resolves_current_channel():
@@ -75,12 +117,47 @@ def test_resolves_exact_package_version():
 
 
 def test_rejects_unknown_exact_package_version():
-    with pytest.raises(FailoverManifestError, match="9.9.9"):
+    with pytest.raises(FailoverRoutingError, match="9.9.9") as exc_info:
         resolve_failover_channel_for_request(
             _manifest(),
             country_id="us",
             requested_version="9.9.9",
         )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.code == "unsupported_version"
+    assert exc_info.value.requested_version == "9.9.9"
+    assert exc_info.value.country_id == "us"
+    assert exc_info.value.available_versions == {
+        "current": "1.0.0",
+        "frontier": "2.0.0",
+    }
+
+
+def test_rejects_retired_exact_package_version():
+    manifest = _manifest()
+    manifest["retired"] = [
+        {
+            "modal_app_name": "modal-retired",
+            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
+        }
+    ]
+
+    with pytest.raises(FailoverRoutingError, match="0.9.0") as exc_info:
+        resolve_failover_channel_for_request(
+            manifest,
+            country_id="us",
+            requested_version="0.9.0",
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.code == "deprecated_version"
+    assert exc_info.value.requested_version == "0.9.0"
+    assert exc_info.value.country_id == "us"
+    assert exc_info.value.available_versions == {
+        "current": "1.0.0",
+        "frontier": "2.0.0",
+    }
 
 
 def test_rejects_unsupported_manifest_schema_version():

--- a/tests/unit/failover/test_failover_manifest.py
+++ b/tests/unit/failover/test_failover_manifest.py
@@ -2,12 +2,12 @@ import pytest
 
 from policyengine_household_api.failover.manifest import (
     FailoverManifestError,
-    FailoverRoutingError,
     build_failover_manifest,
     public_versions_view,
     resolve_failover_channel_for_request,
     validate_failover_manifest,
 )
+from policyengine_household_api.version_routing import VersionRoutingError
 
 
 def _modal_manifest():
@@ -117,7 +117,7 @@ def test_resolves_exact_package_version():
 
 
 def test_rejects_unknown_exact_package_version():
-    with pytest.raises(FailoverRoutingError, match="9.9.9") as exc_info:
+    with pytest.raises(VersionRoutingError, match="9.9.9") as exc_info:
         resolve_failover_channel_for_request(
             _manifest(),
             country_id="us",
@@ -143,7 +143,7 @@ def test_rejects_retired_exact_package_version():
         }
     ]
 
-    with pytest.raises(FailoverRoutingError, match="0.9.0") as exc_info:
+    with pytest.raises(VersionRoutingError, match="0.9.0") as exc_info:
         resolve_failover_channel_for_request(
             manifest,
             country_id="us",

--- a/tests/unit/failover/test_failover_manifest.py
+++ b/tests/unit/failover/test_failover_manifest.py
@@ -43,6 +43,12 @@ def _manifest():
 def test_build_failover_manifest_from_modal_manifest():
     manifest = _manifest()
 
+    assert set(manifest) == {
+        "schema_version",
+        "environment",
+        "generated_at",
+        "channels",
+    }
     assert manifest["channels"]["current"] == {
         "modal_app_name": "modal-current",
         "cloud_run_worker_url": "https://current.run.app",
@@ -50,10 +56,9 @@ def test_build_failover_manifest_from_modal_manifest():
         "deployed_at": "2026-01-01T00:00:00+00:00",
         "analytics_database_revision": "20260519_0004",
     }
-    assert manifest["retired"] == []
 
 
-def test_build_failover_manifest_carries_retired_versions():
+def test_build_failover_manifest_omits_retired_versions():
     modal_manifest = _modal_manifest()
     modal_manifest["retired"] = [
         {
@@ -75,22 +80,15 @@ def test_build_failover_manifest_carries_retired_versions():
         generated_at="2026-06-03T00:00:00+00:00",
     )
 
-    assert manifest["retired"] == [
-        {
-            "modal_app_name": "modal-retired",
-            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
-            "deployed_at": "2025-12-25T00:00:00+00:00",
-            "retired_at": "2026-01-01T00:00:00+00:00",
-            "retirement_reason": "replaced-current",
-        }
-    ]
+    assert "retired" not in manifest
 
 
-def test_validates_failover_manifest_without_retired_field():
+def test_validate_failover_manifest_rejects_retired_field():
     manifest = _manifest()
-    del manifest["retired"]
+    manifest["retired"] = []
 
-    assert validate_failover_manifest(manifest)["retired"] == []
+    with pytest.raises(FailoverManifestError, match="unsupported keys"):
+        validate_failover_manifest(manifest)
 
 
 def test_resolves_current_channel():
@@ -134,24 +132,16 @@ def test_rejects_unknown_exact_package_version():
     }
 
 
-def test_rejects_retired_exact_package_version():
-    manifest = _manifest()
-    manifest["retired"] = [
-        {
-            "modal_app_name": "modal-retired",
-            "package_versions": {"uk": "2.20.0", "us": "0.9.0"},
-        }
-    ]
-
+def test_rejects_inactive_exact_package_version():
     with pytest.raises(VersionRoutingError, match="0.9.0") as exc_info:
         resolve_failover_channel_for_request(
-            manifest,
+            _manifest(),
             country_id="us",
             requested_version="0.9.0",
         )
 
     assert exc_info.value.status_code == 422
-    assert exc_info.value.code == "deprecated_version"
+    assert exc_info.value.code == "unsupported_version"
     assert exc_info.value.requested_version == "0.9.0"
     assert exc_info.value.country_id == "us"
     assert exc_info.value.available_versions == {

--- a/tests/unit/modal_release/test_gateway.py
+++ b/tests/unit/modal_release/test_gateway.py
@@ -122,7 +122,7 @@ def test_calculate_rejects_unknown_version():
     }
 
 
-def test_calculate_rejects_retired_version():
+def test_calculate_rejects_retired_version_as_unsupported():
     manifest = _manifest()
     manifest["retired"] = [
         {
@@ -144,8 +144,10 @@ def test_calculate_rejects_retired_version():
     assert not worker_requests
     assert response.get_json() == {
         "status": "error",
-        "code": "deprecated_version",
-        "message": "Household API `us` package version `0.9.0` is deprecated",
+        "code": "unsupported_version",
+        "message": (
+            "No active household API app serves `us` package version `0.9.0`"
+        ),
         "requested_version": "0.9.0",
         "country_id": "us",
         "available_versions": {"current": "1.0.0", "frontier": "2.0.0"},

--- a/tests/unit/modal_release/test_gateway.py
+++ b/tests/unit/modal_release/test_gateway.py
@@ -108,9 +108,48 @@ def test_calculate_rejects_unknown_version():
         json={"version": "9.9.9", "household": {}},
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 422
     assert not worker_requests
-    assert "9.9.9" in response.get_json()["message"]
+    assert response.get_json() == {
+        "status": "error",
+        "code": "unsupported_version",
+        "message": (
+            "No active household API app serves `us` package version `9.9.9`"
+        ),
+        "requested_version": "9.9.9",
+        "country_id": "us",
+        "available_versions": {"current": "1.0.0", "frontier": "2.0.0"},
+    }
+
+
+def test_calculate_rejects_retired_version():
+    manifest = _manifest()
+    manifest["retired"] = [
+        {
+            "app_name": "retired-app",
+            "package_versions": {"uk": "2.30.0", "us": "0.9.0"},
+            "deployed_at": "2025-12-25T00:00:00+00:00",
+            "retired_at": "2026-01-01T00:00:00+00:00",
+            "retirement_reason": "replaced-current",
+        }
+    ]
+    client, worker_requests = _client_with_dispatch(manifest=lambda: manifest)
+
+    response = client.post(
+        "/us/calculate",
+        json={"version": "0.9.0", "household": {}},
+    )
+
+    assert response.status_code == 422
+    assert not worker_requests
+    assert response.get_json() == {
+        "status": "error",
+        "code": "deprecated_version",
+        "message": "Household API `us` package version `0.9.0` is deprecated",
+        "requested_version": "0.9.0",
+        "country_id": "us",
+        "available_versions": {"current": "1.0.0", "frontier": "2.0.0"},
+    }
 
 
 def test_calculate_rejects_non_string_version():


### PR DESCRIPTION
Fixes #1570

## Summary
- Adds shared version-routing errors for exact version selectors that are not served by active channels.
- Returns HTTP 422 with `unsupported_version` details from both Modal gateway and Cloud Run failover gateway.
- Keeps omitted `version` routed to `current`, while preserving exact active-version routing.
- Maintains the existing Cloud Run failover manifest contract by omitting retired metadata.
- Documents the 422 response shape in OpenAPI.

## Validation
- `uv run ruff check policyengine_household_api/version_routing.py policyengine_household_api/failover/manifest.py policyengine_household_api/failover/cloud_run_gateway.py policyengine_household_api/modal_release/gateway.py tests/unit/failover/test_failover_manifest.py tests/unit/failover/test_cloud_run_gateway.py tests/unit/modal_release/test_gateway.py .github/scripts/test_cloud_run_failover_channels.py`
- `uv run pytest .github/scripts/test_cloud_run_failover_channels.py`
- Direct behavior check for Modal gateway, Cloud Run failover gateway, failover manifest generation, and failover manifest validation.

## Notes
Focused local pytest runs for gateway unit files were difficult to rerun end-to-end in this environment because repo-level `tests/conftest.py` imports the full app and country package systems. The changed behavior was validated directly against the affected gateway and manifest paths.