### PR TITLE
Parallelize Cloud Run fallback warmup

### DIFF
--- a/.github/scripts/cloud-run-warm-workers.sh
+++ b/.github/scripts/cloud-run-warm-workers.sh
@@ -26,8 +26,8 @@ gateway_service="${CLOUD_RUN_GATEWAY_SERVICE:-}"
 base_url="${HOUSEHOLD_API_BASE_URL:-}"
 auth_token="${HOUSEHOLD_API_AUTH_TOKEN:-}"
 channels="${HOUSEHOLD_CLOUD_RUN_WARM_CHANNELS:-current frontier}"
-total_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_TIMEOUT_SECONDS:-300}"
-attempt_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_ATTEMPT_TIMEOUT_SECONDS:-120}"
+total_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_TIMEOUT_SECONDS:-900}"
+attempt_timeout="${HOUSEHOLD_CLOUD_RUN_WARM_ATTEMPT_TIMEOUT_SECONDS:-240}"
 
 if [ -z "${project}" ] || [ -z "${gateway_service}" ]; then
   echo "::warning::GOOGLE_CLOUD_PROJECT and CLOUD_RUN_GATEWAY_SERVICE are required to warm workers; skipping."
@@ -141,7 +141,10 @@ for channel in "${warm_channels[@]}"; do
 done
 wait "${pids[@]}"
 
+pids=()
 for channel in "${warm_channels[@]}"; do
-  warm_gateway_calculate "${channel}"
+  warm_gateway_calculate "${channel}" &
+  pids+=("$!")
 done
+wait "${pids[@]}"
 exit 0

