### PR TITLE
Harden Cloud Run fallback tests

### DIFF
--- a/.github/scripts/cloud-run-deploy-failover.sh
+++ b/.github/scripts/cloud-run-deploy-failover.sh
@@ -211,6 +211,7 @@ worker_max_instances="${HOUSEHOLD_CLOUD_RUN_WORKER_MAX_INSTANCES:-100}"
 worker_concurrency="${HOUSEHOLD_CLOUD_RUN_WORKER_CONCURRENCY:-5}"
 worker_threads="${HOUSEHOLD_CLOUD_RUN_WORKER_THREADS:-${worker_concurrency}}"
 worker_timeout="${HOUSEHOLD_CLOUD_RUN_WORKER_TIMEOUT_SECONDS:-1200}"
+gateway_worker_timeout="${HOUSEHOLD_FAILOVER_CLOUD_RUN_WORKER_TIMEOUT_SECONDS:-900}"
 worker_cpu="${HOUSEHOLD_CLOUD_RUN_WORKER_CPU:-1}"
 worker_memory="${HOUSEHOLD_CLOUD_RUN_WORKER_MEMORY:-4Gi}"
 worker_scaling_concurrency_target="$(
@@ -398,7 +399,7 @@ append_env_if_set \
 append_env_value \
   "${gateway_env_file}" \
   HOUSEHOLD_FAILOVER_CLOUD_RUN_WORKER_TIMEOUT_SECONDS \
-  "${worker_timeout}"
+  "${gateway_worker_timeout}"
 sync_secret_if_set \
   "${gateway_secrets_file}" \
   MODAL_TOKEN_ID

--- a/.github/scripts/cloud-run-warm-workers.sh
+++ b/.github/scripts/cloud-run-warm-workers.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-# Warm the private Cloud Run fallback workers before the forced-fallback test.
+# Warm the Cloud Run fallback path before the forced-fallback test.
 #
 # The workers run at min-instances=0, so the first request triggers a cold
 # start (image pull + container boot + full app import) that can take minutes
-# and exceed the deployed-test read timeout. This pings each worker's liveness
-# endpoint and waits for it to come up so the test step exercises warm workers.
+# and exceed the deployed-test read timeout. This first pings each worker's
+# liveness endpoint and then runs a real authenticated calculate through the
+# public gateway so the test step exercises the same fallback dispatch and
+# calculation path it asserts on.
 #
 # The workers are private (--no-allow-unauthenticated), so an unauthenticated
 # request is rejected at the front door without starting a container; we send
 # an IAM identity token so the request actually reaches the worker and triggers
 # the cold start.
 #
-# Best-effort: this never exits non-zero. A worker that cannot be warmed only
+# Best-effort: this never exits non-zero. A path that cannot be warmed only
 # emits a warning; the deployed test step remains the gate.
 set -uo pipefail
 
@@ -21,6 +23,8 @@ curl_bin="${CURL_BIN:-curl}"
 project="${GOOGLE_CLOUD_PROJECT:-}"
 region="${HOUSEHOLD_CLOUD_RUN_REGION:-us-central1}"
 gateway_service="${CLOUD_RUN_GATEWAY_SERVICE:-}"
+base_url="${HOUSEHOLD_API_BASE_URL:-}"
+auth_token="${HOUSEHOLD_API_AUTH_TOKEN:-}"
 channels="${HOUSEHOLD_CLOUD_RUN_WARM_CHANNELS:-current frontier}"
 total_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_TIMEOUT_SECONDS:-300}"
 attempt_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_ATTEMPT_TIMEOUT_SECONDS:-120}"
@@ -82,6 +86,53 @@ warm_worker() {
   done
 }
 
