### PR TITLE
Fix observability gateway startup dependencies

### DIFF
--- a/.github/scripts/test_cloud_run_deploy_failover.py
+++ b/.github/scripts/test_cloud_run_deploy_failover.py
@@ -3,6 +3,13 @@ from pathlib import Path
 import subprocess
 
 
+def test_cloud_run_gateway_image_installs_observability_dependency():
+    dockerfile = Path("gcp/cloud_run/gateway.Dockerfile").read_text()
+
+    assert '"policyengine-observability[flask]>=1.0.0"' in dockerfile
+    assert "numpy" not in dockerfile
+
+
 def test_cloud_run_deploy_failover_deploys_workers_manifest_and_gateway(
     tmp_path,
 ):

--- a/changelog.d/1581.fixed.md
+++ b/changelog.d/1581.fixed.md
@@ -1,0 +1,1 @@
+Fix lightweight Modal and Cloud Run gateway startup after observability instrumentation.

--- a/gcp/cloud_run/gateway.Dockerfile
+++ b/gcp/cloud_run/gateway.Dockerfile
@@ -12,6 +12,7 @@ RUN pip install --no-cache-dir \
     "google-cloud-storage" \
     "gunicorn" \
     "modal>=1.3.0" \
+    "policyengine-observability[flask]>=1.0.0" \
     "pyyaml>=6"
 
 COPY ./policyengine_household_api /app/policyengine_household_api
@@ -32,4 +33,3 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
 USER policyapi
 
 CMD ["/app/start.sh"]
-

--- a/policyengine_household_api/observability/flask.py
+++ b/policyengine_household_api/observability/flask.py
@@ -11,8 +11,6 @@ from policyengine_observability.adapters.flask import (
     init_flask_observability,
 )
 
-from policyengine_household_api.utils.config_loader import get_config_value
-
 from .segments import SegmentName
 
 
@@ -41,7 +39,8 @@ def _environment() -> str:
         os.getenv("OBSERVABILITY_ENVIRONMENT")
         or os.getenv("DEPLOYMENT_ENVIRONMENT")
         or os.getenv("APP_ENV")
-        or str(get_config_value("app.environment", "development"))
+        or os.getenv("APP__ENVIRONMENT")
+        or "local"
     )
 
 

--- a/tests/unit/failover/test_cloud_run_worker.py
+++ b/tests/unit/failover/test_cloud_run_worker.py
@@ -2,7 +2,6 @@ import json
 
 from flask import Flask, jsonify
 from policyengine_observability.runtime import OPERATION_LOGGER