--- a/.github/scripts/test_cloud_run_warm_workers.py
+++ b/.github/scripts/test_cloud_run_warm_workers.py
@@ -18,7 +18,7 @@ def test_cloud_run_warm_workers_warms_liveness_and_gateway_calculate(
         "CLOUD_RUN_GATEWAY_SERVICE": "household-api-staging-gateway",
         "HOUSEHOLD_API_BASE_URL": "https://gateway.run.app",
         "HOUSEHOLD_API_AUTH_TOKEN": "auth-token",
-        "HOUSEHOLD_CLOUD_RUN_WARM_CHANNELS": "current",
+        "HOUSEHOLD_CLOUD_RUN_WARM_CHANNELS": "current frontier",
     }
 
     result = subprocess.run(
@@ -35,18 +35,67 @@ def test_cloud_run_warm_workers_warms_liveness_and_gateway_calculate(
         "household-api-staging-current-worker" in log
     )
     assert (
-        "curl -sS -o /dev/null -w %{http_code} --max-time 120 "
+        "gcloud run services describe "
+        "household-api-staging-frontier-worker" in log
+    )
+    assert (
+        "curl -sS -o /dev/null -w %{http_code} --max-time 240 "
         "-H Authorization: Bearer identity-token "
         "https://household-api-staging-current-worker.run.app/liveness_check"
         in log
     )
     assert (
-        "curl -sS -o /dev/null -w %{http_code} --max-time 120 "
+        "curl -sS -o /dev/null -w %{http_code} --max-time 240 "
+        "-H Authorization: Bearer identity-token "
+        "https://household-api-staging-frontier-worker.run.app/liveness_check"
+        in log
+    )
+    assert (
+        "curl -sS -o /dev/null -w %{http_code} --max-time 240 "
         "-X POST -H Authorization: Bearer auth-token "
         "-H Content-Type: application/json" in log
     )
     assert "https://gateway.run.app/us/calculate" in log
     assert '"version":"current"' in log
+    assert '"version":"frontier"' in log
+
+
+def test_cloud_run_warm_workers_warms_gateway_calculates_in_parallel(
+    tmp_path,
+):
+    log_path = tmp_path / "commands.log"
+    _write_fake_gcloud(tmp_path, log_path)
+    _write_fake_curl(tmp_path, log_path)
+
+    env = {
+        **os.environ,
+        "GCLOUD_BIN": str(tmp_path / "gcloud"),
+        "CURL_BIN": str(tmp_path / "curl"),
+        "GOOGLE_CLOUD_PROJECT": "policyengine-test",
+        "CLOUD_RUN_GATEWAY_SERVICE": "household-api-staging-gateway",
+        "HOUSEHOLD_API_BASE_URL": "https://gateway.run.app",
+        "HOUSEHOLD_API_AUTH_TOKEN": "auth-token",
+        "HOUSEHOLD_CLOUD_RUN_WARM_CHANNELS": "current frontier",
+        "FAKE_CURL_CALCULATE_SLEEP": "0.2",
+    }
+
+    result = subprocess.run(
+        ["bash", ".github/scripts/cloud-run-warm-workers.sh"],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    lines = log_path.read_text().splitlines()
+    current_start = lines.index("calculate-start current")
+    frontier_start = lines.index("calculate-start frontier")
+    first_end = min(
+        lines.index("calculate-end current"),
+        lines.index("calculate-end frontier"),
+    )
+    assert current_start < first_end
+    assert frontier_start < first_end
 
 
 def _write_fake_gcloud(tmp_path: Path, log_path: Path) -> None:
@@ -76,6 +125,19 @@ def _write_fake_curl(tmp_path: Path, log_path: Path) -> None:
         f"""#!/usr/bin/env bash
 set -euo pipefail
 echo "curl $*" >> "{log_path}"
+if [[ "$*" == *"/us/calculate"* ]]; then
+  channel="unknown"
+  if [[ "$*" == *'"version":"current"'* ]]; then
+    channel="current"
+  elif [[ "$*" == *'"version":"frontier"'* ]]; then
+    channel="frontier"
+  fi
+  echo "calculate-start ${{channel}}" >> "{log_path}"
+  if [ -n "${{FAKE_CURL_CALCULATE_SLEEP:-}}" ]; then
+    sleep "${{FAKE_CURL_CALCULATE_SLEEP}}"
+  fi
+  echo "calculate-end ${{channel}}" >> "{log_path}"
+fi
 printf '200'
 """
     )

--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -350,6 +350,8 @@ jobs:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       CLOUD_RUN_GATEWAY_SERVICE: ${{ vars.HOUSEHOLD_CLOUD_RUN_STAGING_GATEWAY_SERVICE || 'household-api-staging-gateway' }}
+      HOUSEHOLD_CLOUD_RUN_WARM_TIMEOUT_SECONDS: "900"
+      HOUSEHOLD_CLOUD_RUN_WARM_ATTEMPT_TIMEOUT_SECONDS: "240"
 
     steps:
       - name: Checkout code
@@ -399,9 +401,13 @@ jobs:
 
       - name: Run deployed fallback tests
         run: |
-          bash .github/scripts/run-deployed-tests-for-modal-route.sh \
-            current \
-            channel
+          status=0
+          for channel in current frontier; do
+            bash .github/scripts/run-deployed-tests-for-modal-route.sh \
+              "${channel}" \
+              channel || status=$?
+          done
+          exit "${status}"
 
       - name: Restore Modal-primary routing
         if: always()

--- a/changelog.d/1590.fixed.md
+++ b/changelog.d/1590.fixed.md
@@ -1,0 +1,1 @@
+Parallelized Cloud Run fallback warmup and tested both current and frontier fallback channels.


### PR DESCRIPTION
Fixes #1590

## Summary
- Increase Cloud Run fallback warmup defaults to 900s total and 240s per attempt.
- Warm current and frontier gateway calculate paths in parallel after private worker liveness warmup.
- Run forced Cloud Run fallback deployed tests for both current and frontier, while preserving both attempts before failing the step.
- Add script coverage for both channel liveness calls and parallel calculate warmup.

## Root Cause
PR #1589 hardened the fallback path, but the follow-up staging run showed the warmup script still used the older 300s total window and warmed gateway calculate paths serially. The forced fallback deployed test also only exercised the current channel.

## Validation
- ./.venv/bin/python -m pytest .github/scripts/test_cloud_run_warm_workers.py -q
- bash -n .github/scripts/cloud-run-warm-workers.sh
- git diff --check
- make format-check (Ruff passed; Docker API warning printed locally)
- ./.venv/bin/python -m pytest -vv --timeout=150 -rP .github/scripts tests/to_refactor tests/unit

## Modal release
```yaml
modal_release:
  new_app_target: none
  promote_existing_frontier: false
  cleanup_target: none
```