+warm_gateway_calculate() {
+  local channel="$1"
+  local url code deadline body
+
+  if [ -z "${base_url}" ] || [ -z "${auth_token}" ]; then
+    echo "::warning::HOUSEHOLD_API_BASE_URL and HOUSEHOLD_API_AUTH_TOKEN are required to warm the gateway calculate path; skipping ${channel}."
+    return 0
+  fi
+
+  url="${base_url%/}/us/calculate"
+  body="$(
+    cat <<JSON
+{"version":"${channel}","household":{"people":{"parent":{"age":{"2026":35},"employment_income":{"2026":60000}},"child":{"age":{"2026":6}}},"tax_units":{"tax_unit":{"members":["parent","child"],"ctc":{"2026":null}}},"spm_units":{"spm_unit":{"members":["parent","child"]}},"households":{"household":{"members":["parent","child"],"state_name":{"2026":"AZ"}}}}}
+JSON
+  )"
+
+  echo "Warming Cloud Run ${channel} fallback through ${url} (up to ${total_timeout}s)..."
+  deadline=$(( $(date +%s) + total_timeout ))
+  while :; do
+    code="$(
+      "${curl_bin}" -sS -o /dev/null -w '%{http_code}' \
+        --max-time "${attempt_timeout}" \
+        -X POST \
+        -H "Authorization: Bearer ${auth_token}" \
+        -H "Content-Type: application/json" \
+        -d "${body}" \
+        "${url}" || true
+    )"
+    case "${code}" in
+      2*)
+        echo "Cloud Run ${channel} fallback calculate path is warm (HTTP ${code})."
+        return 0
+        ;;
+      401 | 403)
+        echo "::warning::Gateway rejected the ${channel} calculate warm-up request (HTTP ${code}); the calculate path was not warmed."
+        return 0
+        ;;
+    esac
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+      echo "::warning::Cloud Run ${channel} fallback calculate path did not return 2xx within ${total_timeout}s (last HTTP ${code:-none}); continuing to tests anyway."
+      return 0
+    fi
+    echo "Cloud Run ${channel} fallback calculate path not warm yet (HTTP ${code:-timeout}); retrying..."
+    sleep 5
+  done
+}
+
 read -ra warm_channels <<< "${channels}"
 pids=()
 for channel in "${warm_channels[@]}"; do
@@ -89,4 +140,8 @@ for channel in "${warm_channels[@]}"; do
   pids+=("$!")
 done
 wait "${pids[@]}"
+
+for channel in "${warm_channels[@]}"; do
+  warm_gateway_calculate "${channel}"
+done
 exit 0