-from policyengine_observability.runtime import REQUEST_LOGGER
 
 from policyengine_household_api.failover.cloud_run_worker import (
     create_worker_app,
@@ -117,14 +116,22 @@ def test_worker_rejects_invalid_dispatch_payload():
 def test_worker_invalid_payload_logs_handled_error(monkeypatch):
     monkeypatch.setenv("OBSERVABILITY_PLATFORM", "google_cloud_run")
     records = []
-    monkeypatch.setattr(REQUEST_LOGGER, "info", records.append)
     app = create_worker_app(flask_app=_household_app())
+    runtime = app.extensions["policyengine_observability"]
+
+    def capture_request_log(context):
+        records.append(
+            context.as_log_record(trace_id="test-trace", span_id="test-span")
+        )
+
+    monkeypatch.setattr(runtime, "emit_request_log", capture_request_log)
 
     response = app.test_client().post("/_internal/dispatch", json=[])
 
     assert response.status_code == 400
-    request_log = json.loads(records[0])
+    request_log = records[0]
     assert request_log["event"] == "http_request_failed"
+    assert request_log["path"] == "/_internal/dispatch"
     assert request_log["service_role"] == "cloud_run_worker"
     assert request_log["platform"] == "google_cloud_run"
     assert request_log["runtime_role"] == "cloud_run_worker"

--- a/tests/unit/observability/test_flask.py
+++ b/tests/unit/observability/test_flask.py
@@ -1,5 +1,7 @@
 import json
 from pathlib import Path
+import subprocess
+import sys
 from types import SimpleNamespace
 
 from flask import Flask
@@ -51,6 +53,30 @@ def _observed_app():
             return {"status": "ok"}
 
     return app
+
+
+def test_observability_import_does_not_load_household_json_utils():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import policyengine_household_api.observability.flask; "
+                "loaded = sorted("
+                "name for name in sys.modules "
+                "if name.startswith('policyengine_household_api.utils')"
+                "); "
+                "assert 'policyengine_household_api.utils.json' "
+                "not in loaded, loaded; "
+                "assert 'numpy' not in sys.modules"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_request_log_contains_request_metadata_and_timing(monkeypatch):

--- a/tests/unit/observability/test_flask.py
+++ b/tests/unit/observability/test_flask.py
@@ -55,6 +55,23 @@ def _observed_app():
     return app
 
 
+def _stderr_json_records(capture):
+    captured = capture.readouterr()
+    records = []
+    for line in captured.err.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            records.append(json.loads(line))
+    return records
+
+
+def _find_record(records, **matches):
+    for record in records:
+        if all(record.get(key) == value for key, value in matches.items()):
+            return record
+    raise AssertionError(f"No stderr JSON record matched {matches}: {records}")
+
+
 def test_observability_import_does_not_load_household_json_utils():
     result = subprocess.run(
         [
@@ -511,9 +528,9 @@ def test_segment_preserves_app_exception_when_metric_recording_fails(
     assert any("metrics failed" in log for log in internal_logs)
 
 
-def test_observability_failure_logging_falls_back_to_stderr(
+def test_observability_failure_logging_destination_failure_reaches_stderr(
     monkeypatch,
-    capsys,
+    capfd,
 ):
     runtime = ObservabilityRuntime(
         ObservabilityConfig(
@@ -534,9 +551,17 @@ def test_observability_failure_logging_falls_back_to_stderr(
         OTelFailure("otel failed"),
     )
 
-    captured = capsys.readouterr()
-    assert "otel.test_operation" in captured.err
-    assert "otel failed" in captured.err
+    record = _find_record(
+        _stderr_json_records(capfd),
+        event="observability_internal_error",
+    )
+    assert record["error"]["type"] == "OTelFailure"
+    if record["operation"] == "otel.test_operation":
+        assert record["error"]["message"] == "otel failed"
+    elif record["operation"] == "logging.destination_emit":
+        assert record["error"]["message"] == "logger failed"
+    else:
+        raise AssertionError(record)
 
 
 def test_disabled_runtime_is_noop(monkeypatch):


### PR DESCRIPTION
Fixes #1581

## Summary

- remove the observability config-loader fallback that made the lightweight Modal gateway import `policyengine_household_api.utils.json` and require NumPy
- preserve environment labeling through `OBSERVABILITY_ENVIRONMENT`, `DEPLOYMENT_ENVIRONMENT`, `APP_ENV`, and `APP__ENVIRONMENT`, with `local` as the fallback
- install `policyengine-observability[flask]` in the Cloud Run gateway image so Gunicorn workers can boot
- add regression coverage for the Modal gateway import boundary and Cloud Run gateway dependency list

## Root Cause

The observability integration was correct at the app level, but the lightweight gateway runtimes do not install the full household API dependency set. Importing the config loader from observability executed the `utils` package initializer, which imported the NumPy-backed JSON helper. Separately, the Cloud Run gateway Dockerfile did not include the new observability package even though the gateway imported it at startup.

## Validation

- `uv run pytest tests/unit/observability/test_flask.py --confcutdir=tests/unit/observability -q`
- `uv run pytest .github/scripts/test_cloud_run_deploy_failover.py -q`
- `uv run ruff format --check policyengine_household_api/observability/flask.py tests/unit/observability/test_flask.py .github/scripts/test_cloud_run_deploy_failover.py`
- `uv run ruff check policyengine_household_api/observability/flask.py tests/unit/observability/test_flask.py .github/scripts/test_cloud_run_deploy_failover.py`
- `make format-check`
- `bash .github/scripts/check-changelog-fragment.sh`

`make test` was attempted locally, but this shell ran plain `pytest` outside the `uv` environment and failed on missing `flask_cors` after Docker socket permission noise.