--- a/.github/scripts/test_cloud_run_deploy_failover.py
+++ b/.github/scripts/test_cloud_run_deploy_failover.py
@@ -135,7 +135,7 @@ def test_cloud_run_deploy_failover_deploys_workers_manifest_and_gateway(
     assert "HOUSEHOLD_FAILOVER_MODAL_MIN_OPEN_SECONDS: |-" in log
     assert "HOUSEHOLD_FAILOVER_MODAL_RECOVERY_SUCCESSES: |-" in log
     assert "HOUSEHOLD_FAILOVER_CLOUD_RUN_WORKER_TIMEOUT_SECONDS: |-" in log
-    assert "  1200" in log
+    assert "  900" in log
     assert "--allow-unauthenticated --min-instances 1" in log
     assert "--concurrency 32" in log
     assert (

--- a/.github/scripts/test_cloud_run_warm_workers.py
+++ b/.github/scripts/test_cloud_run_warm_workers.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+def test_cloud_run_warm_workers_warms_liveness_and_gateway_calculate(
+    tmp_path,
+):
+    log_path = tmp_path / "commands.log"
+    _write_fake_gcloud(tmp_path, log_path)
+    _write_fake_curl(tmp_path, log_path)
+
+    env = {
+        **os.environ,
+        "GCLOUD_BIN": str(tmp_path / "gcloud"),
+        "CURL_BIN": str(tmp_path / "curl"),
+        "GOOGLE_CLOUD_PROJECT": "policyengine-test",
+        "CLOUD_RUN_GATEWAY_SERVICE": "household-api-staging-gateway",
+        "HOUSEHOLD_API_BASE_URL": "https://gateway.run.app",
+        "HOUSEHOLD_API_AUTH_TOKEN": "auth-token",
+        "HOUSEHOLD_CLOUD_RUN_WARM_CHANNELS": "current",
+    }
+
+    result = subprocess.run(
+        ["bash", ".github/scripts/cloud-run-warm-workers.sh"],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    log = log_path.read_text()
+    assert (
+        "gcloud run services describe "
+        "household-api-staging-current-worker" in log
+    )
+    assert (
+        "curl -sS -o /dev/null -w %{http_code} --max-time 120 "
+        "-H Authorization: Bearer identity-token "
+        "https://household-api-staging-current-worker.run.app/liveness_check"
+        in log
+    )
+    assert (
+        "curl -sS -o /dev/null -w %{http_code} --max-time 120 "
+        "-X POST -H Authorization: Bearer auth-token "
+        "-H Content-Type: application/json" in log
+    )
+    assert "https://gateway.run.app/us/calculate" in log
+    assert '"version":"current"' in log
+
+
+def _write_fake_gcloud(tmp_path: Path, log_path: Path) -> None:
+    script = tmp_path / "gcloud"
+    script.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+echo "gcloud $*" >> "{log_path}"
+
+if [[ "$*" == run\\ services\\ describe* ]]; then
+  echo "https://$4.run.app"
+  exit 0
+fi
+
+if [[ "$*" == auth\\ print-identity-token* ]]; then
+  echo "identity-token"
+  exit 0
+fi
+"""
+    )
+    script.chmod(0o755)
+
+
+def _write_fake_curl(tmp_path: Path, log_path: Path) -> None:
+    script = tmp_path / "curl"
+    script.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+echo "curl $*" >> "{log_path}"
+printf '200'
+"""
+    )
+    script.chmod(0o755)

--- a/changelog.d/1588.fixed.md
+++ b/changelog.d/1588.fixed.md
@@ -1,0 +1,1 @@
+Hardened Cloud Run fallback tests against analytics write failures and cold fallback paths.

--- a/policyengine_household_api/decorators/analytics.py
+++ b/policyengine_household_api/decorators/analytics.py
@@ -91,8 +91,8 @@ def log_analytics_if_enabled(func):
     Decorator that logs analytics only if analytics is enabled in configuration.
 
     If analytics is disabled, this passes through without logging. If
-    analytics is enabled, analytics is required: schema readiness and
-    database write failures propagate like other API failures.
+    analytics is enabled, schema readiness is required at request time, but
+    database write failures are logged and do not fail the user request.
     """
 
     @wraps(func)
@@ -263,10 +263,12 @@ def _record_analytics(
                 )
 
         db.session.commit()
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        logger.error(f"Failed to log analytics: {e}")
-        raise
+        logger.warning(
+            "Failed to log analytics; continuing without analytics",
+            exc_info=True,
+        )
 
 
 def _set_observability_context_attributes(

--- a/tests/fixtures/decorators/analytics_patches.py
+++ b/tests/fixtures/decorators/analytics_patches.py
@@ -10,9 +10,15 @@ from datetime import datetime
 @pytest.fixture
 def mock_analytics_enabled():
     """Mock analytics as enabled."""
-    with patch(
-        "policyengine_household_api.decorators.analytics.is_analytics_enabled",
-        return_value=True,
+    with (
+        patch(
+            "policyengine_household_api.decorators.analytics.is_analytics_enabled",
+            return_value=True,
+        ),
+        patch(
+            "policyengine_household_api.decorators.analytics._collect_variable_usage",
+            return_value=False,
+        ),
     ):
         yield
 

--- a/tests/unit/decorators/test_analytics.py
+++ b/tests/unit/decorators/test_analytics.py
@@ -148,7 +148,7 @@ class TestAnalyticsDecorator:
         # Verify client_id preserved as-is
         assert visit_instance.client_id == "test-client"
 
-    def test__given_database_error__decorator_raises(
+    def test__given_database_error__decorator_logs_warning_and_continues(
         self,
         sample_function,
         mock_analytics_enabled,
@@ -158,18 +158,23 @@ class TestAnalyticsDecorator:
         mock_datetime_fixed,
         mock_version,
         mock_db_session_with_error,
+        caplog,
     ):
-        """Enabled analytics should fail the request on database errors."""
+        """Enabled analytics write failures should not fail the request."""
         from policyengine_household_api.decorators.analytics import (
             log_analytics_if_enabled,
         )
 
         decorated = log_analytics_if_enabled(sample_function)
 
-        with pytest.raises(Exception, match="Database error"):
-            decorated("arg1", "arg2", kwarg1="test")
+        result = decorated("arg1", "arg2", kwarg1="test")
 
+        assert result == "Result: arg1, arg2, test"
         mock_db_session_with_error.rollback.assert_called_once()
+        assert (
+            "Failed to log analytics; continuing without analytics"
+            in caplog.text
+        )
 
     def test__given_analytics_check_raises_error__decorator_raises(
         self, sample_function, mock_analytics_error

--- a/tests/unit/failover/test_cloud_run_gateway.py
+++ b/tests/unit/failover/test_cloud_run_gateway.py
@@ -179,6 +179,24 @@ def test_app_level_500_does_not_trigger_fallback_or_status_page_check():
     assert status_checks == []
 
 
+def test_forced_cloud_run_app_level_500_returns_response(monkeypatch):
+    monkeypatch.setenv("HOUSEHOLD_FAILOVER_FORCE_BACKEND", "cloud_run")
+
+    client = _client(
+        fallback_request=lambda resolved, payload: _json_response(
+            {"status": "error"},
+            status=500,
+        ),
+    )
+
+    response = client.post("/us/calculate", json={"household": {}})
+
+    assert response.status_code == 500
+    assert response.get_json() == {"status": "error"}
+    assert response.headers["X-PolicyEngine-Backend"] == "cloud_run"
+    assert response.headers["X-PolicyEngine-Primary-State"] == "healthy"
+
+
 def test_modal_call_failure_needs_canary_failure_before_fallback():
     status_checks = []
 
@@ -401,7 +419,7 @@ def test_cloud_run_worker_timeout_uses_env(monkeypatch):
     monkeypatch.setenv("HOUSEHOLD_FAILOVER_DISABLE_CLOUD_RUN_AUTH", "1")
     monkeypatch.setenv(
         "HOUSEHOLD_FAILOVER_CLOUD_RUN_WORKER_TIMEOUT_SECONDS",
-        "1200",
+        "900",
     )
     monkeypatch.setattr(
         "policyengine_household_api.failover.cloud_run_gateway.urllib_request.urlopen",
@@ -420,7 +438,50 @@ def test_cloud_run_worker_timeout_uses_env(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert captured["timeout"] == 1200
+    assert captured["timeout"] == 900
+
+
+def test_cloud_run_worker_returns_dispatched_500_response(monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return json.dumps(
+                encode_dispatch_response(
+                    {
+                        "status_code": 500,
+                        "body": b'{"status":"error"}',
+                        "headers": [("Content-Type", "application/json")],
+                    }
+                )
+            ).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        return FakeResponse()
+
+    monkeypatch.setenv("HOUSEHOLD_FAILOVER_DISABLE_CLOUD_RUN_AUTH", "1")
+    monkeypatch.setattr(
+        "policyengine_household_api.failover.cloud_run_gateway.urllib_request.urlopen",
+        fake_urlopen,
+    )
+
+    response = call_cloud_run_worker(
+        _resolved_channel(),
+        {
+            "method": "POST",
+            "path": "/us/calculate",
+            "query_string": "",
+            "headers": {},
+            "body": b"{}",
+        },
+    )
+
+    assert response.status_code == 500
+    assert response.get_data(as_text=True) == '{"status":"error"}'
 
 
 def test_cloud_run_worker_warmup_swallows_auth_failure(monkeypatch):


### PR DESCRIPTION
Fixes #1588

## Summary
- make analytics database write failures non-fatal for user requests while preserving warning logs and rollback
- keep the private worker timeout at 1200s but set the gateway-to-worker upstream timeout to 900s
- warm the real forced Cloud Run fallback calculate path, not only private worker liveness
- add regression coverage for dispatched Cloud Run 500s, deploy timeout wiring, and fallback warmup behavior

## Validation
- make format-check
- uv run ruff check policyengine_household_api/decorators/analytics.py tests/unit/decorators/test_analytics.py tests/fixtures/decorators/analytics_patches.py tests/unit/failover/test_cloud_run_gateway.py .github/scripts/test_cloud_run_deploy_failover.py .github/scripts/test_cloud_run_warm_workers.py
- uv run pytest --confcutdir=tests/unit/decorators -p tests.fixtures.decorators.analytics -p tests.fixtures.decorators.analytics_patches tests/unit/decorators/test_analytics.py -q
- uv run pytest --confcutdir=tests/unit/failover tests/unit/failover/test_cloud_run_gateway.py -q
- uv run pytest --confcutdir=.github/scripts .github/scripts/test_cloud_run_deploy_failover.py .github/scripts/test_cloud_run_warm_workers.py -q
- bash -n .github/scripts/cloud-run-warm-workers.sh .github/scripts/cloud-run-deploy-failover.sh
- git diff --check