### PR TITLE
Migration tooling: golden parity harness + client inventory (Phase 0/2)

### DIFF
--- a/docs/migration-to-api-v2.md
+++ b/docs/migration-to-api-v2.md
@@ -1,0 +1,71 @@
+# Migration plan: household API → policyengine-api-v2
+
+Status as of 2026-07-02. No hard deadline; the strategy is to accumulate
+parity evidence slowly until cutover is boring.
+
+## Evidence so far
+
+| Fact | Source |
+|---|---|
+| 16 client identities, ~43K requests / 90 days | `tools/parity/inventory.py` against prod analytics |
+| **100% of traffic is US** — v2 needs US-only parity on day one | inventory |
+| `frontier` channel used by 5 clients → version routing is contractual | inventory |
+| Prod UK calculate is broken (nobody affected) | #1601 |
+| v2 household endpoint (policyengine-api-v2#599) reproduces prod exactly: **5/5 partner payloads at parity, zero drift** at `policyengine-us==1.744.0` | `tools/parity/parity.py` |
+
+## Phases
+
+0. **Inventory** ✅ — per-client compatibility matrix (`inventory-report.json`).
+1. **v2 contract** ✅ (experiment) — `projects/policyengine-api-household/` on
+   the `household-endpoint-experiment` branch of policyengine-api-v2: sync
+   FastAPI `/{country}/calculate`, v1 wire format + envelope, country packages
+   as the engine, model version surfaced for pinning.
+2. **Golden parity corpus** ✅ — 13 cases: 4 real partner payloads
+   (MyFriendBen, Amplifi ×2, Impactica), 2 synthetic basics, 3 periphery
+   (partial-month warnings, deprecated input, axes sweep), 5 per-client
+   contract cases generated from real variable usage. Goldens frozen from
+   production.
+3. **Shadow** — run the diff continuously against a deployed v2 staging
+   endpoint; regenerate per-client cases as usage evolves.
+4. **Pilot** — 1–2 friendly clients (best candidates: the zero-error steady
+   clients in the inventory) switch base URL with exact-version pinning.
+5. **Cutover** — channel-based policy: `current` served by v2 from date X;
+   exact-version pins honored on legacy until date Y. Transparent proxy from
+   the old gateway is the zero-client-change fallback.
+
+## Running the tools
+
+```bash
+# Client inventory (read-only; prod analytics Cloud SQL via your gcloud ADC)
+ANALYTICS_CONN="policyengine-household-api:us-central1:household-api-user-analytics" \
+  uv run python tools/parity/inventory.py --days 90
+
+# Regenerate per-client contract cases from the inventory
+uv run python tools/parity/corpus_from_inventory.py --top-clients 5
+
+# Freeze goldens from production (unauthenticated demo endpoint, rate-limited)
+uv run python tools/parity/parity.py capture \
+  --base-url https://household.api.policyengine.org \
+  --endpoint calculate_demo --sleep-between 11
+
+# Diff any candidate implementation against the goldens
+uv run python tools/parity/parity.py diff --base-url http://127.0.0.1:8080
+```
+
+Note: the `USER_ANALYTICS_DB_CONNECTION_NAME` secret points at a stale
+instance; the real one is passed via `ANALYTICS_CONN` above.
+
+## Contract decisions taken (revisit before Phase 4)
+
+- **Sync, not job-based** — household calc is sub-second; partners keep
+  request/response semantics.
+- **Path + envelope preserved** — `/{country}/calculate`, v1 entity structure,
+  null-to-compute, `policyengine_bundle.model_version`.
+- **Version channels carry over** — v2's Modal registry mirrors
+  `current`/`frontier`/exact-pin semantics.
+
+## Known gaps in the v2 experiment (tracked by the periphery corpus cases)
+
+Warnings (partial-month), deprecated-input filtering, axes caps, malformed
+period rejection, auth wiring, Modal deploy, analytics. UK support blocked on
+#1601's root cause (policyengine-uk 2.x `Simulation` signature).

--- a/tools/parity/cases/client-1ar7c1fq.json
+++ b/tools/parity/cases/client-1ar7c1fq.json
@@ -1,0 +1,142 @@
+{
+ "country": "us",
+ "payload": {
+  "household": {
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_disabled": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "medicaid_category": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     },
+     "wic_category": {
+      "2026": null
+     },
+     "commodity_supplemental_food_program": {
+      "2026": null
+     },
+     "wa_apple_health_kids_eligible": {
+      "2026": null
+     },
+     "early_head_start": {
+      "2026": null
+     },
+     "head_start": {
+      "2026": null
+     },
+     "meets_ssi_disability_criteria": {
+      "2026": null
+     },
+     "tx_harris_rides_eligible": {
+      "2026": null
+     },
+     "chip": {
+      "2026": null
+     },
+     "tx_dart_benefit_person": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "eitc": {
+      "2026": null
+     },
+     "ctc_value": {
+      "2026": null
+     },
+     "wa_working_families_tax_credit": {
+      "2026": null
+     },
+     "aca_ptc": {
+      "2026": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "lifeline": {
+      "2026": null
+     },
+     "snap": {
+      "2026-01": null,
+      "2026": null
+     },
+     "school_meal_daily_subsidy": {
+      "2026": null
+     },
+     "school_meal_tier": {
+      "2026": null
+     },
+     "wa_tanf": {
+      "2026": null
+     }
+    }
+   },
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "WA"
+     }
+    }
+   }
+  }
+ },
+ "meta": {
+  "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+  "state": "WA",
+  "requested_outputs": 25
+ }
+}

--- a/tools/parity/cases/client-2bvocxth.json
+++ b/tools/parity/cases/client-2bvocxth.json
@@ -1,0 +1,144 @@
+{
+ "country": "us",
+ "payload": {
+  "household": {
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "medicaid_category": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     },
+     "wic_category": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "commodity_supplemental_food_program": {
+      "2026": null
+     },
+     "co_family_affordability_credit": {
+      "2026": null
+     },
+     "co_chp_eligible": {
+      "2026": null
+     },
+     "co_oap": {
+      "2026": null
+     },
+     "co_state_supplement": {
+      "2026": null
+     },
+     "early_head_start": {
+      "2026": null
+     },
+     "head_start": {
+      "2026": null
+     },
+     "msp": {
+      "2026": null
+     },
+     "msp_category": {
+      "2026": null
+     },
+     "msp_eligible": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "ctc_value": {
+      "2026": null
+     },
+     "eitc": {
+      "2026": null
+     },
+     "aca_ptc": {
+      "2026": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "lifeline": {
+      "2026": null
+     },
+     "school_meal_daily_subsidy": {
+      "2026": null
+     },
+     "school_meal_tier": {
+      "2026": null
+     },
+     "snap": {
+      "2026-01": null
+     },
+     "nc_scca_maximum_payment": {
+      "2026": null
+     },
+     "nc_tanf": {
+      "2026": null
+     }
+    }
+   },
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CO"
+     }
+    }
+   }
+  }
+ },
+ "meta": {
+  "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+  "state": "CO",
+  "requested_outputs": 25
+ }
+}

--- a/tools/parity/cases/client-cxwdaxfi.json
+++ b/tools/parity/cases/client-cxwdaxfi.json
@@ -1,0 +1,144 @@
+{
+ "country": "us",
+ "payload": {
+  "household": {
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "ssi": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     },
+     "is_ssi_eligible": {
+      "2026": null
+     },
+     "is_ssi_aged": {
+      "2026": null
+     },
+     "is_aca_ptc_eligible": {
+      "2026": null
+     },
+     "chip": {
+      "2026": null
+     },
+     "msp": {
+      "2026": null
+     },
+     "msp_eligible": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "eitc": {
+      "2026": null
+     },
+     "income_tax": {
+      "2026": null
+     },
+     "aca_ptc": {
+      "2026": null
+     },
+     "premium_tax_credit": {
+      "2026": null
+     },
+     "adjusted_gross_income": {
+      "2026": null
+     },
+     "ca_income_tax": {
+      "2026": null
+     },
+     "ca_exemptions": {
+      "2026": null
+     },
+     "ca_eitc": {
+      "2026": null
+     },
+     "ca_cdcc": {
+      "2026": null
+     },
+     "ca_income_tax_before_credits": {
+      "2026": null
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": null
+     },
+     "ca_yctc": {
+      "2026": null
+     },
+     "taxable_income": {
+      "2026": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "snap": {
+      "2026": null
+     },
+     "is_snap_eligible": {
+      "2026": null
+     }
+    }
+   },
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   }
+  }
+ },
+ "meta": {
+  "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+  "state": "CA",
+  "requested_outputs": 25
+ }
+}

--- a/tools/parity/cases/client-dq9pluou.json
+++ b/tools/parity/cases/client-dq9pluou.json
@@ -1,0 +1,78 @@
+{
+ "country": "us",
+ "payload": {
+  "household": {
+   "people": {
+    "adult": {
+     "age": {
+      "2026": null
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "snap": {
+      "2026": null
+     }
+    }
+   },
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CA"
+     },
+     "state_code_str": {
+      "2026": null
+     }
+    }
+   }
+  }
+ },
+ "meta": {
+  "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+  "state": "CA",
+  "requested_outputs": 4
+ }
+}

--- a/tools/parity/cases/client-ekpf8ynf.json
+++ b/tools/parity/cases/client-ekpf8ynf.json
@@ -1,0 +1,144 @@
+{
+ "country": "us",
+ "payload": {
+  "household": {
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": null
+     },
+     "is_aca_ptc_eligible": {
+      "2026": null
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     },
+     "is_ssi_aged": {
+      "2026": null
+     },
+     "is_ssi_eligible": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "aca_ptc": {
+      "2026": null
+     },
+     "ca_cdcc": {
+      "2026": null
+     },
+     "ca_eitc": {
+      "2026": null
+     },
+     "ca_eitc_eligible": {
+      "2026": null
+     },
+     "ca_foster_youth_tax_credit": {
+      "2026": null
+     },
+     "ca_income_tax_before_credits": {
+      "2026": null
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": null
+     },
+     "ca_renter_credit": {
+      "2026": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "ca_calworks_child_care": {
+      "2026": null
+     },
+     "ca_calworks_child_care_eligible": {
+      "2026": null
+     }
+    }
+   },
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CA"
+     },
+     "ca_la_ez_save": {
+      "2026": null
+     },
+     "ca_la_ez_save_eligible": {
+      "2026": null
+     },
+     "ca_care": {
+      "2026": null
+     },
+     "ca_care_eligible": {
+      "2026": null
+     },
+     "ca_fera": {
+      "2026": null
+     },
+     "ca_fera_eligible": {
+      "2026": null
+     }
+    }
+   }
+  }
+ },
+ "meta": {
+  "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+  "state": "CA",
+  "requested_outputs": 25
+ }
+}

--- a/tools/parity/corpus_from_inventory.py
+++ b/tools/parity/corpus_from_inventory.py
@@ -1,0 +1,123 @@
+"""Generate per-client parity corpus cases from the analytics inventory.
+
+For each active client, builds a synthetic household that requests that
+client's most-used output variables (from calculate_request_variables) on the
+entity types they actually use — i.e. an executable statement of "what this
+client needs the API to compute." Values are synthetic; variable names,
+entities, and states come from real usage, so a case passing parity means the
+candidate implementation covers that client's contract.
+
+    uv run python tools/parity/corpus_from_inventory.py [--top-clients 5] [--top-vars 25]
+
+Writes tools/parity/cases/client-<id8>.json; parity.py picks these up
+automatically alongside the built-in corpus.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+HERE = Path(__file__).parent
+CASES_DIR = HERE / "cases"
+REPORT = HERE / "inventory-report.json"
+
+STATE_PREFIXES = {
+    "ca_": "CA", "co_": "CO", "ny_": "NY", "tx_": "TX", "il_": "IL",
+    "ma_": "MA", "md_": "MD", "mi_": "MI", "nc_": "NC", "nj_": "NJ",
+    "or_": "OR", "pa_": "PA", "wa_": "WA", "dc_": "DC", "mo_": "MO",
+}
+
+ENTITY_GROUP = {
+    "person": None,  # people
+    "tax_unit": "tax_units",
+    "spm_unit": "spm_units",
+    "family": "families",
+    "marital_unit": "marital_units",
+    "household": "households",
+}
+
+YEAR = "2026"
+
+
+def infer_state(output_vars: list[str]) -> str:
+    counts: dict[str, int] = {}
+    for v in output_vars:
+        for pfx, st in STATE_PREFIXES.items():
+            if v.startswith(pfx):
+                counts[st] = counts.get(st, 0) + 1
+    return max(counts, key=counts.get) if counts else "CA"
+
+
+def build_case(client_id: str, rows: list[dict], top_vars: int) -> dict:
+    outputs = [r for r in rows if r["source"] == "requested_output" and r["availability_status"] == "supported"]
+    outputs.sort(key=lambda r: -int(r["n"]))
+    chosen = outputs[:top_vars]
+    state = infer_state([r["variable_name"] for r in chosen])
+
+    household: dict = {
+        "people": {
+            "adult": {"age": {YEAR: 35}, "employment_income": {YEAR: 24000}},
+            "child": {"age": {YEAR: 6}},
+        },
+        "tax_units": {"tu": {"members": ["adult", "child"]}},
+        "spm_units": {"spm": {"members": ["adult", "child"]}},
+        "families": {"fam": {"members": ["adult", "child"]}},
+        "marital_units": {"mu": {"members": ["adult"]}},
+        "households": {"hh": {"members": ["adult", "child"], "state_name": {YEAR: state}}},
+    }
+
+    for r in chosen:
+        entity = r["entity_type"]
+        # Match the client's real period granularity where it's unambiguous.
+        period = f"{YEAR}-01" if r["period_granularity"] == "month" else YEAR
+        if entity == "person":
+            household["people"]["adult"].setdefault(r["variable_name"], {})[period] = None
+        else:
+            group = ENTITY_GROUP.get(entity)
+            if not group:
+                continue
+            key = next(iter(household[group]))
+            household[group][key].setdefault(r["variable_name"], {})[period] = None
+
+    return {
+        "country": "us",
+        "payload": {"household": household},
+        "meta": {
+            "client_id": client_id,
+            "state": state,
+            "requested_outputs": len(chosen),
+        },
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--top-clients", type=int, default=5)
+    ap.add_argument("--top-vars", type=int, default=25)
+    args = ap.parse_args()
+
+    report = json.loads(REPORT.read_text())
+    by_client: dict[str, list[dict]] = {}
+    for row in report.get("variables_by_client", []):
+        if row["client_id"]:
+            by_client.setdefault(row["client_id"], []).append(row)
+
+    # Rank clients by request volume from the clients section.
+    volume = {c["client_id"]: c["requests"] for c in report.get("clients", []) if c["client_id"]}
+    ranked = sorted(by_client, key=lambda c: -volume.get(c, 0))[: args.top_clients]
+
+    CASES_DIR.mkdir(exist_ok=True)
+    for client_id in ranked:
+        case = build_case(client_id, by_client[client_id], args.top_vars)
+        name = f"client-{re.sub(r'[^A-Za-z0-9]', '', client_id)[:8].lower()}"
+        (CASES_DIR / f"{name}.json").write_text(json.dumps(case, indent=1))
+        print(f"✓ {name}: state={case['meta']['state']} outputs={case['meta']['requested_outputs']} (client {client_id[:12]}…, {volume.get(client_id, '?')} req/90d)")
+    print(f"\ncases in {CASES_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/parity/golden/client-1ar7c1fq.json
+++ b/tools/parity/golden/client-1ar7c1fq.json
@@ -1,0 +1,286 @@
+{
+ "captured_at": "2026-07-02T15:04:38.470170+00:00",
+ "case": "client-1ar7c1fq",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "WA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "chip": {
+      "2026": null
+     },
+     "commodity_supplemental_food_program": {
+      "2026": null
+     },
+     "early_head_start": {
+      "2026": null
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "head_start": {
+      "2026": null
+     },
+     "is_disabled": {
+      "2026": null
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "medicaid_category": {
+      "2026": null
+     },
+     "meets_ssi_disability_criteria": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "tx_dart_benefit_person": {
+      "2026": null
+     },
+     "tx_harris_rides_eligible": {
+      "2026": null
+     },
+     "wa_apple_health_kids_eligible": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     },
+     "wic_category": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "lifeline": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "school_meal_daily_subsidy": {
+      "2026": null
+     },
+     "school_meal_tier": {
+      "2026": null
+     },
+     "snap": {
+      "2026": null,
+      "2026-01": null
+     },
+     "wa_tanf": {
+      "2026": null
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": null
+     },
+     "ctc_value": {
+      "2026": null
+     },
+     "eitc": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "wa_working_families_tax_credit": {
+      "2026": null
+     }
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "WA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "chip": {
+      "2026": 0.0
+     },
+     "commodity_supplemental_food_program": {
+      "2026": 0.0
+     },
+     "early_head_start": {
+      "2026": 0.0
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "head_start": {
+      "2026": 0.0
+     },
+     "is_disabled": {
+      "2026": false
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2026": false
+     },
+     "medicaid": {
+      "2026": 19548.031
+     },
+     "medicaid_category": {
+      "2026": "ADULT"
+     },
+     "meets_ssi_disability_criteria": {
+      "2026": false
+     },
+     "ssi": {
+      "2026": 0.0
+     },
+     "tx_dart_benefit_person": {
+      "2026": 0.0
+     },
+     "tx_harris_rides_eligible": {
+      "2026": false
+     },
+     "wa_apple_health_kids_eligible": {
+      "2026": false
+     },
+     "wic": {
+      "2026": 0.0
+     },
+     "wic_category": {
+      "2026": "NONE"
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "lifeline": {
+      "2026": 0.0
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "school_meal_daily_subsidy": {
+      "2026": 7.1546535
+     },
+     "school_meal_tier": {
+      "2026": "FREE"
+     },
+     "snap": {
+      "2026": 1585.617,
+      "2026-01": 128.69998
+     },
+     "wa_tanf": {
+      "2026": 0.0
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": 0.0
+     },
+     "ctc_value": {
+      "2026": 2200.0
+     },
+     "eitc": {
+      "2026": 4409.422
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "wa_working_families_tax_credit": {
+      "2026": 674.9575
+     }
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/client-2bvocxth.json
+++ b/tools/parity/golden/client-2bvocxth.json
@@ -1,0 +1,290 @@
+{
+ "captured_at": "2026-07-02T15:04:51.589899+00:00",
+ "case": "client-2bvocxth",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CO"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "co_chp_eligible": {
+      "2026": null
+     },
+     "co_family_affordability_credit": {
+      "2026": null
+     },
+     "co_oap": {
+      "2026": null
+     },
+     "co_state_supplement": {
+      "2026": null
+     },
+     "commodity_supplemental_food_program": {
+      "2026": null
+     },
+     "early_head_start": {
+      "2026": null
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "head_start": {
+      "2026": null
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "medicaid_category": {
+      "2026": null
+     },
+     "msp": {
+      "2026": null
+     },
+     "msp_category": {
+      "2026": null
+     },
+     "msp_eligible": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     },
+     "wic_category": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "lifeline": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "nc_scca_maximum_payment": {
+      "2026": null
+     },
+     "nc_tanf": {
+      "2026": null
+     },
+     "school_meal_daily_subsidy": {
+      "2026": null
+     },
+     "school_meal_tier": {
+      "2026": null
+     },
+     "snap": {
+      "2026-01": null
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": null
+     },
+     "ctc_value": {
+      "2026": null
+     },
+     "eitc": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CO"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "co_chp_eligible": {
+      "2026": false
+     },
+     "co_family_affordability_credit": {
+      "2026": 0.0
+     },
+     "co_oap": {
+      "2026": 0.0
+     },
+     "co_state_supplement": {
+      "2026": 0.0
+     },
+     "commodity_supplemental_food_program": {
+      "2026": 0.0
+     },
+     "early_head_start": {
+      "2026": 0.0
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "head_start": {
+      "2026": 0.0
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2026": false
+     },
+     "medicaid": {
+      "2026": 13451.431
+     },
+     "medicaid_category": {
+      "2026": "ADULT"
+     },
+     "msp": {
+      "2026": 0.0
+     },
+     "msp_category": {
+      "2026": "NONE"
+     },
+     "msp_eligible": {
+      "2026": false
+     },
+     "ssi": {
+      "2026": 0.0
+     },
+     "wic": {
+      "2026": 0.0
+     },
+     "wic_category": {
+      "2026": "NONE"
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "lifeline": {
+      "2026": 0.0
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "nc_scca_maximum_payment": {
+      "2026": 0.0
+     },
+     "nc_tanf": {
+      "2026": 0.0
+     },
+     "school_meal_daily_subsidy": {
+      "2026": 7.1546535
+     },
+     "school_meal_tier": {
+      "2026": "FREE"
+     },
+     "snap": {
+      "2026-01": 128.69998
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": 0.0
+     },
+     "ctc_value": {
+      "2026": 2200.0
+     },
+     "eitc": {
+      "2026": 4409.422
+     },
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/client-cxwdaxfi.json
+++ b/tools/parity/golden/client-cxwdaxfi.json
@@ -1,0 +1,290 @@
+{
+ "captured_at": "2026-07-02T15:05:04.694675+00:00",
+ "case": "client-cxwdaxfi",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "chip": {
+      "2026": null
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_aca_ptc_eligible": {
+      "2026": null
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     },
+     "is_ssi_aged": {
+      "2026": null
+     },
+     "is_ssi_eligible": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "msp": {
+      "2026": null
+     },
+     "msp_eligible": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "is_snap_eligible": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "snap": {
+      "2026": null
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": null
+     },
+     "adjusted_gross_income": {
+      "2026": null
+     },
+     "ca_cdcc": {
+      "2026": null
+     },
+     "ca_eitc": {
+      "2026": null
+     },
+     "ca_exemptions": {
+      "2026": null
+     },
+     "ca_income_tax": {
+      "2026": null
+     },
+     "ca_income_tax_before_credits": {
+      "2026": null
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": null
+     },
+     "ca_yctc": {
+      "2026": null
+     },
+     "eitc": {
+      "2026": null
+     },
+     "income_tax": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "premium_tax_credit": {
+      "2026": null
+     },
+     "taxable_income": {
+      "2026": null
+     }
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "chip": {
+      "2026": 0.0
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_aca_ptc_eligible": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": true
+     },
+     "is_ssi_aged": {
+      "2026": false
+     },
+     "is_ssi_eligible": {
+      "2026": false
+     },
+     "medicaid": {
+      "2026": 11360.863
+     },
+     "msp": {
+      "2026": 0.0
+     },
+     "msp_eligible": {
+      "2026": false
+     },
+     "ssi": {
+      "2026": 0.0
+     },
+     "wic": {
+      "2026": 0.0
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "is_snap_eligible": {
+      "2026": true
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "snap": {
+      "2026": 1585.617
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": 0.0
+     },
+     "adjusted_gross_income": {
+      "2026": 24000.0
+     },
+     "ca_cdcc": {
+      "2026": 0.0
+     },
+     "ca_eitc": {
+      "2026": 282.9856
+     },
+     "ca_exemptions": {
+      "2026": 642.2323
+     },
+     "ca_income_tax": {
+      "2026": -282.9856
+     },
+     "ca_income_tax_before_credits": {
+      "2026": 125.88
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": 0.0
+     },
+     "ca_yctc": {
+      "2026": 0.0
+     },
+     "eitc": {
+      "2026": 4409.422
+     },
+     "income_tax": {
+      "2026": -6109.422
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "premium_tax_credit": {
+      "2026": 0.0
+     },
+     "taxable_income": {
+      "2026": 0.0
+     }
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/client-dq9pluou.json
+++ b/tools/parity/golden/client-dq9pluou.json
@@ -1,0 +1,158 @@
+{
+ "captured_at": "2026-07-02T15:05:17.444771+00:00",
+ "case": "client-dq9pluou",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_code_str": {
+      "2026": null
+     },
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": null
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "snap": {
+      "2026": null
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_code_str": {
+      "2026": "CA"
+     },
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 40.0
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_medicaid_eligible": {
+      "2026": true
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult",
+      "child"
+     ],
+     "snap": {
+      "2026": 1585.617
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/client-ekpf8ynf.json
+++ b/tools/parity/golden/client-ekpf8ynf.json
@@ -1,0 +1,290 @@
+{
+ "captured_at": "2026-07-02T15:05:30.377339+00:00",
+ "case": "client-ekpf8ynf",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "ca_care": {
+      "2026": null
+     },
+     "ca_care_eligible": {
+      "2026": null
+     },
+     "ca_fera": {
+      "2026": null
+     },
+     "ca_fera_eligible": {
+      "2026": null
+     },
+     "ca_la_ez_save": {
+      "2026": null
+     },
+     "ca_la_ez_save_eligible": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": null
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": null
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_aca_ptc_eligible": {
+      "2026": null
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     },
+     "is_ssi_aged": {
+      "2026": null
+     },
+     "is_ssi_eligible": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "ca_calworks_child_care": {
+      "2026": null
+     },
+     "ca_calworks_child_care_eligible": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": null
+     },
+     "ca_cdcc": {
+      "2026": null
+     },
+     "ca_eitc": {
+      "2026": null
+     },
+     "ca_eitc_eligible": {
+      "2026": null
+     },
+     "ca_foster_youth_tax_credit": {
+      "2026": null
+     },
+     "ca_income_tax_before_credits": {
+      "2026": null
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": null
+     },
+     "ca_renter_credit": {
+      "2026": null
+     },
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "ca_care": {
+      "2026": 0.0
+     },
+     "ca_care_eligible": {
+      "2026": true
+     },
+     "ca_fera": {
+      "2026": 0.0
+     },
+     "ca_fera_eligible": {
+      "2026": false
+     },
+     "ca_la_ez_save": {
+      "2026": 0.0
+     },
+     "ca_la_ez_save_eligible": {
+      "2026": false
+     },
+     "members": [
+      "adult",
+      "child"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": true
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": false
+     },
+     "employment_income": {
+      "2026": 24000
+     },
+     "is_aca_ptc_eligible": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": true
+     },
+     "is_ssi_aged": {
+      "2026": false
+     },
+     "is_ssi_eligible": {
+      "2026": false
+     },
+     "medicaid": {
+      "2026": 11360.863
+     },
+     "ssi": {
+      "2026": 0.0
+     },
+     "wic": {
+      "2026": 0.0
+     }
+    },
+    "child": {
+     "age": {
+      "2026": 6
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "ca_calworks_child_care": {
+      "2026": 0.0
+     },
+     "ca_calworks_child_care_eligible": {
+      "2026": false
+     },
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "aca_ptc": {
+      "2026": 0.0
+     },
+     "ca_cdcc": {
+      "2026": 0.0
+     },
+     "ca_eitc": {
+      "2026": 282.9856
+     },
+     "ca_eitc_eligible": {
+      "2026": true
+     },
+     "ca_foster_youth_tax_credit": {
+      "2026": 0.0
+     },
+     "ca_income_tax_before_credits": {
+      "2026": 125.88
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": 0.0
+     },
+     "ca_renter_credit": {
+      "2026": 0.0
+     },
+     "members": [
+      "adult",
+      "child"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/us-amplifi-2025.json
+++ b/tools/parity/golden/us-amplifi-2025.json
@@ -1,0 +1,744 @@
+{
+ "captured_at": "2026-07-02T12:59:31.387078+00:00",
+ "case": "us-amplifi-2025",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "family": {
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ]
+    }
+   },
+   "households": {
+    "household": {
+     "ca_care": {
+      "2025": null
+     },
+     "ca_care_eligible": {
+      "2025": null
+     },
+     "ca_fera": {
+      "2025": null
+     },
+     "ca_fera_eligible": {
+      "2025": null
+     },
+     "ca_la_ez_save": {
+      "2025-3": null
+     },
+     "ca_la_ez_save_eligible": {
+      "2025-3": null
+     },
+     "ca_tanf_region1": {
+      "2025": true
+     },
+     "household_vehicles_owned": {
+      "2025": 1
+     },
+     "household_vehicles_value": {
+      "2025": "33501"
+     },
+     "in_ala": {
+      "2025": false
+     },
+     "in_la": {
+      "2025": true
+     },
+     "in_riv": {
+      "2025": false
+     },
+     "lives_in_vehicle": {
+      "2025": false
+     },
+     "living_arrangements_allow_for_food_preparation": {
+      "2025": true
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "state_code_str": {
+      "2025": "CA"
+     },
+     "tenant_pays_utilities": {
+      "2025": true
+     },
+     "zip_code": {
+      "2025": "91367"
+     }
+    }
+   },
+   "people": {
+    "member1": {
+     "age": {
+      "2025": 3
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2025": null
+     },
+     "ca_calworks_child_care_time_category": {
+      "2025": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2025": null
+     },
+     "immigration_status_str": {
+      "2025": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2025": false
+     },
+     "is_aca_ptc_eligible": {
+      "2025": null
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_medicaid_eligible": {
+      "2025": null
+     },
+     "is_ssi_aged": {
+      "2025": null
+     },
+     "is_ssi_eligible": {
+      "2025": null
+     },
+     "medicaid": {
+      "2025": null
+     },
+     "ssi": {
+      "2025": null
+     },
+     "wic": {
+      "2025": null
+     }
+    },
+    "member2": {
+     "age": {
+      "2025": 1
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2025": null
+     },
+     "ca_calworks_child_care_time_category": {
+      "2025": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2025": null
+     },
+     "immigration_status_str": {
+      "2025": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2025": false
+     },
+     "is_aca_ptc_eligible": {
+      "2025": null
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_medicaid_eligible": {
+      "2025": null
+     },
+     "is_ssi_aged": {
+      "2025": null
+     },
+     "is_ssi_eligible": {
+      "2025": null
+     },
+     "medicaid": {
+      "2025": null
+     },
+     "ssi": {
+      "2025": null
+     },
+     "wic": {
+      "2025": null
+     }
+    },
+    "you": {
+     "age": {
+      "2025": 30
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2025": null
+     },
+     "ca_calworks_child_care_time_category": {
+      "2025": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2025": null
+     },
+     "employment_income": {
+      "2025": 48000
+     },
+     "immigration_status_str": {
+      "2025": "UNDOCUMENTED"
+     },
+     "is_aca_eshi_eligible": {
+      "2025": false
+     },
+     "is_aca_ptc_eligible": {
+      "2025": null
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_medicaid_eligible": {
+      "2025": null
+     },
+     "is_pregnant": {
+      "2025": false
+     },
+     "is_ssi_aged": {
+      "2025": null
+     },
+     "is_ssi_eligible": {
+      "2025": null
+     },
+     "medicaid": {
+      "2025": null
+     },
+     "receives_medicaid": {
+      "2025": false
+     },
+     "rent": {
+      "2025": 38748
+     },
+     "ssi": {
+      "2025": null
+     },
+     "wic": {
+      "2025": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "ca_ala_general_assistance": {
+      "2025": null
+     },
+     "ca_ala_general_assistance_income_eligible": {
+      "2025": null
+     },
+     "ca_calworks_child_care": {
+      "2025": null
+     },
+     "ca_calworks_child_care_eligible": {
+      "2025": null
+     },
+     "ca_riv_general_relief": {
+      "2025": null
+     },
+     "ca_riv_general_relief_eligible": {
+      "2025": null
+     },
+     "ca_riv_share_eligible": {
+      "2025": null
+     },
+     "ca_riv_share_payment": {
+      "2025": null
+     },
+     "ca_state_supplement": {
+      "2025": null
+     },
+     "ca_tanf": {
+      "2025": null
+     },
+     "ca_tanf_eligible": {
+      "2025": null
+     },
+     "heating_cooling_expense": {
+      "2025": 1
+     },
+     "is_lifeline_eligible": {
+      "2025": null
+     },
+     "is_snap_eligible": {
+      "2025": null
+     },
+     "la_general_relief": {
+      "2025": null
+     },
+     "la_general_relief_eligible": {
+      "2025": null
+     },
+     "lifeline": {
+      "2025": null
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "phone_cost": {
+      "2025": 999
+     },
+     "pre_subsidy_electricity_expense": {
+      "2025": 6000
+     },
+     "snap": {
+      "2025": null
+     }
+    }
+   },
+   "tax_units": {
+    "tax_unit": {
+     "aca_ptc": {
+      "2025": null
+     },
+     "ca_cdcc": {
+      "2025": null
+     },
+     "ca_eitc": {
+      "2025": null
+     },
+     "ca_eitc_eligible": {
+      "2025": null
+     },
+     "ca_foster_youth_tax_credit": {
+      "2025": null
+     },
+     "ca_income_tax_before_credits": {
+      "2025": null
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2025": null
+     },
+     "ca_renter_credit": {
+      "2025": null
+     },
+     "ca_yctc": {
+      "2025": null
+     },
+     "cdcc": {
+      "2025": null
+     },
+     "ctc": {
+      "2025": null
+     },
+     "eitc": {
+      "2025": null
+     },
+     "eitc_eligible": {
+      "2025": null
+     },
+     "income_tax": {
+      "2025": null
+     },
+     "income_tax_before_credits": {
+      "2025": null
+     },
+     "income_tax_before_refundable_credits": {
+      "2025": null
+     },
+     "income_tax_capped_non_refundable_credits": {
+      "2025": null
+     },
+     "income_tax_non_refundable_credits": {
+      "2025": null
+     },
+     "income_tax_refundable_credits": {
+      "2025": null
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "premium_tax_credit": {
+      "2025": null
+     },
+     "refundable_ctc": {
+      "2025": null
+     },
+     "tax_unit_is_joint": {
+      "2025": false
+     }
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "family": {
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ]
+    }
+   },
+   "households": {
+    "household": {
+     "ca_care": {
+      "2025": 1950.0
+     },
+     "ca_care_eligible": {
+      "2025": true
+     },
+     "ca_fera": {
+      "2025": 0.0
+     },
+     "ca_fera_eligible": {
+      "2025": false
+     },
+     "ca_la_ez_save": {
+      "2025-3": 8.17
+     },
+     "ca_la_ez_save_eligible": {
+      "2025-3": true
+     },
+     "ca_tanf_region1": {
+      "2025": true
+     },
+     "household_vehicles_owned": {
+      "2025": 1
+     },
+     "household_vehicles_value": {
+      "2025": "33501"
+     },
+     "in_ala": {
+      "2025": false
+     },
+     "in_la": {
+      "2025": true
+     },
+     "in_riv": {
+      "2025": false
+     },
+     "lives_in_vehicle": {
+      "2025": false
+     },
+     "living_arrangements_allow_for_food_preparation": {
+      "2025": true
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "state_code_str": {
+      "2025": "CA"
+     },
+     "tenant_pays_utilities": {
+      "2025": true
+     },
+     "zip_code": {
+      "2025": "91367"
+     }
+    }
+   },
+   "people": {
+    "member1": {
+     "age": {
+      "2025": 3
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2025": false
+     },
+     "ca_calworks_child_care_time_category": {
+      "2025": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2025": false
+     },
+     "immigration_status_str": {
+      "2025": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2025": false
+     },
+     "is_aca_ptc_eligible": {
+      "2025": false
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_medicaid_eligible": {
+      "2025": true
+     },
+     "is_ssi_aged": {
+      "2025": false
+     },
+     "is_ssi_eligible": {
+      "2025": false
+     },
+     "medicaid": {
+      "2025": 7954.026
+     },
+     "ssi": {
+      "2025": 0.0
+     },
+     "wic": {
+      "2025": 711.42633
+     }
+    },
+    "member2": {
+     "age": {
+      "2025": 1
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2025": false
+     },
+     "ca_calworks_child_care_time_category": {
+      "2025": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2025": false
+     },
+     "immigration_status_str": {
+      "2025": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2025": false
+     },
+     "is_aca_ptc_eligible": {
+      "2025": false
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_medicaid_eligible": {
+      "2025": true
+     },
+     "is_ssi_aged": {
+      "2025": false
+     },
+     "is_ssi_eligible": {
+      "2025": false
+     },
+     "medicaid": {
+      "2025": 7954.026
+     },
+     "ssi": {
+      "2025": 0.0
+     },
+     "wic": {
+      "2025": 711.27057
+     }
+    },
+    "you": {
+     "age": {
+      "2025": 30
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2025": false
+     },
+     "ca_calworks_child_care_time_category": {
+      "2025": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2025": false
+     },
+     "employment_income": {
+      "2025": 48000
+     },
+     "immigration_status_str": {
+      "2025": "UNDOCUMENTED"
+     },
+     "is_aca_eshi_eligible": {
+      "2025": false
+     },
+     "is_aca_ptc_eligible": {
+      "2025": false
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_medicaid_eligible": {
+      "2025": false
+     },
+     "is_pregnant": {
+      "2025": false
+     },
+     "is_ssi_aged": {
+      "2025": false
+     },
+     "is_ssi_eligible": {
+      "2025": false
+     },
+     "medicaid": {
+      "2025": 0.0
+     },
+     "receives_medicaid": {
+      "2025": false
+     },
+     "rent": {
+      "2025": 38748
+     },
+     "ssi": {
+      "2025": 0.0
+     },
+     "wic": {
+      "2025": 0.0
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "ca_ala_general_assistance": {
+      "2025": 0.0
+     },
+     "ca_ala_general_assistance_income_eligible": {
+      "2025": false
+     },
+     "ca_calworks_child_care": {
+      "2025": 0.0
+     },
+     "ca_calworks_child_care_eligible": {
+      "2025": false
+     },
+     "ca_riv_general_relief": {
+      "2025": 0.0
+     },
+     "ca_riv_general_relief_eligible": {
+      "2025": false
+     },
+     "ca_riv_share_eligible": {
+      "2025": false
+     },
+     "ca_riv_share_payment": {
+      "2025": 0.0
+     },
+     "ca_state_supplement": {
+      "2025": 0.0
+     },
+     "ca_tanf": {
+      "2025": 0.0
+     },
+     "ca_tanf_eligible": {
+      "2025": false
+     },
+     "heating_cooling_expense": {
+      "2025": 1
+     },
+     "is_lifeline_eligible": {
+      "2025": true
+     },
+     "is_snap_eligible": {
+      "2025": false
+     },
+     "la_general_relief": {
+      "2025": 0.0
+     },
+     "la_general_relief_eligible": {
+      "2025": false
+     },
+     "lifeline": {
+      "2025": 228.0
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "phone_cost": {
+      "2025": 999
+     },
+     "pre_subsidy_electricity_expense": {
+      "2025": 6000
+     },
+     "snap": {
+      "2025": 0.0
+     }
+    }
+   },
+   "tax_units": {
+    "tax_unit": {
+     "aca_ptc": {
+      "2025": 0.0
+     },
+     "ca_cdcc": {
+      "2025": 0.0
+     },
+     "ca_eitc": {
+      "2025": 0.0
+     },
+     "ca_eitc_eligible": {
+      "2025": false
+     },
+     "ca_foster_youth_tax_credit": {
+      "2025": 0.0
+     },
+     "ca_income_tax_before_credits": {
+      "2025": 510.03
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2025": 0.0
+     },
+     "ca_renter_credit": {
+      "2025": 120.0
+     },
+     "ca_yctc": {
+      "2025": 0.0
+     },
+     "cdcc": {
+      "2025": 0.0
+     },
+     "ctc": {
+      "2025": 4400.0
+     },
+     "eitc": {
+      "2025": 1960.71
+     },
+     "eitc_eligible": {
+      "2025": true
+     },
+     "income_tax": {
+      "2025": -3775.71
+     },
+     "income_tax_before_credits": {
+      "2025": 2585.0
+     },
+     "income_tax_before_refundable_credits": {
+      "2025": 0.0
+     },
+     "income_tax_capped_non_refundable_credits": {
+      "2025": 2585.0
+     },
+     "income_tax_non_refundable_credits": {
+      "2025": 2585.0
+     },
+     "income_tax_refundable_credits": {
+      "2025": 3775.71
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "premium_tax_credit": {
+      "2025": 0.0
+     },
+     "refundable_ctc": {
+      "2025": 1815.0
+     },
+     "tax_unit_is_joint": {
+      "2025": false
+     }
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/us-amplifi.json
+++ b/tools/parity/golden/us-amplifi.json
@@ -1,0 +1,744 @@
+{
+ "captured_at": "2026-07-02T12:59:18.461460+00:00",
+ "case": "us-amplifi",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "family": {
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ]
+    }
+   },
+   "households": {
+    "household": {
+     "ca_care": {
+      "2026": null
+     },
+     "ca_care_eligible": {
+      "2026": null
+     },
+     "ca_fera": {
+      "2026": null
+     },
+     "ca_fera_eligible": {
+      "2026": null
+     },
+     "ca_la_ez_save": {
+      "2026-3": null
+     },
+     "ca_la_ez_save_eligible": {
+      "2026-3": null
+     },
+     "ca_tanf_region1": {
+      "2026": true
+     },
+     "household_vehicles_owned": {
+      "2026": 1
+     },
+     "household_vehicles_value": {
+      "2026": "33501"
+     },
+     "in_ala": {
+      "2026": false
+     },
+     "in_la": {
+      "2026": true
+     },
+     "in_riv": {
+      "2026": false
+     },
+     "lives_in_vehicle": {
+      "2026": false
+     },
+     "living_arrangements_allow_for_food_preparation": {
+      "2026": true
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "state_code_str": {
+      "2026": "CA"
+     },
+     "tenant_pays_utilities": {
+      "2026": true
+     },
+     "zip_code": {
+      "2026": "91367"
+     }
+    }
+   },
+   "people": {
+    "member1": {
+     "age": {
+      "2026": 3
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": null
+     },
+     "ca_calworks_child_care_time_category": {
+      "2026": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": null
+     },
+     "immigration_status_str": {
+      "2026": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2026": false
+     },
+     "is_aca_ptc_eligible": {
+      "2026": null
+     },
+     "is_disabled": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     },
+     "is_ssi_aged": {
+      "2026": null
+     },
+     "is_ssi_eligible": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     }
+    },
+    "member2": {
+     "age": {
+      "2026": 1
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": null
+     },
+     "ca_calworks_child_care_time_category": {
+      "2026": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": null
+     },
+     "immigration_status_str": {
+      "2026": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2026": false
+     },
+     "is_aca_ptc_eligible": {
+      "2026": null
+     },
+     "is_disabled": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     },
+     "is_ssi_aged": {
+      "2026": null
+     },
+     "is_ssi_eligible": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "ssi": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     }
+    },
+    "you": {
+     "age": {
+      "2026": 30
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": null
+     },
+     "ca_calworks_child_care_time_category": {
+      "2026": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": null
+     },
+     "employment_income": {
+      "2026": 48000
+     },
+     "immigration_status_str": {
+      "2026": "UNDOCUMENTED"
+     },
+     "is_aca_eshi_eligible": {
+      "2026": false
+     },
+     "is_aca_ptc_eligible": {
+      "2026": null
+     },
+     "is_disabled": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": null
+     },
+     "is_pregnant": {
+      "2026": false
+     },
+     "is_ssi_aged": {
+      "2026": null
+     },
+     "is_ssi_eligible": {
+      "2026": null
+     },
+     "medicaid": {
+      "2026": null
+     },
+     "receives_medicaid": {
+      "2026": false
+     },
+     "rent": {
+      "2026": 38748
+     },
+     "ssi": {
+      "2026": null
+     },
+     "wic": {
+      "2026": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "ca_ala_general_assistance": {
+      "2026": null
+     },
+     "ca_ala_general_assistance_income_eligible": {
+      "2026": null
+     },
+     "ca_calworks_child_care": {
+      "2026": null
+     },
+     "ca_calworks_child_care_eligible": {
+      "2026": null
+     },
+     "ca_riv_general_relief": {
+      "2026": null
+     },
+     "ca_riv_general_relief_eligible": {
+      "2026": null
+     },
+     "ca_riv_share_eligible": {
+      "2026": null
+     },
+     "ca_riv_share_payment": {
+      "2026": null
+     },
+     "ca_state_supplement": {
+      "2026": null
+     },
+     "ca_tanf": {
+      "2026": null
+     },
+     "ca_tanf_eligible": {
+      "2026": null
+     },
+     "heating_cooling_expense": {
+      "2026": 1
+     },
+     "is_lifeline_eligible": {
+      "2026": null
+     },
+     "is_snap_eligible": {
+      "2026": null
+     },
+     "la_general_relief": {
+      "2026": null
+     },
+     "la_general_relief_eligible": {
+      "2026": null
+     },
+     "lifeline": {
+      "2026": null
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "phone_cost": {
+      "2026": 999
+     },
+     "pre_subsidy_electricity_expense": {
+      "2026": 6000
+     },
+     "snap": {
+      "2026": null
+     }
+    }
+   },
+   "tax_units": {
+    "tax_unit": {
+     "aca_ptc": {
+      "2026": null
+     },
+     "ca_cdcc": {
+      "2026": null
+     },
+     "ca_eitc": {
+      "2026": null
+     },
+     "ca_eitc_eligible": {
+      "2026": null
+     },
+     "ca_foster_youth_tax_credit": {
+      "2026": null
+     },
+     "ca_income_tax_before_credits": {
+      "2026": null
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": null
+     },
+     "ca_renter_credit": {
+      "2026": null
+     },
+     "ca_yctc": {
+      "2026": null
+     },
+     "cdcc": {
+      "2026": null
+     },
+     "ctc": {
+      "2026": null
+     },
+     "eitc": {
+      "2026": null
+     },
+     "eitc_eligible": {
+      "2026": null
+     },
+     "income_tax": {
+      "2026": null
+     },
+     "income_tax_before_credits": {
+      "2026": null
+     },
+     "income_tax_before_refundable_credits": {
+      "2026": null
+     },
+     "income_tax_capped_non_refundable_credits": {
+      "2026": null
+     },
+     "income_tax_non_refundable_credits": {
+      "2026": null
+     },
+     "income_tax_refundable_credits": {
+      "2026": null
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "premium_tax_credit": {
+      "2026": null
+     },
+     "refundable_ctc": {
+      "2026": null
+     },
+     "tax_unit_is_joint": {
+      "2026": false
+     }
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "family": {
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ]
+    }
+   },
+   "households": {
+    "household": {
+     "ca_care": {
+      "2026": 1950.0
+     },
+     "ca_care_eligible": {
+      "2026": true
+     },
+     "ca_fera": {
+      "2026": 0.0
+     },
+     "ca_fera_eligible": {
+      "2026": false
+     },
+     "ca_la_ez_save": {
+      "2026-3": 8.17
+     },
+     "ca_la_ez_save_eligible": {
+      "2026-3": true
+     },
+     "ca_tanf_region1": {
+      "2026": true
+     },
+     "household_vehicles_owned": {
+      "2026": 1
+     },
+     "household_vehicles_value": {
+      "2026": "33501"
+     },
+     "in_ala": {
+      "2026": false
+     },
+     "in_la": {
+      "2026": true
+     },
+     "in_riv": {
+      "2026": false
+     },
+     "lives_in_vehicle": {
+      "2026": false
+     },
+     "living_arrangements_allow_for_food_preparation": {
+      "2026": true
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "state_code_str": {
+      "2026": "CA"
+     },
+     "tenant_pays_utilities": {
+      "2026": true
+     },
+     "zip_code": {
+      "2026": "91367"
+     }
+    }
+   },
+   "people": {
+    "member1": {
+     "age": {
+      "2026": 3
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": false
+     },
+     "ca_calworks_child_care_time_category": {
+      "2026": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": false
+     },
+     "immigration_status_str": {
+      "2026": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2026": false
+     },
+     "is_aca_ptc_eligible": {
+      "2026": false
+     },
+     "is_disabled": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": true
+     },
+     "is_ssi_aged": {
+      "2026": false
+     },
+     "is_ssi_eligible": {
+      "2026": false
+     },
+     "medicaid": {
+      "2026": 7954.026
+     },
+     "ssi": {
+      "2026": 0.0
+     },
+     "wic": {
+      "2026": 723.1546
+     }
+    },
+    "member2": {
+     "age": {
+      "2026": 1
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": false
+     },
+     "ca_calworks_child_care_time_category": {
+      "2026": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": false
+     },
+     "immigration_status_str": {
+      "2026": "CITIZEN"
+     },
+     "is_aca_eshi_eligible": {
+      "2026": false
+     },
+     "is_aca_ptc_eligible": {
+      "2026": false
+     },
+     "is_disabled": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": true
+     },
+     "is_ssi_aged": {
+      "2026": false
+     },
+     "is_ssi_eligible": {
+      "2026": false
+     },
+     "medicaid": {
+      "2026": 7954.026
+     },
+     "ssi": {
+      "2026": 0.0
+     },
+     "wic": {
+      "2026": 722.9943
+     }
+    },
+    "you": {
+     "age": {
+      "2026": 30
+     },
+     "ca_ala_general_assistance_eligible_person": {
+      "2026": false
+     },
+     "ca_calworks_child_care_time_category": {
+      "2026": "MONTHLY"
+     },
+     "ca_state_supplement_eligible_person": {
+      "2026": false
+     },
+     "employment_income": {
+      "2026": 48000
+     },
+     "immigration_status_str": {
+      "2026": "UNDOCUMENTED"
+     },
+     "is_aca_eshi_eligible": {
+      "2026": false
+     },
+     "is_aca_ptc_eligible": {
+      "2026": false
+     },
+     "is_disabled": {
+      "2026": false
+     },
+     "is_medicaid_eligible": {
+      "2026": false
+     },
+     "is_pregnant": {
+      "2026": false
+     },
+     "is_ssi_aged": {
+      "2026": false
+     },
+     "is_ssi_eligible": {
+      "2026": false
+     },
+     "medicaid": {
+      "2026": 0.0
+     },
+     "receives_medicaid": {
+      "2026": false
+     },
+     "rent": {
+      "2026": 38748
+     },
+     "ssi": {
+      "2026": 0.0
+     },
+     "wic": {
+      "2026": 0.0
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "ca_ala_general_assistance": {
+      "2026": 0.0
+     },
+     "ca_ala_general_assistance_income_eligible": {
+      "2026": false
+     },
+     "ca_calworks_child_care": {
+      "2026": 0.0
+     },
+     "ca_calworks_child_care_eligible": {
+      "2026": false
+     },
+     "ca_riv_general_relief": {
+      "2026": 0.0
+     },
+     "ca_riv_general_relief_eligible": {
+      "2026": false
+     },
+     "ca_riv_share_eligible": {
+      "2026": false
+     },
+     "ca_riv_share_payment": {
+      "2026": 0.0
+     },
+     "ca_state_supplement": {
+      "2026": 0.0
+     },
+     "ca_tanf": {
+      "2026": 0.0
+     },
+     "ca_tanf_eligible": {
+      "2026": false
+     },
+     "heating_cooling_expense": {
+      "2026": 1
+     },
+     "is_lifeline_eligible": {
+      "2026": true
+     },
+     "is_snap_eligible": {
+      "2026": false
+     },
+     "la_general_relief": {
+      "2026": 0.0
+     },
+     "la_general_relief_eligible": {
+      "2026": false
+     },
+     "lifeline": {
+      "2026": 228.0
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "phone_cost": {
+      "2026": 999
+     },
+     "pre_subsidy_electricity_expense": {
+      "2026": 6000
+     },
+     "snap": {
+      "2026": 0.0
+     }
+    }
+   },
+   "tax_units": {
+    "tax_unit": {
+     "aca_ptc": {
+      "2026": 0.0
+     },
+     "ca_cdcc": {
+      "2026": 0.0
+     },
+     "ca_eitc": {
+      "2026": 0.0
+     },
+     "ca_eitc_eligible": {
+      "2026": false
+     },
+     "ca_foster_youth_tax_credit": {
+      "2026": 0.0
+     },
+     "ca_income_tax_before_credits": {
+      "2026": 505.00494
+     },
+     "ca_income_tax_before_refundable_credits": {
+      "2026": 0.0
+     },
+     "ca_renter_credit": {
+      "2026": 120.0
+     },
+     "ca_yctc": {
+      "2026": 0.0
+     },
+     "cdcc": {
+      "2026": 0.0
+     },
+     "ctc": {
+      "2026": 4400.0
+     },
+     "eitc": {
+      "2026": 2238.434
+     },
+     "eitc_eligible": {
+      "2026": true
+     },
+     "income_tax": {
+      "2026": -4130.434
+     },
+     "income_tax_before_credits": {
+      "2026": 2508.0
+     },
+     "income_tax_before_refundable_credits": {
+      "2026": 0.0
+     },
+     "income_tax_capped_non_refundable_credits": {
+      "2026": 2508.0
+     },
+     "income_tax_non_refundable_credits": {
+      "2026": 2508.0
+     },
+     "income_tax_refundable_credits": {
+      "2026": 4130.434
+     },
+     "members": [
+      "you",
+      "member1",
+      "member2"
+     ],
+     "premium_tax_credit": {
+      "2026": 0.0
+     },
+     "refundable_ctc": {
+      "2026": 1892.0
+     },
+     "tax_unit_is_joint": {
+      "2026": false
+     }
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/us-axes-sweep.json
+++ b/tools/parity/golden/us-axes-sweep.json
@@ -1,0 +1,162 @@
+{
+ "captured_at": "2026-07-02T15:00:53.122124+00:00",
+ "case": "us-axes-sweep",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "axes": [
+    [
+     {
+      "count": 5,
+      "max": 100000,
+      "min": 0,
+      "name": "employment_income",
+      "period": "2026"
+     }
+    ]
+   ],
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "TX"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 30
+     },
+     "employment_income": {
+      "2026": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": null
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "axes": [
+    [
+     {
+      "count": 5,
+      "max": 100000,
+      "min": 0,
+      "name": "employment_income",
+      "period": "2026"
+     }
+    ]
+   ],
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "TX"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 30
+     },
+     "employment_income": {
+      "2026": [
+       0.0,
+       25000.0,
+       50000.0,
+       75000.0,
+       100000.0
+      ]
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": [
+       0.0,
+       890.0,
+       3820.0,
+       7670.0,
+       13170.0
+      ]
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/us-err-unknown-variable.json
+++ b/tools/parity/golden/us-err-unknown-variable.json
@@ -1,0 +1,70 @@
+{
+ "captured_at": "2026-07-02T15:15:57.347937+00:00",
+ "case": "us-err-unknown-variable",
+ "country": "us",
+ "expected_status": 400,
+ "model_versions": null,
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "definitely_not_a_variable": {
+      "2026": 1
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": null
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "errors": [
+   "Variable `definitely_not_a_variable` on `people/adult` is not available in PolicyEngine model version 1.744.0 used by this API. Remove it or migrate to a supported variable."
+  ],
+  "message": "Invalid household variables.",
+  "status": "error"
+ }
+}

--- a/tools/parity/golden/us-impactica.json
+++ b/tools/parity/golden/us-impactica.json
@@ -1,0 +1,140 @@
+{
+ "captured_at": "2026-07-02T12:59:43.914574+00:00",
+ "case": "us-impactica",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "households": {
+    "household": {
+     "members": [
+      "you",
+      "Child_0"
+     ],
+     "state_code_str": {
+      "2025": "OR"
+     }
+    }
+   },
+   "people": {
+    "Child_0": {
+     "age": {
+      "2025": 1
+     }
+    },
+    "you": {
+     "age": {
+      "2025": 30
+     },
+     "employment_income": {
+      "2025": 4752.0
+     },
+     "is_medicaid_eligible": {
+      "2025": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "members": [
+      "you",
+      "Child_0"
+     ],
+     "snap": {
+      "2025": null
+     },
+     "snap_assets": {
+      "2025": 0.0
+     },
+     "snap_excess_shelter_expense_deduction": {
+      "2025": 672
+     }
+    }
+   },
+   "tax_units": {
+    "tax_unit": {
+     "basic_standard_deduction": {
+      "2025": 0
+     },
+     "members": [
+      "you",
+      "Child_0"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "households": {
+    "household": {
+     "members": [
+      "you",
+      "Child_0"
+     ],
+     "state_code_str": {
+      "2025": "OR"
+     }
+    }
+   },
+   "people": {
+    "Child_0": {
+     "age": {
+      "2025": 1
+     }
+    },
+    "you": {
+     "age": {
+      "2025": 30
+     },
+     "employment_income": {
+      "2025": 4752.0
+     },
+     "is_medicaid_eligible": {
+      "2025": true
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "members": [
+      "you",
+      "Child_0"
+     ],
+     "snap": {
+      "2025": 5422.5
+     },
+     "snap_assets": {
+      "2025": 0.0
+     },
+     "snap_excess_shelter_expense_deduction": {
+      "2025": 672
+     }
+    }
+   },
+   "tax_units": {
+    "tax_unit": {
+     "basic_standard_deduction": {
+      "2025": 0
+     },
+     "members": [
+      "you",
+      "Child_0"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/us-my-friend-ben.json
+++ b/tools/parity/golden/us-my-friend-ben.json
@@ -1,0 +1,494 @@
+{
+ "captured_at": "2026-07-02T12:59:05.738938+00:00",
+ "case": "us-my-friend-ben",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "family": {
+     "members": [
+      "2021359"
+     ]
+    }
+   },
+   "households": {
+    "household": {
+     "members": [
+      "2021359"
+     ],
+     "state_code": {
+      "2024": "CO",
+      "2025": "CO"
+     }
+    }
+   },
+   "marital_units": {},
+   "people": {
+    "2021359": {
+     "age": {
+      "2024": 49,
+      "2025": 49
+     },
+     "capital_gains": {
+      "2024": 0,
+      "2025": 0
+     },
+     "child_support_expense": {
+      "2025": 0
+     },
+     "co_chp_eligible": {
+      "2025": null
+     },
+     "co_family_affordability_credit": {
+      "2024": null
+     },
+     "co_oap": {
+      "2025": null
+     },
+     "co_state_supplement": {
+      "2025": null
+     },
+     "commodity_supplemental_food_program": {
+      "2025": null
+     },
+     "current_pregnancies": {
+      "2025": 1
+     },
+     "employment_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "is_blind": {
+      "2025": false
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_full_time_college_student": {
+      "2025": true
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2025": null
+     },
+     "is_pregnant": {
+      "2025": true
+     },
+     "is_snap_ineligible_student": {
+      "2025": true
+     },
+     "is_tax_unit_dependent": {
+      "2024": false,
+      "2025": false
+     },
+     "is_tax_unit_head": {
+      "2025": true
+     },
+     "is_tax_unit_spouse": {
+      "2024": false,
+      "2025": false
+     },
+     "medicaid": {
+      "2025": null
+     },
+     "medicaid_category": {
+      "2025": null
+     },
+     "other_medical_expenses": {
+      "2025": 0
+     },
+     "real_estate_taxes": {
+      "2025": 0
+     },
+     "rental_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "self_employment_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "social_security": {
+      "2024": 0,
+      "2025": 0
+     },
+     "ssi": {
+      "2025": null
+     },
+     "ssi_countable_resources": {
+      "2025": 200
+     },
+     "ssi_earned_income": {
+      "2025": 0
+     },
+     "ssi_reported": {
+      "2025": 0
+     },
+     "ssi_unearned_income": {
+      "2025": 0
+     },
+     "taxable_ira_distributions": {
+      "2024": 0,
+      "2025": 0
+     },
+     "taxable_pension_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "unemployment_compensation": {
+      "2024": 0,
+      "2025": 0
+     },
+     "wic": {
+      "2025": null
+     },
+     "wic_category": {
+      "2025": null
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "broadband_cost": {
+      "2025": 500
+     },
+     "co_tanf": {
+      "2025": null
+     },
+     "co_tanf_countable_gross_earned_income": {
+      "2025": 0
+     },
+     "co_tanf_countable_gross_unearned_income": {
+      "2025": 0
+     },
+     "has_heating_cooling_expense": {
+      "2025": false
+     },
+     "has_phone_expense": {
+      "2025": false
+     },
+     "heating_cooling_expense": {
+      "2025": 0
+     },
+     "homeowners_association_fees": {
+      "2025": 0
+     },
+     "homeowners_insurance": {
+      "2025": 0
+     },
+     "housing_cost": {
+      "2025": 0
+     },
+     "lifeline": {
+      "2025": null
+     },
+     "members": [
+      "2021359"
+     ],
+     "phone_expense": {
+      "2025": 0
+     },
+     "school_meal_countable_income": {
+      "2025": 0
+     },
+     "school_meal_daily_subsidy": {
+      "2025": null
+     },
+     "school_meal_tier": {
+      "2025": null
+     },
+     "snap": {
+      "2025-01": null
+     },
+     "snap_assets": {
+      "2025": 200
+     },
+     "snap_earned_income": {
+      "2025": 0
+     },
+     "snap_emergency_allotment": {
+      "2025": 0
+     },
+     "snap_unearned_income": {
+      "2025": 0
+     },
+     "spm_unit_pre_subsidy_childcare_expenses": {
+      "2025": 0
+     },
+     "water_expense": {
+      "2025": 0
+     }
+    }
+   },
+   "tax_units": {
+    "main_tax_unit": {
+     "co_ctc": {
+      "2024": null
+     },
+     "co_eitc": {
+      "2024": null
+     },
+     "ctc_value": {
+      "2024": null
+     },
+     "eitc": {
+      "2024": null
+     },
+     "members": [
+      "2021359"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "family": {
+     "members": [
+      "2021359"
+     ]
+    }
+   },
+   "households": {
+    "household": {
+     "members": [
+      "2021359"
+     ],
+     "state_code": {
+      "2024": "CO",
+      "2025": "CO"
+     }
+    }
+   },
+   "marital_units": {},
+   "people": {
+    "2021359": {
+     "age": {
+      "2024": 49,
+      "2025": 49
+     },
+     "capital_gains": {
+      "2024": 0,
+      "2025": 0
+     },
+     "child_support_expense": {
+      "2025": 0
+     },
+     "co_chp_eligible": {
+      "2025": false
+     },
+     "co_family_affordability_credit": {
+      "2024": 0.0
+     },
+     "co_oap": {
+      "2025": 0.0
+     },
+     "co_state_supplement": {
+      "2025": 0.0
+     },
+     "commodity_supplemental_food_program": {
+      "2025": 0.0
+     },
+     "current_pregnancies": {
+      "2025": 1
+     },
+     "employment_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "is_blind": {
+      "2025": false
+     },
+     "is_disabled": {
+      "2025": false
+     },
+     "is_full_time_college_student": {
+      "2025": true
+     },
+     "is_optional_senior_or_disabled_for_medicaid": {
+      "2025": false
+     },
+     "is_pregnant": {
+      "2025": true
+     },
+     "is_snap_ineligible_student": {
+      "2025": true
+     },
+     "is_tax_unit_dependent": {
+      "2024": false,
+      "2025": false
+     },
+     "is_tax_unit_head": {
+      "2025": true
+     },
+     "is_tax_unit_spouse": {
+      "2024": false,
+      "2025": false
+     },
+     "medicaid": {
+      "2025": 10936.13
+     },
+     "medicaid_category": {
+      "2025": "PREGNANT"
+     },
+     "other_medical_expenses": {
+      "2025": 0
+     },
+     "real_estate_taxes": {
+      "2025": 0
+     },
+     "rental_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "self_employment_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "social_security": {
+      "2024": 0,
+      "2025": 0
+     },
+     "ssi": {
+      "2025": 0.0
+     },
+     "ssi_countable_resources": {
+      "2025": 200
+     },
+     "ssi_earned_income": {
+      "2025": 0
+     },
+     "ssi_reported": {
+      "2025": 0
+     },
+     "ssi_unearned_income": {
+      "2025": 0
+     },
+     "taxable_ira_distributions": {
+      "2024": 0,
+      "2025": 0
+     },
+     "taxable_pension_income": {
+      "2024": 0,
+      "2025": 0
+     },
+     "unemployment_compensation": {
+      "2024": 0,
+      "2025": 0
+     },
+     "wic": {
+      "2025": 1004.8897
+     },
+     "wic_category": {
+      "2025": "PREGNANT"
+     }
+    }
+   },
+   "spm_units": {
+    "spm_unit": {
+     "broadband_cost": {
+      "2025": 500
+     },
+     "co_tanf": {
+      "2025": 5712.0
+     },
+     "co_tanf_countable_gross_earned_income": {
+      "2025": 0
+     },
+     "co_tanf_countable_gross_unearned_income": {
+      "2025": 0
+     },
+     "has_heating_cooling_expense": {
+      "2025": false
+     },
+     "has_phone_expense": {
+      "2025": false
+     },
+     "heating_cooling_expense": {
+      "2025": 0
+     },
+     "homeowners_association_fees": {
+      "2025": 0
+     },
+     "homeowners_insurance": {
+      "2025": 0
+     },
+     "housing_cost": {
+      "2025": 0
+     },
+     "lifeline": {
+      "2025": 111.0
+     },
+     "members": [
+      "2021359"
+     ],
+     "phone_expense": {
+      "2025": 0
+     },
+     "school_meal_countable_income": {
+      "2025": 0
+     },
+     "school_meal_daily_subsidy": {
+      "2025": 7.06
+     },
+     "school_meal_tier": {
+      "2025": "FREE"
+     },
+     "snap": {
+      "2025-01": 0.0
+     },
+     "snap_assets": {
+      "2025": 200
+     },
+     "snap_earned_income": {
+      "2025": 0
+     },
+     "snap_emergency_allotment": {
+      "2025": 0
+     },
+     "snap_unearned_income": {
+      "2025": 0
+     },
+     "spm_unit_pre_subsidy_childcare_expenses": {
+      "2025": 0
+     },
+     "water_expense": {
+      "2025": 0
+     }
+    }
+   },
+   "tax_units": {
+    "main_tax_unit": {
+     "co_ctc": {
+      "2024": 0.0
+     },
+     "co_eitc": {
+      "2024": 0.0
+     },
+     "ctc_value": {
+      "2024": 0.0
+     },
+     "eitc": {
+      "2024": 0.0
+     },
+     "members": [
+      "2021359"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/us-single-adult.json
+++ b/tools/parity/golden/us-single-adult.json
@@ -1,0 +1,134 @@
+{
+ "captured_at": "2026-07-02T12:59:56.711376+00:00",
+ "case": "us-single-adult",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026": 30000
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ],
+     "snap": {
+      "2026": null
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": null
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026": 30000
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ],
+     "snap": {
+      "2026": 0.0
+     }
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": 1420.0
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/golden/us-warn-deprecated-input.json
+++ b/tools/parity/golden/us-warn-deprecated-input.json
@@ -1,0 +1,134 @@
+{
+ "captured_at": "2026-07-02T15:00:40.766202+00:00",
+ "case": "us-warn-deprecated-input",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "NY"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 40
+     },
+     "employment_income": {
+      "2026": 50000
+     },
+     "medical_out_of_pocket_expenses": {
+      "2026": 1200
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": null
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "NY"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 40
+     },
+     "employment_income": {
+      "2026": 50000
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": 3820.0
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  },
+  "status": "ok",
+  "warnings": [
+   "Input `medical_out_of_pocket_expenses` on `people/adult` is deprecated and was ignored for this calculation. Removed in policyengine-us 1.673.0. Migrate non-premium spending to `other_medical_expenses` and premium spending to `health_insurance_premiums`."
+  ]
+ }
+}

--- a/tools/parity/golden/us-warn-partial-month.json
+++ b/tools/parity/golden/us-warn-partial-month.json
@@ -1,0 +1,128 @@
+{
+ "captured_at": "2026-07-02T15:00:28.036123+00:00",
+ "case": "us-warn-partial-month",
+ "country": "us",
+ "model_versions": {
+  "data_version": null,
+  "dataset": null,
+  "model_version": "1.744.0"
+ },
+ "reference_base_url": "https://household.api.policyengine.org",
+ "request": {
+  "household": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026-01": 2500
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": null
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  }
+ },
+ "response": {
+  "message": null,
+  "policyengine_bundle": {
+   "data_version": null,
+   "dataset": null,
+   "model_version": "1.744.0"
+  },
+  "result": {
+   "families": {
+    "fam": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "households": {
+    "hh": {
+     "members": [
+      "adult"
+     ],
+     "state_name": {
+      "2026": "CA"
+     }
+    }
+   },
+   "marital_units": {
+    "mu": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "people": {
+    "adult": {
+     "age": {
+      "2026": 35
+     },
+     "employment_income": {
+      "2026-01": 2500
+     }
+    }
+   },
+   "spm_units": {
+    "spm": {
+     "members": [
+      "adult"
+     ]
+    }
+   },
+   "tax_units": {
+    "tu": {
+     "income_tax": {
+      "2026": -191.25
+     },
+     "members": [
+      "adult"
+     ]
+    }
+   }
+  },
+  "status": "ok"
+ }
+}

--- a/tools/parity/inventory-report.json
+++ b/tools/parity/inventory-report.json
@@ -1,0 +1,5900 @@
+{
+ "generated_at": "2026-07-02T13:05:53.673476+00:00",
+ "window_days": 90,
+ "tables": [
+  "alembic_version",
+  "calculate_request_variables",
+  "calculate_requests",
+  "users",
+  "visits"
+ ],
+ "clients": [
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "requests": 19138,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current,frontier",
+   "requested_versions": "1.715.2,current",
+   "error_responses": "0",
+   "first_seen": "2026-05-12 21:16:10",
+   "last_seen": "2026-07-02 13:05:39"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "requests": 8283,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current,frontier",
+   "requested_versions": "1.715.2,1.732.0,current,frontier",
+   "error_responses": "2",
+   "first_seen": "2026-05-12 21:20:43",
+   "last_seen": "2026-07-01 17:25:00"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "requests": 6308,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current,frontier",
+   "requested_versions": "current,frontier",
+   "error_responses": "158",
+   "first_seen": "2026-05-12 21:33:23",
+   "last_seen": "2026-07-01 22:46:47"
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "requests": 4279,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "0",
+   "first_seen": "2026-05-12 21:23:32",
+   "last_seen": "2026-07-02 11:12:37"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "requests": 3076,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current,frontier",
+   "requested_versions": "1.691.1,1.715.2,1.726.0,1.732.0,1.744.0,1.755.0,current,frontier",
+   "error_responses": "27",
+   "first_seen": "2026-05-13 12:21:11",
+   "last_seen": "2026-07-02 01:56:22"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "requests": 922,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "135",
+   "first_seen": "2026-06-02 17:10:00",
+   "last_seen": "2026-07-02 00:56:24"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "requests": 852,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "0",
+   "first_seen": "2026-05-12 22:54:53",
+   "last_seen": "2026-07-02 10:44:15"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "requests": 339,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "0",
+   "first_seen": "2026-05-12 21:46:19",
+   "last_seen": "2026-07-01 08:20:33"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "requests": 299,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "0",
+   "first_seen": "2026-05-12 21:45:27",
+   "last_seen": "2026-07-02 09:13:02"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "requests": 68,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current,frontier",
+   "requested_versions": "current,frontier",
+   "error_responses": "8",
+   "first_seen": "2026-05-22 18:19:07",
+   "last_seen": "2026-05-22 18:38:15"
+  },
+  {
+   "client_id": null,
+   "requests": 57,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "0",
+   "first_seen": "2026-06-25 16:42:02",
+   "last_seen": "2026-07-02 10:43:57"
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "requests": 52,
+   "countries": 1,
+   "country_list": "us",
+   "channels": null,
+   "requested_versions": null,
+   "error_responses": "4",
+   "first_seen": "2026-05-19 15:52:36",
+   "last_seen": "2026-05-19 16:07:33"
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "requests": 33,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "23",
+   "first_seen": "2026-06-02 23:03:01",
+   "last_seen": "2026-06-05 05:12:25"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "requests": 24,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current,frontier",
+   "requested_versions": "current,frontier",
+   "error_responses": "0",
+   "first_seen": "2026-05-27 15:45:35",
+   "last_seen": "2026-05-27 15:46:10"
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "requests": 7,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "2",
+   "first_seen": "2026-06-23 20:39:21",
+   "last_seen": "2026-06-25 14:41:45"
+  },
+  {
+   "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
+   "requests": 4,
+   "countries": 1,
+   "country_list": "us",
+   "channels": "current",
+   "requested_versions": "current",
+   "error_responses": "0",
+   "first_seen": "2026-05-30 22:02:18",
+   "last_seen": "2026-05-30 22:05:23"
+  }
+ ],
+ "daily_volume": [
+  {
+   "day": "2026-07-02",
+   "requests": 293,
+   "active_clients": 6
+  },
+  {
+   "day": "2026-07-01",
+   "requests": 686,
+   "active_clients": 9
+  },
+  {
+   "day": "2026-06-30",
+   "requests": 1365,
+   "active_clients": 8
+  },
+  {
+   "day": "2026-06-29",
+   "requests": 802,
+   "active_clients": 8
+  },
+  {
+   "day": "2026-06-28",
+   "requests": 276,
+   "active_clients": 6
+  },
+  {
+   "day": "2026-06-27",
+   "requests": 285,
+   "active_clients": 5
+  },
+  {
+   "day": "2026-06-26",
+   "requests": 604,
+   "active_clients": 7
+  },
+  {
+   "day": "2026-06-25",
+   "requests": 477,
+   "active_clients": 9
+  },
+  {
+   "day": "2026-06-24",
+   "requests": 352,
+   "active_clients": 7
+  },
+  {
+   "day": "2026-06-23",
+   "requests": 233,
+   "active_clients": 8
+  },
+  {
+   "day": "2026-06-22",
+   "requests": 296,
+   "active_clients": 8
+  },
+  {
+   "day": "2026-06-21",
+   "requests": 157,
+   "active_clients": 5
+  },
+  {
+   "day": "2026-06-20",
+   "requests": 77,
+   "active_clients": 4
+  },
+  {
+   "day": "2026-06-19",
+   "requests": 114,
+   "active_clients": 5
+  }
+ ],
+ "errors_by_client": [
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "response_status_code": 400,
+   "n": 158
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "response_status_code": 500,
+   "n": 127
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "response_status_code": 400,
+   "n": 23
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "response_status_code": 400,
+   "n": 20
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "response_status_code": 400,
+   "n": 8
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "response_status_code": 500,
+   "n": 7
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "response_status_code": 400,
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "response_status_code": 500,
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "response_status_code": 400,
+   "n": 4
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "response_status_code": 400,
+   "n": 2
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "response_status_code": 400,
+   "n": 2
+  }
+ ],
+ "uk_usage": [],
+ "variables_by_client": [
+  {
+   "client_id": null,
+   "variable_name": "age",
+   "n": 57
+  },
+  {
+   "client_id": null,
+   "variable_name": "employment_income",
+   "n": 57
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap",
+   "n": 57
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_assets",
+   "n": 57
+  },
+  {
+   "client_id": null,
+   "variable_name": "broadband_cost",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "child_support_expense",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "commodity_supplemental_food_program",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_chp_eligible",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_ctc",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_eitc",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_family_affordability_credit",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_oap",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_state_supplement",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_tanf",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "ctc_value",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "current_pregnancies",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "eitc",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "has_heating_cooling_expense",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "has_phone_expense",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "heating_cooling_expense",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "homeowners_association_fees",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "homeowners_insurance",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "housing_cost",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_blind",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_disabled",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_full_time_college_student",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_pregnant",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_snap_ineligible_student",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_tax_unit_dependent",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_tax_unit_head",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_tax_unit_spouse",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "lifeline",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "medicaid",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "medicaid_category",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "other_medical_expenses",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "phone_expense",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "real_estate_taxes",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "rental_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "school_meal_countable_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "school_meal_daily_subsidy",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "school_meal_tier",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "self_employment_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_earned_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_emergency_allotment",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_unearned_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "social_security",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_countable_resources",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_earned_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_reported",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_unearned_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "state_code",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "taxable_ira_distributions",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "taxable_pension_income",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "unemployment_compensation",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "water_expense",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "wic",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "wic_category",
+   "n": 56
+  },
+  {
+   "client_id": null,
+   "variable_name": "capital_gains",
+   "n": 55
+  },
+  {
+   "client_id": null,
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "n": 55
+  },
+  {
+   "client_id": null,
+   "variable_name": "basic_standard_deduction",
+   "n": 1
+  },
+  {
+   "client_id": null,
+   "variable_name": "childcare_expenses",
+   "n": 1
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_medicaid_eligible",
+   "n": 1
+  },
+  {
+   "client_id": null,
+   "variable_name": "long_term_capital_gains",
+   "n": 1
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "n": 1
+  },
+  {
+   "client_id": null,
+   "variable_name": "state_code_str",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "age",
+   "n": 8283
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "state_code",
+   "n": 8282
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "employment_income",
+   "n": 8236
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "rental_income",
+   "n": 8236
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "self_employment_income",
+   "n": 8236
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "social_security",
+   "n": 8236
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "taxable_ira_distributions",
+   "n": 8236
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "taxable_pension_income",
+   "n": 8236
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "unemployment_compensation",
+   "n": 8236
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_tax_unit_dependent",
+   "n": 8233
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_tax_unit_spouse",
+   "n": 8233
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_disabled",
+   "n": 8146
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "broadband_cost",
+   "n": 7658
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "eitc",
+   "n": 7658
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "lifeline",
+   "n": 7658
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "childcare_expenses",
+   "n": 7647
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "child_support_expense",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "has_heating_cooling_expense",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "has_phone_expense",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "heating_cooling_expense",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "homeowners_association_fees",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "homeowners_insurance",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "housing_cost",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_snap_ineligible_student",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "phone_expense",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "real_estate_taxes",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_assets",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_earned_income",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_emergency_allotment",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_unearned_income",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "water_expense",
+   "n": 7617
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi",
+   "n": 7599
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_countable_resources",
+   "n": 7560
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_tax_unit_head",
+   "n": 7528
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_blind",
+   "n": 7518
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_reported",
+   "n": 7450
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_earned_income",
+   "n": 7440
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_unearned_income",
+   "n": 7440
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_pregnant",
+   "n": 7226
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "other_medical_expenses",
+   "n": 6760
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ctc_value",
+   "n": 6680
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_full_time_college_student",
+   "n": 6386
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "long_term_capital_gains",
+   "n": 6015
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "n": 5867
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "medicaid",
+   "n": 5867
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "medicaid_category",
+   "n": 5867
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "spm_unit_cash_assets",
+   "n": 4933
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "current_pregnancies",
+   "n": 4206
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "school_meal_countable_income",
+   "n": 4206
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "school_meal_daily_subsidy",
+   "n": 4206
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "school_meal_tier",
+   "n": 4206
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wic",
+   "n": 4206
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wic_category",
+   "n": 4206
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wa_working_families_tax_credit",
+   "n": 3681
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "aca_ptc",
+   "n": 3030
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "zip_code",
+   "n": 3030
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "commodity_supplemental_food_program",
+   "n": 3024
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "county_str",
+   "n": 3017
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "employment_income_before_lsr",
+   "n": 2952
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "self_employment_income_before_lsr",
+   "n": 2952
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wa_show_all_cash_assistance_programs",
+   "n": 2952
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wa_tanf",
+   "n": 2952
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "spm_unit_assets",
+   "n": 2295
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "meets_ssi_disability_criteria",
+   "n": 2249
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "capital_gains",
+   "n": 2221
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "n": 2117
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "weekly_hours_worked_before_lsr",
+   "n": 2117
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "early_head_start",
+   "n": 2072
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "head_start",
+   "n": 2054
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "alimony_income",
+   "n": 1823
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wa_apple_health_kids_eligible",
+   "n": 1773
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "social_security_disability",
+   "n": 1611
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "childcare_attending_days_per_month",
+   "n": 1521
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_ccs",
+   "n": 1521
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_harris_rides_eligible",
+   "n": 1521
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_tanf",
+   "n": 1521
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_medicare_eligible",
+   "n": 1518
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "medicare_quarters_of_coverage",
+   "n": 1514
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "msp",
+   "n": 1514
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "msp_category",
+   "n": 1514
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "msp_eligible",
+   "n": 1514
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "chip",
+   "n": 1501
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_veteran",
+   "n": 1501
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_dart_benefit_person",
+   "n": 1501
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_medicaid_eligible",
+   "n": 1319
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tanf",
+   "n": 1301
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "was_in_foster_care",
+   "n": 1298
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "electricity_expense",
+   "n": 1122
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "miscellaneous_income",
+   "n": 1076
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_fpp_benefit",
+   "n": 889
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_scca_countable_income",
+   "n": 879
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_scca_maximum_payment",
+   "n": 879
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_tanf",
+   "n": 879
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_tanf_countable_earned_income",
+   "n": 879
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_tanf_countable_gross_unearned_income",
+   "n": 879
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "n": 857
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "heat_expense_included_in_rent",
+   "n": 774
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_ccdf_eligible",
+   "n": 774
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_ccdf_reason_for_care_eligible",
+   "n": 774
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_child_and_family_credit",
+   "n": 774
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_eitc",
+   "n": 774
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_liheap",
+   "n": 774
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "receives_housing_assistance",
+   "n": 774
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "heating_expense_person",
+   "n": 762
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_chp_eligible",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_ctc",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_eitc",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_family_affordability_credit",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_oap",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_state_supplement",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_tanf",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "n": 729
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_in_public_housing",
+   "n": 444
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_tafdc",
+   "n": 444
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_tcap_gross_earned_income",
+   "n": 444
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_tcap_gross_unearned_income",
+   "n": 444
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "chip_category",
+   "n": 406
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_eaedc",
+   "n": 406
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_eaedc_living_arrangement",
+   "n": 406
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_eaedc_non_financial_eligible",
+   "n": 406
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_state_supplement",
+   "n": 406
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_ceap",
+   "n": 360
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "has_bcc_qualifying_coverage",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_bcc_eligible",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_ctc",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_eitc",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_fpp_eligible",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_hbwd_eligible",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_hbwd_person",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_mpe_eligible",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_tanf",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_tanf_countable_gross_earned_income",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_tanf_countable_unearned_income",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_female",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "receives_medicaid",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "workers_compensation",
+   "n": 302
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_liheap_income_eligible",
+   "n": 301
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_enrolled_in_applicable_programs",
+   "n": 254
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
+   "n": 254
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_senior_charlie_card_eligible",
+   "n": 254
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_tap_charlie_card_eligible",
+   "n": 254
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_aabd_person",
+   "n": 244
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "mortgage_payments",
+   "n": 244
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "rent",
+   "n": 244
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "use_reported_ssi",
+   "n": 110
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_tafdc_pregnancy_eligible",
+   "n": 73
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ks_total_eitc",
+   "n": 32
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ks_cdcc",
+   "n": 30
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ks_tanf",
+   "n": 3
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "cdcc",
+   "n": 2
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "adjusted_gross_income",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "cdcc_credit_limit",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "cdcc_potential",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "cdcc_relevant_expenses",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_liheap",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "income_tax_before_credits",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "min_head_spouse_earned",
+   "n": 1
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tax_unit_childcare_expenses",
+   "n": 1
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi",
+   "n": 19282
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "age",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ctc_value",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "eitc",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "employment_income",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_tax_unit_dependent",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_tax_unit_spouse",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "rental_income",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "self_employment_income",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "social_security",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "state_code",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "taxable_ira_distributions",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "taxable_pension_income",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "unemployment_compensation",
+   "n": 19138
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_disabled",
+   "n": 18991
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "childcare_expenses",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "child_support_expense",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "has_heating_cooling_expense",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "has_phone_expense",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "heating_cooling_expense",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "homeowners_association_fees",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "homeowners_insurance",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "housing_cost",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_pregnant",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_snap_ineligible_student",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "phone_expense",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "real_estate_taxes",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_assets",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_earned_income",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_emergency_allotment",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_unearned_income",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "water_expense",
+   "n": 18976
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "broadband_cost",
+   "n": 18973
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "lifeline",
+   "n": 18973
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_tax_unit_head",
+   "n": 18807
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_blind",
+   "n": 18665
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_countable_resources",
+   "n": 18505
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_earned_income",
+   "n": 18505
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_reported",
+   "n": 18505
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_unearned_income",
+   "n": 18505
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "current_pregnancies",
+   "n": 18422
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "school_meal_countable_income",
+   "n": 18422
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "school_meal_daily_subsidy",
+   "n": 18422
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "school_meal_tier",
+   "n": 18422
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wic",
+   "n": 18422
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wic_category",
+   "n": 18422
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "n": 18360
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "medicaid",
+   "n": 18360
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "medicaid_category",
+   "n": 18360
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "other_medical_expenses",
+   "n": 17762
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_full_time_college_student",
+   "n": 17344
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "aca_ptc",
+   "n": 12334
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "zip_code",
+   "n": 12334
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "county_str",
+   "n": 11123
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "long_term_capital_gains",
+   "n": 10957
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "commodity_supplemental_food_program",
+   "n": 9826
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "capital_gains",
+   "n": 8181
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_scca_countable_income",
+   "n": 7608
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_scca_maximum_payment",
+   "n": 7608
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_tanf",
+   "n": 7608
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_tanf_countable_earned_income",
+   "n": 7608
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_tanf_countable_gross_unearned_income",
+   "n": 7608
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_ctc",
+   "n": 5791
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_eitc",
+   "n": 5791
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_family_affordability_credit",
+   "n": 5791
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_chp_eligible",
+   "n": 5629
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_oap",
+   "n": 5629
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_state_supplement",
+   "n": 5629
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_tanf",
+   "n": 5629
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "n": 5629
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "n": 5629
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "spm_unit_cash_assets",
+   "n": 5418
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "early_head_start",
+   "n": 4197
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "spm_unit_assets",
+   "n": 4197
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "n": 4197
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "weekly_hours_worked_before_lsr",
+   "n": 4197
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "head_start",
+   "n": 4195
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "meets_ssi_disability_criteria",
+   "n": 3738
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_medicare_eligible",
+   "n": 3667
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "alimony_income",
+   "n": 3553
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "social_security_disability",
+   "n": 3531
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "medicare_quarters_of_coverage",
+   "n": 3391
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "msp",
+   "n": 3391
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "msp_category",
+   "n": 3391
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "msp_eligible",
+   "n": 3391
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_medicaid_eligible",
+   "n": 2883
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "miscellaneous_income",
+   "n": 2620
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "was_in_foster_care",
+   "n": 2585
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "childcare_attending_days_per_month",
+   "n": 2565
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tanf",
+   "n": 2565
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_ccs",
+   "n": 2565
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_harris_rides_eligible",
+   "n": 2565
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_tanf",
+   "n": 2565
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "chip",
+   "n": 2545
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_veteran",
+   "n": 2545
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_dart_benefit_person",
+   "n": 2545
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "electricity_expense",
+   "n": 2268
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_fpp_benefit",
+   "n": 1815
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "heat_expense_included_in_rent",
+   "n": 1632
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_ccdf_eligible",
+   "n": 1632
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_ccdf_reason_for_care_eligible",
+   "n": 1632
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_child_and_family_credit",
+   "n": 1632
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eitc",
+   "n": 1632
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_liheap",
+   "n": 1632
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "receives_housing_assistance",
+   "n": 1632
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_in_public_housing",
+   "n": 1619
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_tafdc",
+   "n": 1619
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_tcap_gross_earned_income",
+   "n": 1619
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_tcap_gross_unearned_income",
+   "n": 1619
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "heating_expense_person",
+   "n": 1532
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "chip_category",
+   "n": 1333
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eaedc",
+   "n": 1333
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eaedc_living_arrangement",
+   "n": 1333
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eaedc_non_financial_eligible",
+   "n": 1333
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_state_supplement",
+   "n": 1333
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_mbta_enrolled_in_applicable_programs",
+   "n": 1320
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
+   "n": 1320
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_mbta_senior_charlie_card_eligible",
+   "n": 1320
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_mbta_tap_charlie_card_eligible",
+   "n": 1320
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "n": 1214
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "has_bcc_qualifying_coverage",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_bcc_eligible",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_ctc",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_eitc",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_fpp_eligible",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_hbwd_eligible",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_hbwd_person",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_liheap_income_eligible",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_mpe_eligible",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_tanf",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_tanf_countable_gross_earned_income",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_tanf_countable_unearned_income",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_female",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "receives_medicaid",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "workers_compensation",
+   "n": 988
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_aabd_person",
+   "n": 848
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "mortgage_payments",
+   "n": 848
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "rent",
+   "n": 848
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_ceap",
+   "n": 736
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "employment_income_before_lsr",
+   "n": 554
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "self_employment_income_before_lsr",
+   "n": 554
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wa_show_all_cash_assistance_programs",
+   "n": 554
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wa_tanf",
+   "n": 554
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wa_working_families_tax_credit",
+   "n": 554
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wa_apple_health_kids_eligible",
+   "n": 397
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_care_worker_credit",
+   "n": 162
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_care_worker_credit_eligible_care_worker",
+   "n": 162
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_tafdc_pregnancy_eligible",
+   "n": 89
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "adjusted_gross_income",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "age",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "employment_income",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "filing_status",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "health_savings_account_payroll_contributions",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "income_tax",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "pre_tax_health_insurance_premiums",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "state_code",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "state_income_tax",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "traditional_401k_contributions",
+   "n": 7
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "employee_medicare_tax",
+   "n": 5
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "employee_social_security_tax",
+   "n": 5
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "student_loan_interest",
+   "n": 5
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "ca_employee_state_disability_insurance_contribution",
+   "n": 3
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "gov.states.ca.tax.payroll.disability.employee_rate",
+   "n": 2
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "student_loan_interest_ald",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "age",
+   "n": 3076
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "employment_income",
+   "n": 2883
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "state_name",
+   "n": 1664
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "zip_code",
+   "n": 1456
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_disabled",
+   "n": 1454
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_tax_unit_head",
+   "n": 1440
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_tax_unit_dependent",
+   "n": 1427
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_tax_unit_spouse",
+   "n": 1400
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "county_str",
+   "n": 1315
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "state_code_str",
+   "n": 1309
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "immigration_status_str",
+   "n": 1301
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tax_unit_is_joint",
+   "n": 1301
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_pregnant",
+   "n": 991
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "eitc",
+   "n": 954
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax",
+   "n": 846
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi",
+   "n": 615
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medicaid",
+   "n": 596
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi_countable_resources",
+   "n": 577
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_medicaid_eligible",
+   "n": 479
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_ssi_eligible",
+   "n": 472
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_ssi_aged",
+   "n": 471
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap",
+   "n": 470
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "aca_ptc",
+   "n": 452
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_aca_ptc_eligible",
+   "n": 451
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_aca_eshi_eligible",
+   "n": 449
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "premium_tax_credit",
+   "n": 449
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "chip",
+   "n": 440
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_ccdf_reason_for_care_eligible",
+   "n": 437
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "msp",
+   "n": 436
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "msp_eligible",
+   "n": 436
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_breastfeeding",
+   "n": 429
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_medicare_eligible",
+   "n": 428
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_assets",
+   "n": 389
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "adjusted_gross_income",
+   "n": 381
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_snap_eligible",
+   "n": 292
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_income_tax",
+   "n": 275
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_exemptions",
+   "n": 273
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_eitc",
+   "n": 260
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_cdcc",
+   "n": 256
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_income_tax_before_credits",
+   "n": 256
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_income_tax_before_refundable_credits",
+   "n": 256
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_yctc",
+   "n": 256
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "taxable_income",
+   "n": 255
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_use_tax",
+   "n": 245
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "housing_cost",
+   "n": 245
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_taxable_income",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "filing_status",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_additions",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_agi",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_agi_subtractions",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_amt",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_deductions",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_itemized_deductions",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_mental_health_services_tax",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_non_refundable_credits",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_refundable_credits",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_standard_deduction",
+   "n": 243
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ctc_value",
+   "n": 238
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "housing_assistance",
+   "n": 206
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "school_meal_daily_subsidy",
+   "n": 190
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "school_meal_tier",
+   "n": 190
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ctc",
+   "n": 182
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "wic",
+   "n": 171
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "rent",
+   "n": 164
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "receives_housing_assistance",
+   "n": 160
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "eitc_eligible",
+   "n": 159
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "lifeline",
+   "n": 156
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "refundable_ctc",
+   "n": 153
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi_earned_income",
+   "n": 151
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi_unearned_income",
+   "n": 151
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "commodity_supplemental_food_program",
+   "n": 150
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "wic_category",
+   "n": 148
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "cdcc",
+   "n": 139
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_full_time_student",
+   "n": 138
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medicaid_category",
+   "n": 138
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "social_security",
+   "n": 135
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "n": 121
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "n": 118
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_earned_income",
+   "n": 118
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_emergency_allotment",
+   "n": 118
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_unearned_income",
+   "n": 118
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_blind",
+   "n": 116
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "head_start",
+   "n": 113
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_eitc",
+   "n": 110
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "early_head_start",
+   "n": 110
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_oap",
+   "n": 109
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_chp_eligible",
+   "n": 108
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_ctc",
+   "n": 108
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_family_affordability_credit",
+   "n": 108
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "current_pregnancies",
+   "n": 108
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "heating_cooling_expense",
+   "n": 107
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "broadband_cost",
+   "n": 106
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "capital_gains",
+   "n": 106
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "county_fips",
+   "n": 105
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_state_supplement",
+   "n": 105
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_tanf",
+   "n": 103
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "n": 103
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "n": 102
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_snap_ineligible_student",
+   "n": 102
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "real_estate_taxes",
+   "n": 102
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "school_meal_countable_income",
+   "n": 102
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi_reported",
+   "n": 102
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "child_support_expense",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "has_heating_cooling_expense",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "has_phone_expense",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "homeowners_association_fees",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "homeowners_insurance",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_full_time_college_student",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "other_medical_expenses",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "phone_expense",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "rental_income",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "self_employment_income",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "state_code",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "taxable_ira_distributions",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "taxable_pension_income",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "unemployment_compensation",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "water_expense",
+   "n": 100
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "pre_subsidy_rent",
+   "n": 93
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_wic_eligible",
+   "n": 59
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_lifeline_eligible",
+   "n": 54
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tanf",
+   "n": 43
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tx_tanf",
+   "n": 38
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_ccdf_eligible",
+   "n": 37
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_net_income",
+   "n": 31
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care_time_category",
+   "n": 25
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care",
+   "n": 23
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care_eligible",
+   "n": 23
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax_before_credits",
+   "n": 23
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "in_la",
+   "n": 22
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medicaid_group",
+   "n": 22
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tenant_pays_utilities",
+   "n": 22
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care_full_time",
+   "n": 22
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_state_supplement",
+   "n": 21
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_state_supplement_eligible_person",
+   "n": 21
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "childcare_expenses",
+   "n": 20
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medicaid_enrolled",
+   "n": 20
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "in_ala",
+   "n": 19
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "in_riv",
+   "n": 19
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_eligible_for_housing_assistance",
+   "n": 19
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "phone_cost",
+   "n": 19
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "receives_medicaid",
+   "n": 19
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_ala_general_assistance",
+   "n": 19
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_ala_general_assistance_income_eligible",
+   "n": 19
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "meets_ssi_disability_criteria",
+   "n": 18
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "social_security_retirement",
+   "n": 17
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "wy_power",
+   "n": 17
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_tanf",
+   "n": 16
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_tanf_eligible",
+   "n": 15
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_tanf_region1",
+   "n": 15
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ny_eitc",
+   "n": 15
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tax_unit_childcare_expenses",
+   "n": 15
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_eitc_eligible",
+   "n": 15
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_ala_general_assistance_eligible_person",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_care",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_care_eligible",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_fera",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_fera_eligible",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_foster_youth_tax_credit",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_la_ez_save",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_la_ez_save_eligible",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_renter_credit",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_riv_general_relief",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_riv_general_relief_eligible",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_riv_share_eligible",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_riv_share_payment",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_vehicles_value",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax_before_refundable_credits",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax_capped_non_refundable_credits",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax_non_refundable_credits",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax_refundable_credits",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "la_general_relief",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "la_general_relief_eligible",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "lives_in_vehicle",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "living_arrangements_allow_for_food_preparation",
+   "n": 13
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "chip_category",
+   "n": 12
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "has_bcc_qualifying_coverage",
+   "n": 12
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_female",
+   "n": 12
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_riv_general_relief_meets_work_requirements",
+   "n": 12
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "state_income_tax",
+   "n": 11
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_vehicles_owned",
+   "n": 10
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ma_eaedc",
+   "n": 10
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ma_eaedc_non_financial_eligible",
+   "n": 10
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "msp_category",
+   "n": 10
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "n": 10
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "wy_power_eligible",
+   "n": 10
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ks_tanf",
+   "n": 9
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_income_level",
+   "n": 8
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_in_public_housing",
+   "n": 8
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "nc_scca_countable_income",
+   "n": 8
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "nc_scca_maximum_payment",
+   "n": 8
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "social_security_disability",
+   "n": 8
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "basic_standard_deduction",
+   "n": 8
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "pre_subsidy_electricity_expense",
+   "n": 7
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "wy_power_eligibility",
+   "n": 7
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_annual_income",
+   "n": 6
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_extremely_low_income_limit",
+   "n": 6
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_low_income_limit",
+   "n": 6
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_very_low_income_limit",
+   "n": 6
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ami",
+   "n": 6
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ma_state_supplement",
+   "n": 5
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ma_tafdc",
+   "n": 5
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "survivor_benefits",
+   "n": 5
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "current_pregnancy_month",
+   "n": 4
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "heat_expense_included_in_rent",
+   "n": 4
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "n": 4
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "meets_snap_work_requirements_person",
+   "n": 4
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_gross_rent",
+   "n": 3
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_hap",
+   "n": 3
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_max_subsidy",
+   "n": 3
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_ttp",
+   "n": 3
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "marital_unit_id",
+   "n": 3
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "pha_payment_standard",
+   "n": 3
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "bedrooms",
+   "n": 3
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "applicable_ssi",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_withheld_income_tax",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_benefits",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_market_income",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_refundable_tax_credits",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_state_income_tax",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_tax",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "household_tax_before_refundable_credits",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "il_eitc",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "il_tanf",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "il_tanf_countable_gross_earned_income",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "il_tanf_countable_unearned_income",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_incapable_of_self_care",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_in_work_program",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ks_tanf_is_assistance_unit_member",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ma_eitc",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ma_tcap_gross_earned_income",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ma_tcap_gross_unearned_income",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "months_since_calworks_exit",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "nc_tanf",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "nc_tanf_countable_earned_income",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "nc_tanf_countable_gross_unearned_income",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "spm_unit_tenure_type",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "use_reported_ssi",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "was_calworks_recipient",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "was_in_foster_care",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "wa_tanf",
+   "n": 2
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "codex_probe_20260513_variable_tracking",
+   "n": 1
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "educational_assistance",
+   "n": 1
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "financial_assistance",
+   "n": 1
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_fair_market_rent",
+   "n": 1
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "age",
+   "n": 4322
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "basic_standard_deduction",
+   "n": 4279
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "employment_income",
+   "n": 4279
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "is_medicaid_eligible",
+   "n": 4279
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "snap",
+   "n": 4279
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "snap_assets",
+   "n": 4279
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "n": 4279
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "state_code_str",
+   "n": 4279
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "aca_ptc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_child_care",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_child_care_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_child_care_time_category",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_care",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_care_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_cdcc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_eitc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_eitc_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_fera",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_fera_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_foster_youth_tax_credit",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_income_tax_before_credits",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_income_tax_before_refundable_credits",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_la_ez_save",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_la_ez_save_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_renter_credit",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_state_supplement",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_state_supplement_eligible_person",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf_region1",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_yctc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "cdcc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ctc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "eitc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "eitc_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "immigration_status_str",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_before_credits",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_before_refundable_credits",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_capped_non_refundable_credits",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_non_refundable_credits",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_refundable_credits",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_la",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_aca_eshi_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_aca_ptc_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_disabled",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_lifeline_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_medicaid_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_pregnant",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_snap_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_ssi_aged",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_ssi_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "la_general_relief",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "la_general_relief_eligible",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "lifeline",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "lives_in_vehicle",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "living_arrangements_allow_for_food_preparation",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "medicaid",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "phone_cost",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "premium_tax_credit",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "refundable_ctc",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "snap",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ssi",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "state_code_str",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "tax_unit_is_joint",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "wic",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "zip_code",
+   "n": 6308
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "age",
+   "n": 6294
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance_eligible_person",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance_income_eligible",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_2",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_2_eligible",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_3",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_3_eligible",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_capp",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_capp_eligible",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_general_relief",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_general_relief_eligible",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_share_eligible",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_share_payment",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "health_insurance_premiums",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_ala",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_riv",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "months_since_calworks_exit",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "receives_medicaid",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "tenant_pays_utilities",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "was_calworks_recipient",
+   "n": 6280
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "household_vehicles_value",
+   "n": 6226
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "rent",
+   "n": 4524
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "employment_income",
+   "n": 4140
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "weekly_hours_worked_before_lsr",
+   "n": 3875
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "meets_snap_work_requirements_person",
+   "n": 2535
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "heating_cooling_expense",
+   "n": 2461
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "pre_subsidy_electricity_expense",
+   "n": 2068
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "household_vehicles_owned",
+   "n": 1821
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "other_medical_expenses",
+   "n": 1015
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "meets_ssi_disability_criteria",
+   "n": 974
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_snap_work_program_participant",
+   "n": 943
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_child_care_full_time",
+   "n": 783
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "n": 783
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_general_relief_meets_work_requirements",
+   "n": 446
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "was_in_foster_care",
+   "n": 403
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "social_security_retirement",
+   "n": 289
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_homeless",
+   "n": 226
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "social_security_disability",
+   "n": 147
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "bedrooms",
+   "n": 104
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "pre_subsidy_rent",
+   "n": 104
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "self_employment_income",
+   "n": 100
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "unemployment_compensation",
+   "n": 92
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "housing_assistance",
+   "n": 62
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "receives_housing_assistance",
+   "n": 62
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "child_support_received",
+   "n": 55
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_state_disability_insurance",
+   "n": 54
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_capi_eligible_person",
+   "n": 28
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "mortgage_payments",
+   "n": 16
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "n": 14
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "alimony_income",
+   "n": 12
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_marin_general_relief",
+   "n": 4
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_marin_general_relief_eligible",
+   "n": 4
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_marin",
+   "n": 4
+  },
+  {
+   "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
+   "variable_name": "age",
+   "n": 4
+  },
+  {
+   "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
+   "variable_name": "ca_income_tax",
+   "n": 4
+  },
+  {
+   "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
+   "variable_name": "employment_income",
+   "n": 4
+  },
+  {
+   "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
+   "variable_name": "income_tax",
+   "n": 4
+  },
+  {
+   "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
+   "variable_name": "state_name",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "age",
+   "n": 24
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "state_code_str",
+   "n": 24
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "employment_income",
+   "n": 16
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "income_tax",
+   "n": 12
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "is_medicaid_eligible",
+   "n": 12
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "snap",
+   "n": 12
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "eitc",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "basic_standard_deduction",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "ctc",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "pension_income",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "self_employment_income",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "snap_assets",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "social_security",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "age",
+   "n": 60
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "state_code_str",
+   "n": 60
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "employment_income",
+   "n": 40
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "income_tax",
+   "n": 30
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "is_medicaid_eligible",
+   "n": 30
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "snap",
+   "n": 30
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "eitc",
+   "n": 20
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "basic_standard_deduction",
+   "n": 10
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "ctc",
+   "n": 10
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "pension_income",
+   "n": 10
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "self_employment_income",
+   "n": 10
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "snap_assets",
+   "n": 10
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "n": 10
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "social_security",
+   "n": 10
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "child1",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "family",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "head",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "household",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "marital_unit",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "spm_unit",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "tax_unit",
+   "n": 4
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "age",
+   "n": 52
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "state_code_str",
+   "n": 52
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "employment_income",
+   "n": 34
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "snap",
+   "n": 28
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "is_medicaid_eligible",
+   "n": 26
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "income_tax",
+   "n": 24
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "eitc",
+   "n": 16
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "basic_standard_deduction",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "ctc",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "pension_income",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "self_employment_income",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "snap_assets",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "social_security",
+   "n": 8
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "employment_income_2",
+   "n": 2
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "is_medicaid_eligible_2",
+   "n": 2
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "age",
+   "n": 299
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "employment_income",
+   "n": 299
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_name",
+   "n": 299
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "weekly_hours_worked",
+   "n": 231
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "adjusted_gross_income",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "cdcc",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "county_fips",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "ctc",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "eitc",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "filing_status",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "income_tax",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "income_tax_before_credits",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_cdcc",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_code",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_code_str",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_ctc",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_eitc",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_fips",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_income_tax",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_income_tax_before_refundable_credits",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "tax_unit_childcare_expenses",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "tax_unit_is_joint",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "tax_unit_married",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "zip_code",
+   "n": 183
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_disabled",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_full_time_student",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_incapable_of_self_care",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_pregnant",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_snap_eligible",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_wic_eligible",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "snap",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "wic",
+   "n": 116
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_breastfeeding",
+   "n": 26
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_female",
+   "n": 26
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_parent",
+   "n": 26
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_homeless",
+   "n": 12
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "child_support_received",
+   "n": 5
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "self_employment_income",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi",
+   "n": 351
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_disabled",
+   "n": 343
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "has_heating_cooling_expense",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "has_phone_expense",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "heating_cooling_expense",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "homeowners_association_fees",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "homeowners_insurance",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "housing_cost",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_blind",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_pregnant",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_tax_unit_dependent",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_tax_unit_head",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_tax_unit_spouse",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "lifeline",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "medicaid",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "medicaid_category",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "phone_expense",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "real_estate_taxes",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "rental_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "school_meal_countable_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "school_meal_daily_subsidy",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "school_meal_tier",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "self_employment_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "snap",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "snap_assets",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "snap_earned_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "snap_emergency_allotment",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "snap_unearned_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "social_security",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi_countable_resources",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi_earned_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi_reported",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi_unearned_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "state_code",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "taxable_ira_distributions",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "taxable_pension_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "unemployment_compensation",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "water_expense",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "wic",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "wic_category",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "age",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "broadband_cost",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "childcare_expenses",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "child_support_expense",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ctc_value",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "current_pregnancies",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "eitc",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "employment_income",
+   "n": 339
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_snap_ineligible_student",
+   "n": 338
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "other_medical_expenses",
+   "n": 292
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "zip_code",
+   "n": 262
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "aca_ptc",
+   "n": 262
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "commodity_supplemental_food_program",
+   "n": 256
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_full_time_college_student",
+   "n": 210
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "long_term_capital_gains",
+   "n": 181
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "spm_unit_assets",
+   "n": 179
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "n": 179
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "weekly_hours_worked_before_lsr",
+   "n": 179
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "capital_gains",
+   "n": 158
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "county_str",
+   "n": 133
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "spm_unit_cash_assets",
+   "n": 132
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "head_start",
+   "n": 131
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "early_head_start",
+   "n": 131
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "miscellaneous_income",
+   "n": 130
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "heat_expense_included_in_rent",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_ccdf_eligible",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_ccdf_reason_for_care_eligible",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_in_public_housing",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_child_and_family_credit",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eaedc",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eaedc_living_arrangement",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eaedc_non_financial_eligible",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eitc",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_liheap",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_enrolled_in_applicable_programs",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_senior_charlie_card_eligible",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_tap_charlie_card_eligible",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_state_supplement",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_tafdc",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_tcap_gross_earned_income",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_tcap_gross_unearned_income",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "receives_housing_assistance",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "chip_category",
+   "n": 129
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "electricity_expense",
+   "n": 127
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "heating_expense_person",
+   "n": 127
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_scca_countable_income",
+   "n": 82
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_scca_maximum_payment",
+   "n": 82
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_tanf",
+   "n": 82
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_tanf_countable_earned_income",
+   "n": 82
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_tanf_countable_gross_unearned_income",
+   "n": 82
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_chp_eligible",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_ctc",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_eitc",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_family_affordability_credit",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_oap",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_state_supplement",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_tanf",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "n": 77
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "alimony_income",
+   "n": 51
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "childcare_attending_days_per_month",
+   "n": 50
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "chip",
+   "n": 50
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_veteran",
+   "n": 50
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tx_ccs",
+   "n": 50
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tx_dart_benefit_person",
+   "n": 50
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tx_harris_rides_eligible",
+   "n": 50
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tx_tanf",
+   "n": 50
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "n": 47
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tx_fpp_benefit",
+   "n": 26
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_tafdc_pregnancy_eligible",
+   "n": 13
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "current_pregnancy_month",
+   "n": 8
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_medicare_eligible",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "medicare_quarters_of_coverage",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "meets_ssi_disability_criteria",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "msp",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "msp_category",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "msp_eligible",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "social_security_disability",
+   "n": 3
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_medicaid_eligible",
+   "n": 2
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tanf",
+   "n": 2
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "was_in_foster_care",
+   "n": 2
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "has_bcc_qualifying_coverage",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_aabd_person",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_bcc_eligible",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_ctc",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_eitc",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_fpp_eligible",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_hbwd_eligible",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_hbwd_person",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_liheap_income_eligible",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_mpe_eligible",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_tanf",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_tanf_countable_gross_earned_income",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "il_tanf_countable_unearned_income",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_federal_work_study_participant",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_female",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_part_time_college_student",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_snap_higher_ed_student",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "mortgage_payments",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "receives_medicaid",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "rent",
+   "n": 1
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "workers_compensation",
+   "n": 1
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "age",
+   "n": 794
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "employment_income",
+   "n": 792
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "state_code",
+   "n": 792
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "income_tax",
+   "n": 791
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "adjusted_gross_income",
+   "n": 779
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "filing_status",
+   "n": 779
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "is_tax_unit_head",
+   "n": 776
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "state_income_tax",
+   "n": 776
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "is_tax_unit_spouse",
+   "n": 682
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "additional_medicare_tax",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "alternative_minimum_tax",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "local_income_tax",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "marginal_tax_rate",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "net_investment_income_tax",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "qualified_business_income_deduction",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "self_employment_tax",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "standard_deduction",
+   "n": 630
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "taxable_income_deductions",
+   "n": 606
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "tax_unit_taxable_social_security",
+   "n": 600
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "taxable_ira_distributions",
+   "n": 347
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "taxable_interest_income",
+   "n": 150
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "social_security",
+   "n": 58
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "long_term_capital_gains",
+   "n": 13
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "qualified_dividend_income",
+   "n": 12
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "taxable_roth_conversions",
+   "n": 7
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "taxable_income",
+   "n": 3
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "traditional_ira_contributions",
+   "n": 3
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "traditional_ira_contributions_desired",
+   "n": 3
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "adjusted_gross_income",
+   "n": 33
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "age",
+   "n": 33
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "eitc",
+   "n": 33
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "filing_status",
+   "n": 33
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "income_tax",
+   "n": 33
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "state_income_tax",
+   "n": 33
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "state_name",
+   "n": 33
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "employment_income",
+   "n": 29
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "charitable_cash_donations",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "deductible_mortgage_interest",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "health_savings_account_payroll_contributions",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "long_term_capital_gains",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "non_qualified_dividend_income",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "real_estate_taxes",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "taxable_interest_income",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "traditional_ira_contributions",
+   "n": 27
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "standard_deduction",
+   "n": 6
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "short_term_capital_gains",
+   "n": 2
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "social_security",
+   "n": 2
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "unemployment_compensation",
+   "n": 2
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "weekly_hours_worked",
+   "n": 1409
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "age",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "employment_income",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_disabled",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_full_time_student",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_incapable_of_self_care",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_pregnant",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_snap_eligible",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_wic_eligible",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "snap",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "state_name",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "wic",
+   "n": 852
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "rent",
+   "n": 270
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "pre_subsidy_electricity_expense",
+   "n": 224
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "phone_expense",
+   "n": 212
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "n": 134
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "health_insurance_premiums",
+   "n": 121
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "water_expense",
+   "n": 109
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "gas_expense",
+   "n": 93
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "mortgage_payments",
+   "n": 85
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_homeless",
+   "n": 77
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "n": 71
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_breastfeeding",
+   "n": 55
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_female",
+   "n": 55
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_parent",
+   "n": 55
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "trash_expense",
+   "n": 46
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "heating_cooling_expense",
+   "n": 37
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "self_employment_income",
+   "n": 28
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "sewage_expense",
+   "n": 28
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "other_medical_expenses",
+   "n": 23
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "real_estate_taxes",
+   "n": 16
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "child_support_received",
+   "n": 13
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "homeowners_association_fees",
+   "n": 13
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "child_support_expense",
+   "n": 11
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "miscellaneous_income",
+   "n": 9
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "social_security",
+   "n": 7
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "ssi",
+   "n": 6
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "disability_benefits",
+   "n": 4
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "general_assistance",
+   "n": 4
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_wic_at_nutritional_risk",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "medicaid_enrolled",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "meets_wic_categorical_eligibility",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "meets_wic_income_test",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "pension_income",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "retirement_distributions",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "wic_category",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "wic_category_str",
+   "n": 3
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "alimony_income",
+   "n": 2
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "rental_income",
+   "n": 2
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "gi_cash_assistance",
+   "n": 1
+  }
+ ],
+ "endpoints": [
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "endpoint": "calculate",
+   "n": 35081,
+   "last_seen": "2026-07-02 13:05:39"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "endpoint": "calculate",
+   "n": 13878,
+   "last_seen": "2026-07-01 17:25:00"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "endpoint": "calculate",
+   "n": 12458,
+   "last_seen": "2026-07-01 22:46:47"
+  },
+  {
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "endpoint": "calculate",
+   "n": 9368,
+   "last_seen": "2026-07-02 11:12:37"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "endpoint": "calculate",
+   "n": 3079,
+   "last_seen": "2026-07-02 01:56:22"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "endpoint": "calculate",
+   "n": 1216,
+   "last_seen": "2026-07-02 10:44:15"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "endpoint": "calculate",
+   "n": 922,
+   "last_seen": "2026-07-02 00:56:24"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "endpoint": "calculate",
+   "n": 778,
+   "last_seen": "2026-07-01 08:20:33"
+  },
+  {
+   "client_id": "gs6efNb3RxhUFQgwS9OvTpJP0trZJiKz",
+   "endpoint": "calculate",
+   "n": 542,
+   "last_seen": "2026-05-08 18:17:36"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "endpoint": "calculate",
+   "n": 447,
+   "last_seen": "2026-07-02 09:13:02"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "endpoint": "calculate",
+   "n": 68,
+   "last_seen": "2026-05-22 18:38:15"
+  },
+  {
+   "client_id": null,
+   "endpoint": "calculate",
+   "n": 57,
+   "last_seen": "2026-07-02 10:43:57"
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "endpoint": "calculate",
+   "n": 52,
+   "last_seen": "2026-05-19 16:07:33"
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "endpoint": "calculate",
+   "n": 36,
+   "last_seen": "2026-06-05 05:12:25"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "endpoint": "calculate",
+   "n": 24,
+   "last_seen": "2026-05-27 15:46:10"
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "endpoint": "calculate",
+   "n": 7,
+   "last_seen": "2026-06-25 14:41:45"
+  },
+  {
+   "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
+   "endpoint": "calculate",
+   "n": 4,
+   "last_seen": "2026-05-30 22:05:23"
+  }
+ ]
+}

--- a/tools/parity/inventory-report.json
+++ b/tools/parity/inventory-report.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-02T13:05:53.673476+00:00",
+ "generated_at": "2026-07-02T15:02:05.152170+00:00",
  "window_days": 90,
  "tables": [
   "alembic_version",
@@ -11,47 +11,47 @@
  "clients": [
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "requests": 19138,
+   "requests": 19186,
    "countries": 1,
    "country_list": "us",
    "channels": "current,frontier",
    "requested_versions": "1.715.2,current",
    "error_responses": "0",
    "first_seen": "2026-05-12 21:16:10",
-   "last_seen": "2026-07-02 13:05:39"
+   "last_seen": "2026-07-02 15:00:42"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "requests": 8283,
+   "requests": 8286,
    "countries": 1,
    "country_list": "us",
    "channels": "current,frontier",
    "requested_versions": "1.715.2,1.732.0,current,frontier",
    "error_responses": "2",
    "first_seen": "2026-05-12 21:20:43",
-   "last_seen": "2026-07-01 17:25:00"
+   "last_seen": "2026-07-02 14:24:16"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "requests": 6308,
+   "requests": 6310,
    "countries": 1,
    "country_list": "us",
    "channels": "current,frontier",
    "requested_versions": "current,frontier",
    "error_responses": "158",
    "first_seen": "2026-05-12 21:33:23",
-   "last_seen": "2026-07-01 22:46:47"
+   "last_seen": "2026-07-02 14:38:33"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
-   "requests": 4279,
+   "requests": 4288,
    "countries": 1,
    "country_list": "us",
    "channels": "current",
    "requested_versions": "current",
    "error_responses": "0",
    "first_seen": "2026-05-12 21:23:32",
-   "last_seen": "2026-07-02 11:12:37"
+   "last_seen": "2026-07-02 14:50:24"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
@@ -66,25 +66,25 @@
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "requests": 922,
+   "requests": 931,
    "countries": 1,
    "country_list": "us",
    "channels": "current",
    "requested_versions": "current",
    "error_responses": "135",
    "first_seen": "2026-06-02 17:10:00",
-   "last_seen": "2026-07-02 00:56:24"
+   "last_seen": "2026-07-02 14:08:46"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "requests": 852,
+   "requests": 854,
    "countries": 1,
    "country_list": "us",
    "channels": "current",
    "requested_versions": "current",
    "error_responses": "0",
    "first_seen": "2026-05-12 22:54:53",
-   "last_seen": "2026-07-02 10:44:15"
+   "last_seen": "2026-07-02 14:29:09"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
@@ -189,8 +189,8 @@
  "daily_volume": [
   {
    "day": "2026-07-02",
-   "requests": 293,
-   "active_clients": 6
+   "requests": 366,
+   "active_clients": 8
   },
   {
    "day": "2026-07-01",
@@ -320,5503 +320,11116 @@
   {
    "client_id": null,
    "variable_name": "age",
-   "n": 57
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "117"
   },
   {
    "client_id": null,
    "variable_name": "employment_income",
-   "n": 57
-  },
-  {
-   "client_id": null,
-   "variable_name": "snap",
-   "n": 57
-  },
-  {
-   "client_id": null,
-   "variable_name": "snap_assets",
-   "n": 57
-  },
-  {
-   "client_id": null,
-   "variable_name": "broadband_cost",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "child_support_expense",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "commodity_supplemental_food_program",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_chp_eligible",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_ctc",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_eitc",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_family_affordability_credit",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_oap",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_state_supplement",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_tanf",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_tanf_countable_gross_earned_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "co_tanf_countable_gross_unearned_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "ctc_value",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "current_pregnancies",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "eitc",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "has_heating_cooling_expense",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "has_phone_expense",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "heating_cooling_expense",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "homeowners_association_fees",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "homeowners_insurance",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "housing_cost",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "is_blind",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "is_disabled",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "is_full_time_college_student",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "is_pregnant",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "is_snap_ineligible_student",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "115"
   },
   {
    "client_id": null,
    "variable_name": "is_tax_unit_dependent",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "is_tax_unit_head",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
    "variable_name": "is_tax_unit_spouse",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "lifeline",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "medicaid",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "medicaid_category",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "other_medical_expenses",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "phone_expense",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "real_estate_taxes",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
    "variable_name": "rental_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "school_meal_countable_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "school_meal_daily_subsidy",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "school_meal_tier",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
    "variable_name": "self_employment_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "snap_earned_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "snap_emergency_allotment",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "snap_unearned_income",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
    "variable_name": "social_security",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "ssi",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "ssi_countable_resources",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "ssi_earned_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "ssi_reported",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "ssi_unearned_income",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "state_code",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
    "variable_name": "taxable_ira_distributions",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
    "variable_name": "taxable_pension_income",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
    "variable_name": "unemployment_compensation",
-   "n": 56
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "114"
   },
   {
    "client_id": null,
-   "variable_name": "water_expense",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "wic",
-   "n": 56
-  },
-  {
-   "client_id": null,
-   "variable_name": "wic_category",
-   "n": 56
+   "variable_name": "state_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "112"
   },
   {
    "client_id": null,
    "variable_name": "capital_gains",
-   "n": 55
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "110"
+  },
+  {
+   "client_id": null,
+   "variable_name": "child_support_expense",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "commodity_supplemental_food_program",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_chp_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_family_affordability_credit",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_oap",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_state_supplement",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "current_pregnancies",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_blind",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_full_time_college_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_pregnant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_snap_ineligible_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "is_tax_unit_head",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "medicaid_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "other_medical_expenses",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "real_estate_taxes",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_countable_resources",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_earned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_reported",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "ssi_unearned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "wic",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "wic_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "57"
+  },
+  {
+   "client_id": null,
+   "variable_name": "broadband_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "ctc_value",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "has_heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "has_phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "homeowners_association_fees",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "homeowners_insurance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "housing_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "lifeline",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "school_meal_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "school_meal_daily_subsidy",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "school_meal_tier",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_emergency_allotment",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "snap_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
+  },
+  {
+   "client_id": null,
+   "variable_name": "water_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "56"
   },
   {
    "client_id": null,
    "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
-   "n": 55
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "55"
+  },
+  {
+   "client_id": null,
+   "variable_name": "long_term_capital_gains",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": null,
    "variable_name": "basic_standard_deduction",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": null,
    "variable_name": "childcare_expenses",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": null,
    "variable_name": "is_medicaid_eligible",
-   "n": 1
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": null,
-   "variable_name": "long_term_capital_gains",
-   "n": 1
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": null,
    "variable_name": "snap_excess_shelter_expense_deduction",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": null,
    "variable_name": "state_code_str",
-   "n": 1
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "age",
-   "n": 8283
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "state_code",
-   "n": 8282
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "employment_income",
-   "n": 8236
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30157"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "rental_income",
-   "n": 8236
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30157"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "self_employment_income",
-   "n": 8236
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30157"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "social_security",
-   "n": 8236
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30157"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "taxable_ira_distributions",
-   "n": 8236
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30157"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "taxable_pension_income",
-   "n": 8236
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30157"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "unemployment_compensation",
-   "n": 8236
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30157"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "age",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30090"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "is_tax_unit_dependent",
-   "n": 8233
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "29249"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "is_tax_unit_spouse",
-   "n": 8233
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_disabled",
-   "n": 8146
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "broadband_cost",
-   "n": 7658
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "eitc",
-   "n": 7658
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "lifeline",
-   "n": 7658
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "childcare_expenses",
-   "n": 7647
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "child_support_expense",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "has_heating_cooling_expense",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "has_phone_expense",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "heating_cooling_expense",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "homeowners_association_fees",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "homeowners_insurance",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "housing_cost",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_snap_ineligible_student",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "phone_expense",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "real_estate_taxes",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "snap",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "snap_assets",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "snap_earned_income",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "snap_emergency_allotment",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "snap_unearned_income",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "water_expense",
-   "n": 7617
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ssi",
-   "n": 7599
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ssi_countable_resources",
-   "n": 7560
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_tax_unit_head",
-   "n": 7528
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_blind",
-   "n": 7518
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ssi_reported",
-   "n": 7450
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ssi_earned_income",
-   "n": 7440
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ssi_unearned_income",
-   "n": 7440
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_pregnant",
-   "n": 7226
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "other_medical_expenses",
-   "n": 6760
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ctc_value",
-   "n": 6680
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_full_time_college_student",
-   "n": 6386
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "28463"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "long_term_capital_gains",
-   "n": 6015
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "21218"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_countable_resources",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16974"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_blind",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16793"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_tax_unit_head",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16384"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_pregnant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15910"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15252"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "state_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15131"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_full_time_college_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14559"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_reported",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14425"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "child_support_expense",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14298"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_snap_ineligible_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14298"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "real_estate_taxes",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14298"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_earned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14188"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi_unearned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14188"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13972"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "other_medical_expenses",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12416"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "is_optional_senior_or_disabled_for_medicaid",
-   "n": 5867
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10554"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "medicaid",
-   "n": 5867
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10554"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "medicaid_category",
-   "n": 5867
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "spm_unit_cash_assets",
-   "n": 4933
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "current_pregnancies",
-   "n": 4206
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "school_meal_countable_income",
-   "n": 4206
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "school_meal_daily_subsidy",
-   "n": 4206
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "school_meal_tier",
-   "n": 4206
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "wic",
-   "n": 4206
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "wic_category",
-   "n": 4206
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "wa_working_families_tax_credit",
-   "n": 3681
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "aca_ptc",
-   "n": 3030
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "zip_code",
-   "n": 3030
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "commodity_supplemental_food_program",
-   "n": 3024
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "county_str",
-   "n": 3017
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "employment_income_before_lsr",
-   "n": 2952
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "self_employment_income_before_lsr",
-   "n": 2952
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "wa_show_all_cash_assistance_programs",
-   "n": 2952
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "wa_tanf",
-   "n": 2952
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "spm_unit_assets",
-   "n": 2295
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "meets_ssi_disability_criteria",
-   "n": 2249
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10554"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "capital_gains",
-   "n": 2221
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8939"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
-   "n": 2117
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7831"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "weekly_hours_worked_before_lsr",
-   "n": 2117
+   "variable_name": "broadband_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7661"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "early_head_start",
-   "n": 2072
+   "variable_name": "lifeline",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7661"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "head_start",
-   "n": 2054
+   "variable_name": "childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7650"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "alimony_income",
-   "n": 1823
+   "variable_name": "has_heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "has_phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "homeowners_association_fees",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "homeowners_insurance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "housing_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_emergency_allotment",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "water_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7620"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ctc_value",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6801"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "current_pregnancies",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6769"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wic",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6769"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wic_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6769"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "employment_income_before_lsr",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6513"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "self_employment_income_before_lsr",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6513"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "6267"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "commodity_supplemental_food_program",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4936"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "spm_unit_cash_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4933"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "school_meal_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4209"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "school_meal_daily_subsidy",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4209"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "school_meal_tier",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4209"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3956"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wa_working_families_tax_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3792"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "wa_apple_health_kids_eligible",
-   "n": 1773
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3789"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "social_security_disability",
-   "n": 1611
+   "variable_name": "weekly_hours_worked_before_lsr",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3569"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "early_head_start",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3334"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "head_start",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3316"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "aca_ptc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3050"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "zip_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3033"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "county_str",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3020"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "alimony_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2970"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wa_show_all_cash_assistance_programs",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2952"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "wa_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2952"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2797"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "childcare_attending_days_per_month",
-   "n": 1521
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "tx_ccs",
-   "n": 1521
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2540"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "tx_harris_rides_eligible",
-   "n": 1521
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2540"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "tx_tanf",
-   "n": 1521
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_medicare_eligible",
-   "n": 1518
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "medicare_quarters_of_coverage",
-   "n": 1514
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "msp",
-   "n": 1514
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "msp_category",
-   "n": 1514
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "msp_eligible",
-   "n": 1514
+   "variable_name": "social_security_disability",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2522"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "chip",
-   "n": 1501
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2518"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "is_veteran",
-   "n": 1501
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2518"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "tx_dart_benefit_person",
-   "n": 1501
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2518"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_medicaid_eligible",
-   "n": 1319
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "mixed",
+   "availability_status": "supported",
+   "n": "2484"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "tanf",
-   "n": 1301
+   "variable_name": "medicare_quarters_of_coverage",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2404"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "msp",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2404"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "msp_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2404"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "msp_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2404"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "spm_unit_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2295"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_medicare_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2201"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2117"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "was_in_foster_care",
-   "n": 1298
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "electricity_expense",
-   "n": 1122
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "miscellaneous_income",
-   "n": 1076
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "tx_fpp_benefit",
-   "n": 889
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "nc_scca_countable_income",
-   "n": 879
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "nc_scca_maximum_payment",
-   "n": 879
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "nc_tanf",
-   "n": 879
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "nc_tanf_countable_earned_income",
-   "n": 879
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "nc_tanf_countable_gross_unearned_income",
-   "n": 879
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2068"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "medical_out_of_pocket_expenses",
-   "n": 857
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "1882"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "heat_expense_included_in_rent",
-   "n": 774
+   "variable_name": "is_medicaid_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1828"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "miscellaneous_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1696"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_fpp_benefit",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1526"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_ccs",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1521"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1521"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1285"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "is_ccdf_eligible",
-   "n": 774
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1266"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "is_ccdf_reason_for_care_eligible",
-   "n": 774
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_child_and_family_credit",
-   "n": 774
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_eitc",
-   "n": 774
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_liheap",
-   "n": 774
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "receives_housing_assistance",
-   "n": 774
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1266"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "heating_expense_person",
-   "n": 762
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1254"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1235"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "co_chp_eligible",
-   "n": 729
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "co_ctc",
-   "n": 729
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "co_eitc",
-   "n": 729
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1130"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "co_family_affordability_credit",
-   "n": 729
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1130"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "co_oap",
-   "n": 729
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1130"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "co_state_supplement",
-   "n": 729
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1130"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "electricity_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1122"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_scca_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "882"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_scca_maximum_payment",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "882"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "882"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_tanf_countable_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "882"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "nc_tanf_countable_gross_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "882"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_child_and_family_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "782"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "782"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "heat_expense_included_in_rent",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "774"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_liheap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "774"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "receives_housing_assistance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "774"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "757"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "co_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "757"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "co_tanf",
-   "n": 729
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "729"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "co_tanf_countable_gross_earned_income",
-   "n": 729
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "729"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "co_tanf_countable_gross_unearned_income",
-   "n": 729
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "is_in_public_housing",
-   "n": 444
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_tafdc",
-   "n": 444
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "729"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "ma_tcap_gross_earned_income",
-   "n": 444
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "712"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "ma_tcap_gross_unearned_income",
-   "n": 444
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "712"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "chip_category",
-   "n": 406
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_eaedc",
-   "n": 406
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_eaedc_living_arrangement",
-   "n": 406
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_eaedc_non_financial_eligible",
-   "n": 406
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "661"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "ma_state_supplement",
-   "n": 406
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "661"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "tx_ceap",
-   "n": 360
+   "variable_name": "is_in_public_housing",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "444"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_tafdc",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "444"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "has_bcc_qualifying_coverage",
-   "n": 302
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "il_bcc_eligible",
-   "n": 302
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "il_ctc",
-   "n": 302
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "il_eitc",
-   "n": 302
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "il_fpp_eligible",
-   "n": 302
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "il_hbwd_eligible",
-   "n": 302
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "il_hbwd_person",
-   "n": 302
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "il_mpe_eligible",
-   "n": 302
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "il_tanf",
-   "n": 302
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "il_tanf_countable_gross_earned_income",
-   "n": 302
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "il_tanf_countable_unearned_income",
-   "n": 302
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "is_female",
-   "n": 302
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "receives_medicaid",
-   "n": 302
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "workers_compensation",
-   "n": 302
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "430"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "il_liheap_income_eligible",
-   "n": 301
+   "variable_name": "ma_eaedc",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "406"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_mbta_enrolled_in_applicable_programs",
-   "n": 254
+   "variable_name": "ma_eaedc_living_arrangement",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "406"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
-   "n": 254
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_mbta_senior_charlie_card_eligible",
-   "n": 254
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "ma_mbta_tap_charlie_card_eligible",
-   "n": 254
+   "variable_name": "ma_eaedc_non_financial_eligible",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "406"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "il_aabd_person",
-   "n": 244
-  },
-  {
-   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
-   "variable_name": "mortgage_payments",
-   "n": 244
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "365"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "rent",
-   "n": 244
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "365"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tx_ceap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "360"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_enrolled_in_applicable_programs",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "344"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "344"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_senior_charlie_card_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "344"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ma_mbta_tap_charlie_card_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "344"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "304"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "304"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "302"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_tanf_countable_gross_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "302"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_tanf_countable_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "302"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "il_liheap_income_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "301"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "262"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "mortgage_payments",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "244"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_medicaid_eligible",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "211"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "is_medicare_eligible",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "203"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "use_reported_ssi",
-   "n": 110
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "201"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "ma_tafdc_pregnancy_eligible",
-   "n": 73
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "119"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "mixed",
+   "availability_status": "supported",
+   "n": "112"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "55"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "ks_total_eitc",
-   "n": 32
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "34"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "ks_cdcc",
-   "n": 30
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "tanf",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "ks_tanf",
-   "n": 3
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "cdcc",
-   "n": 2
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "2"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "adjusted_gross_income",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "cdcc_credit_limit",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "cdcc_potential",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "cdcc_relevant_expenses",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "il_liheap",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "income_tax_before_credits",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "min_head_spouse_earned",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "variable_name": "tax_unit_childcare_expenses",
-   "n": 1
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ssi",
-   "n": 19282
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "age",
-   "n": 19138
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ctc_value",
-   "n": 19138
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "eitc",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "employment_income",
-   "n": 19138
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_tax_unit_dependent",
-   "n": 19138
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_tax_unit_spouse",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "rental_income",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "self_employment_income",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "social_security",
-   "n": 19138
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "state_code",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "taxable_ira_distributions",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "taxable_pension_income",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "unemployment_compensation",
-   "n": 19138
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83748"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_disabled",
-   "n": 18991
+   "variable_name": "is_tax_unit_dependent",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83591"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "childcare_expenses",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "child_support_expense",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "has_heating_cooling_expense",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "has_phone_expense",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "heating_cooling_expense",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "homeowners_association_fees",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "homeowners_insurance",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "housing_cost",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_pregnant",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_snap_ineligible_student",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "phone_expense",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "real_estate_taxes",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "snap",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "snap_assets",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "snap_earned_income",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "snap_emergency_allotment",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "snap_unearned_income",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "water_expense",
-   "n": 18976
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "broadband_cost",
-   "n": 18973
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "lifeline",
-   "n": 18973
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_tax_unit_head",
-   "n": 18807
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_blind",
-   "n": 18665
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ssi_countable_resources",
-   "n": 18505
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ssi_earned_income",
-   "n": 18505
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ssi_reported",
-   "n": 18505
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ssi_unearned_income",
-   "n": 18505
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "current_pregnancies",
-   "n": 18422
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "school_meal_countable_income",
-   "n": 18422
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "school_meal_daily_subsidy",
-   "n": 18422
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "school_meal_tier",
-   "n": 18422
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "wic",
-   "n": 18422
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "wic_category",
-   "n": 18422
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
-   "n": 18360
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "medicaid",
-   "n": 18360
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "medicaid_category",
-   "n": 18360
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "other_medical_expenses",
-   "n": 17762
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_full_time_college_student",
-   "n": 17344
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "aca_ptc",
-   "n": 12334
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "zip_code",
-   "n": 12334
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "county_str",
-   "n": 11123
+   "variable_name": "is_tax_unit_spouse",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83242"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "long_term_capital_gains",
-   "n": 10957
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "47831"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "commodity_supplemental_food_program",
-   "n": 9826
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "47657"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_pregnant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "47386"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_tax_unit_head",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "47368"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_blind",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "46878"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_countable_resources",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "46699"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_full_time_college_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "43775"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "child_support_expense",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "41618"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_snap_ineligible_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "41618"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "real_estate_taxes",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "41618"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_earned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40931"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_reported",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40931"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi_unearned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40931"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40588"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40588"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "medicaid_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40588"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "current_pregnancies",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40409"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wic",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40409"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wic_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40409"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "39572"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "other_medical_expenses",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "38822"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "capital_gains",
-   "n": 8181
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "35917"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "nc_scca_countable_income",
-   "n": 7608
+   "variable_name": "state_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "31108"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "nc_scca_maximum_payment",
-   "n": 7608
+   "variable_name": "ctc_value",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "21525"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "nc_tanf",
-   "n": 7608
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "21525"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "nc_tanf_countable_earned_income",
-   "n": 7608
+   "variable_name": "commodity_supplemental_food_program",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "21522"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "nc_tanf_countable_gross_unearned_income",
-   "n": 7608
+   "variable_name": "childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "co_ctc",
-   "n": 5791
+   "variable_name": "has_heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "co_eitc",
-   "n": 5791
+   "variable_name": "has_phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "homeowners_association_fees",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "homeowners_insurance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "housing_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_emergency_allotment",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "water_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19024"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "broadband_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19021"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "lifeline",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19021"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "school_meal_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "18470"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "school_meal_daily_subsidy",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "18470"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "school_meal_tier",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "18470"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "14608"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "aca_ptc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "14090"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "co_family_affordability_credit",
-   "n": 5791
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12611"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "zip_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12370"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "co_chp_eligible",
-   "n": 5629
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12099"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "co_oap",
-   "n": 5629
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12099"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "co_state_supplement",
-   "n": 5629
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12099"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "co_tanf",
-   "n": 5629
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "co_tanf_countable_gross_earned_income",
-   "n": 5629
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "co_tanf_countable_gross_unearned_income",
-   "n": 5629
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "spm_unit_cash_assets",
-   "n": 5418
+   "variable_name": "county_str",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "11159"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "early_head_start",
-   "n": 4197
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "spm_unit_assets",
-   "n": 4197
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
-   "n": 4197
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9423"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "weekly_hours_worked_before_lsr",
-   "n": 4197
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9423"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "head_start",
-   "n": 4195
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9419"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "meets_ssi_disability_criteria",
-   "n": 3738
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7978"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_medicare_eligible",
-   "n": 3667
+   "variable_name": "nc_scca_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7633"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_scca_maximum_payment",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7633"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7633"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_tanf_countable_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7633"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "nc_tanf_countable_gross_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7633"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "alimony_income",
-   "n": 3553
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7600"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "social_security_disability",
-   "n": 3531
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7574"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "medicare_quarters_of_coverage",
-   "n": 3391
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7417"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "msp",
-   "n": 3391
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7417"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "msp_category",
-   "n": 3391
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7417"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "msp_eligible",
-   "n": 3391
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7417"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_medicaid_eligible",
-   "n": 2883
+   "variable_name": "is_medicare_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6547"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "miscellaneous_income",
-   "n": 2620
+   "variable_name": "co_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6392"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "was_in_foster_care",
-   "n": 2585
+   "variable_name": "co_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6392"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "childcare_attending_days_per_month",
-   "n": 2565
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "tanf",
-   "n": 2565
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "tx_ccs",
-   "n": 2565
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5790"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "tx_harris_rides_eligible",
-   "n": 2565
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "tx_tanf",
-   "n": 2565
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5790"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "chip",
-   "n": 2545
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5768"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "is_veteran",
-   "n": 2545
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5768"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "tx_dart_benefit_person",
-   "n": 2545
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5768"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "electricity_expense",
-   "n": 2268
+   "variable_name": "was_in_foster_care",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5745"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5641"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5641"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5641"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "miscellaneous_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5443"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "spm_unit_cash_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5429"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_medicaid_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4641"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4615"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "mixed",
+   "availability_status": "supported",
+   "n": "4572"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "spm_unit_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4208"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4208"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "tx_fpp_benefit",
-   "n": 1815
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "heat_expense_included_in_rent",
-   "n": 1632
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4094"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "is_ccdf_eligible",
-   "n": 1632
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3633"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "is_ccdf_reason_for_care_eligible",
-   "n": 1632
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ma_child_and_family_credit",
-   "n": 1632
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ma_eitc",
-   "n": 1632
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ma_liheap",
-   "n": 1632
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "receives_housing_assistance",
-   "n": 1632
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "is_in_public_housing",
-   "n": 1619
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ma_tafdc",
-   "n": 1619
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3633"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_tcap_gross_earned_income",
-   "n": 1619
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3618"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_tcap_gross_unearned_income",
-   "n": 1619
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3618"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "heating_expense_person",
-   "n": 1532
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3366"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "chip_category",
-   "n": 1333
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ma_eaedc",
-   "n": 1333
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ma_eaedc_living_arrangement",
-   "n": 1333
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "ma_eaedc_non_financial_eligible",
-   "n": 1333
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3149"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_state_supplement",
-   "n": 1333
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3149"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_mbta_enrolled_in_applicable_programs",
-   "n": 1320
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3134"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
-   "n": 1320
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3134"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_mbta_senior_charlie_card_eligible",
-   "n": 1320
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3134"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_mbta_tap_charlie_card_eligible",
-   "n": 1320
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3134"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "medical_out_of_pocket_expenses",
-   "n": 1214
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "2796"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_ccs",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2571"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tx_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2571"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2558"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "electricity_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2279"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "1845"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "has_bcc_qualifying_coverage",
-   "n": 988
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "il_bcc_eligible",
-   "n": 988
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "il_ctc",
-   "n": 988
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "il_eitc",
-   "n": 988
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "il_fpp_eligible",
-   "n": 988
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "il_hbwd_eligible",
-   "n": 988
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "il_hbwd_person",
-   "n": 988
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "il_liheap_income_eligible",
-   "n": 988
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "il_mpe_eligible",
-   "n": 988
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "il_tanf",
-   "n": 988
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "il_tanf_countable_gross_earned_income",
-   "n": 988
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "il_tanf_countable_unearned_income",
-   "n": 988
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "is_female",
-   "n": 988
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "receives_medicaid",
-   "n": 988
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "workers_compensation",
-   "n": 988
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1810"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_child_and_family_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1746"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1746"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "il_aabd_person",
-   "n": 848
-  },
-  {
-   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "mortgage_payments",
-   "n": 848
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1653"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "rent",
-   "n": 848
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1653"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "tx_ceap",
-   "n": 736
+   "variable_name": "heat_expense_included_in_rent",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1637"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_liheap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1637"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "receives_housing_assistance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1637"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_in_public_housing",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1624"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_tafdc",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1624"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1381"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eaedc",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1338"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eaedc_living_arrangement",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1338"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "ma_eaedc_non_financial_eligible",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1338"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "employment_income_before_lsr",
-   "n": 554
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1209"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "self_employment_income_before_lsr",
-   "n": 554
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1209"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "wa_show_all_cash_assistance_programs",
-   "n": 554
+   "variable_name": "is_medicaid_eligible",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1123"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "wa_tanf",
-   "n": 554
+   "variable_name": "il_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1046"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "wa_working_families_tax_credit",
-   "n": 554
+   "variable_name": "il_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1046"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_liheap_income_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "988"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "988"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_tanf_countable_gross_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "988"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "il_tanf_countable_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "988"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "is_medicare_eligible",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "870"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "mortgage_payments",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "848"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "wa_apple_health_kids_eligible",
-   "n": 397
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "842"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
-   "variable_name": "co_care_worker_credit",
-   "n": 162
+   "variable_name": "tx_ceap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "742"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wa_working_families_tax_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "574"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "mixed",
+   "availability_status": "supported",
+   "n": "570"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wa_show_all_cash_assistance_programs",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "554"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "wa_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "554"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "co_care_worker_credit_eligible_care_worker",
-   "n": 162
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "512"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "274"
   },
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "variable_name": "ma_tafdc_pregnancy_eligible",
-   "n": 89
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "260"
   },
   {
-   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
-   "variable_name": "adjusted_gross_income",
-   "n": 7
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "co_care_worker_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "162"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "was_in_foster_care",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "45"
+  },
+  {
+   "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
+   "variable_name": "tanf",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "age",
-   "n": 7
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "28"
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "adjusted_gross_income",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "employment_income",
-   "n": 7
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "filing_status",
-   "n": 7
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "health_savings_account_payroll_contributions",
-   "n": 7
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "income_tax",
-   "n": 7
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "pre_tax_health_insurance_premiums",
-   "n": 7
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "state_code",
-   "n": 7
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "state_income_tax",
-   "n": 7
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "traditional_401k_contributions",
-   "n": 7
-  },
-  {
-   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
-   "variable_name": "employee_medicare_tax",
-   "n": 5
-  },
-  {
-   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
-   "variable_name": "employee_social_security_tax",
-   "n": 5
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "student_loan_interest",
-   "n": 5
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5"
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "employee_medicare_tax",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5"
+  },
+  {
+   "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
+   "variable_name": "employee_social_security_tax",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "ca_employee_state_disability_insurance_contribution",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "gov.states.ca.tax.payroll.disability.employee_rate",
-   "n": 2
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "2"
   },
   {
    "client_id": "Alum5bZq4SKrBWZdMLBEuPmeRa7tWzKM",
    "variable_name": "student_loan_interest_ald",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "age",
-   "n": 3076
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5670"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "employment_income",
-   "n": 2883
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "state_name",
-   "n": 1664
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "zip_code",
-   "n": 1456
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_disabled",
-   "n": 1454
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_tax_unit_head",
-   "n": 1440
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4646"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_tax_unit_dependent",
-   "n": 1427
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3187"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_tax_unit_spouse",
-   "n": 1400
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3137"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "county_str",
-   "n": 1315
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3117"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "state_code_str",
-   "n": 1309
+   "variable_name": "is_tax_unit_head",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3077"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "immigration_status_str",
-   "n": 1301
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "tax_unit_is_joint",
-   "n": 1301
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2964"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_pregnant",
-   "n": 991
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1833"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "eitc",
-   "n": 954
+   "variable_name": "state_name",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1664"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "income_tax",
-   "n": 846
+   "variable_name": "zip_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1456"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "county_str",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1315"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "state_code_str",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1309"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tax_unit_is_joint",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1301"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ssi",
-   "n": 615
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1032"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "medicaid",
-   "n": 596
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1029"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ssi_countable_resources",
-   "n": 577
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "966"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_medicaid_eligible",
-   "n": 479
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_ssi_eligible",
-   "n": 472
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_ssi_aged",
-   "n": 471
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "snap",
-   "n": 470
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "aca_ptc",
-   "n": 452
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_aca_ptc_eligible",
-   "n": 451
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_aca_eshi_eligible",
-   "n": 449
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "premium_tax_credit",
-   "n": 449
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "chip",
-   "n": 440
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "954"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_ccdf_reason_for_care_eligible",
-   "n": 437
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "895"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "msp",
-   "n": 436
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "msp_eligible",
-   "n": 436
+   "variable_name": "is_medicaid_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "892"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_breastfeeding",
-   "n": 429
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "887"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_ssi_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "887"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_ssi_aged",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "886"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_aca_ptc_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "858"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_aca_eshi_eligible",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "856"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "846"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "chip",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "821"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "msp",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "817"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "msp_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "817"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_medicare_eligible",
-   "n": 428
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "809"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "aca_ptc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "452"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "premium_tax_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "449"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "snap_assets",
-   "n": 389
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "389"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "adjusted_gross_income",
-   "n": 381
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "381"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_full_time_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "375"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "370"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_snap_eligible",
-   "n": 292
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "292"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_income_tax",
-   "n": 275
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "275"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_exemptions",
-   "n": 273
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "273"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_eitc",
-   "n": 260
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "260"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_cdcc",
-   "n": 256
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "256"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_income_tax_before_credits",
-   "n": 256
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "256"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_income_tax_before_refundable_credits",
-   "n": 256
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "256"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_yctc",
-   "n": 256
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "256"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "taxable_income",
-   "n": 255
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "255"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "wic",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "247"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_use_tax",
-   "n": 245
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "245"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "housing_cost",
-   "n": 245
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_taxable_income",
-   "n": 243
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "filing_status",
-   "n": 243
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "245"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_additions",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_agi",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_agi_subtractions",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_amt",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_deductions",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_itemized_deductions",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_mental_health_services_tax",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_non_refundable_credits",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_refundable_credits",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_standard_deduction",
-   "n": 243
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_taxable_income",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "filing_status",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "243"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ctc_value",
-   "n": 238
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "housing_assistance",
-   "n": 206
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "school_meal_daily_subsidy",
-   "n": 190
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "school_meal_tier",
-   "n": 190
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ctc",
-   "n": 182
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "wic",
-   "n": 171
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "rent",
-   "n": 164
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "receives_housing_assistance",
-   "n": 160
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "eitc_eligible",
-   "n": 159
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "lifeline",
-   "n": 156
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "refundable_ctc",
-   "n": 153
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ssi_earned_income",
-   "n": 151
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ssi_unearned_income",
-   "n": 151
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "commodity_supplemental_food_program",
-   "n": 150
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "wic_category",
-   "n": 148
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "cdcc",
-   "n": 139
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_full_time_student",
-   "n": 138
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "medicaid_category",
-   "n": 138
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "238"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "social_security",
-   "n": 135
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
-   "n": 121
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
-   "n": 118
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "snap_earned_income",
-   "n": 118
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "snap_emergency_allotment",
-   "n": 118
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "snap_unearned_income",
-   "n": 118
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_blind",
-   "n": 116
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "235"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "head_start",
-   "n": 113
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_eitc",
-   "n": 110
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "early_head_start",
-   "n": 110
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_oap",
-   "n": 109
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_chp_eligible",
-   "n": 108
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_ctc",
-   "n": 108
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_family_affordability_credit",
-   "n": 108
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "current_pregnancies",
-   "n": 108
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "heating_cooling_expense",
-   "n": 107
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "broadband_cost",
-   "n": 106
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "221"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "capital_gains",
-   "n": 106
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "206"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "county_fips",
-   "n": 105
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_state_supplement",
-   "n": 105
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_tanf",
-   "n": 103
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_tanf_countable_gross_earned_income",
-   "n": 103
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "co_tanf_countable_gross_unearned_income",
-   "n": 102
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_snap_ineligible_student",
-   "n": 102
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "real_estate_taxes",
-   "n": 102
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "school_meal_countable_income",
-   "n": 102
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ssi_reported",
-   "n": 102
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "child_support_expense",
-   "n": 100
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "has_heating_cooling_expense",
-   "n": 100
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "has_phone_expense",
-   "n": 100
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "homeowners_association_fees",
-   "n": 100
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "homeowners_insurance",
-   "n": 100
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_full_time_college_student",
-   "n": 100
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "other_medical_expenses",
-   "n": 100
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "phone_expense",
-   "n": 100
+   "variable_name": "housing_assistance",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "206"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "rental_income",
-   "n": 100
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "200"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "self_employment_income",
-   "n": 100
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "200"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "state_code",
-   "n": 100
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "200"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "taxable_ira_distributions",
-   "n": 100
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "200"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "taxable_pension_income",
-   "n": 100
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "200"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "unemployment_compensation",
-   "n": 100
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "200"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "water_expense",
-   "n": 100
+   "variable_name": "wic_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "196"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "pre_subsidy_rent",
-   "n": 93
+   "variable_name": "school_meal_daily_subsidy",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "190"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "school_meal_tier",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "190"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "early_head_start",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "188"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "182"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "commodity_supplemental_food_program",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "171"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "rent",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "164"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "eitc_eligible",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "159"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi_earned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "159"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi_unearned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "159"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "receives_housing_assistance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "158"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "lifeline",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "156"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "refundable_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "153"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medicaid_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "152"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "cdcc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "139"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "124"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "121"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_blind",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "119"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_chp_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "118"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_family_affordability_credit",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "118"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "118"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_emergency_allotment",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "118"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "118"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "110"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_oap",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "109"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "108"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "current_pregnancies",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "108"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "107"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_wic_eligible",
-   "n": 59
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "107"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_lifeline_eligible",
-   "n": 54
+   "variable_name": "broadband_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "106"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "tanf",
-   "n": 43
+   "variable_name": "co_state_supplement",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "105"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "tx_tanf",
-   "n": 38
+   "variable_name": "county_fips",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "103"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "103"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "103"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "102"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_snap_ineligible_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "102"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "real_estate_taxes",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "102"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "school_meal_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "102"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ssi_reported",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "102"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "child_support_expense",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "has_heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "has_phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "homeowners_association_fees",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "homeowners_insurance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_full_time_college_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "other_medical_expenses",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "water_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "pre_subsidy_rent",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "93"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_ccdf_eligible",
-   "n": 37
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "67"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care_time_category",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "54"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_lifeline_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "54"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_state_supplement_eligible_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "47"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "43"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_ala_general_assistance_eligible_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "39"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tx_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "38"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care_full_time",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "35"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "employment_income",
+   "entity_type": "person",
+   "source": "axis",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "31"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_net_income",
-   "n": 31
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_calworks_child_care_time_category",
-   "n": 25
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_calworks_child_care",
-   "n": 23
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_calworks_child_care_eligible",
-   "n": 23
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "income_tax_before_credits",
-   "n": 23
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "in_la",
-   "n": 22
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "31"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "medicaid_group",
-   "n": 22
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "tenant_pays_utilities",
-   "n": 22
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_calworks_child_care_full_time",
-   "n": 22
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_state_supplement",
-   "n": 21
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_state_supplement_eligible_person",
-   "n": 21
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "childcare_expenses",
-   "n": 20
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "medicaid_enrolled",
-   "n": 20
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "28"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "23"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_calworks_child_care_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "23"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "income_tax_before_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "23"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "tenant_pays_utilities",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "22"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_state_supplement",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "21"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "20"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_ala_general_assistance",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_ala_general_assistance_income_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "in_ala",
-   "n": 19
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "in_la",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "in_riv",
-   "n": 19
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_eligible_for_housing_assistance",
-   "n": 19
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "phone_cost",
-   "n": 19
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "receives_medicaid",
-   "n": 19
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_ala_general_assistance",
-   "n": 19
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_ala_general_assistance_income_eligible",
-   "n": 19
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "meets_ssi_disability_criteria",
-   "n": 18
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "social_security_retirement",
-   "n": 17
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "17"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "wy_power",
-   "n": 17
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "17"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_tanf",
-   "n": 16
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_eitc_eligible",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "ca_riv_general_relief_meets_work_requirements",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_tanf_eligible",
-   "n": 15
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_tanf_region1",
-   "n": 15
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "has_bcc_qualifying_coverage",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "is_female",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ny_eitc",
-   "n": 15
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "tax_unit_childcare_expenses",
-   "n": 15
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_eitc_eligible",
-   "n": 15
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_ala_general_assistance_eligible_person",
-   "n": 13
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_care",
-   "n": 13
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_care_eligible",
-   "n": 13
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_fera",
-   "n": 13
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_fera_eligible",
-   "n": 13
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_foster_youth_tax_credit",
-   "n": 13
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_la_ez_save",
-   "n": 13
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_la_ez_save_eligible",
-   "n": 13
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_renter_credit",
-   "n": 13
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_riv_general_relief",
-   "n": 13
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_riv_general_relief_eligible",
-   "n": 13
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_riv_share_eligible",
-   "n": 13
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_riv_share_payment",
-   "n": 13
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_vehicles_value",
-   "n": 13
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "income_tax_before_refundable_credits",
-   "n": 13
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "income_tax_capped_non_refundable_credits",
-   "n": 13
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "income_tax_non_refundable_credits",
-   "n": 13
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "income_tax_refundable_credits",
-   "n": 13
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "la_general_relief",
-   "n": 13
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "la_general_relief_eligible",
-   "n": 13
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "lives_in_vehicle",
-   "n": 13
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "living_arrangements_allow_for_food_preparation",
-   "n": 13
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "chip_category",
-   "n": 12
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "has_bcc_qualifying_coverage",
-   "n": 12
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "is_female",
-   "n": 12
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "ca_riv_general_relief_meets_work_requirements",
-   "n": 12
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "state_income_tax",
-   "n": 11
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "11"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_vehicles_owned",
-   "n": 10
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ma_eaedc",
-   "n": 10
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ma_eaedc_non_financial_eligible",
-   "n": 10
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "msp_category",
-   "n": 10
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "snap_excess_shelter_expense_deduction",
-   "n": 10
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "wy_power_eligible",
-   "n": 10
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ks_tanf",
-   "n": 9
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "basic_standard_deduction",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "hud_income_level",
-   "n": 8
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_in_public_housing",
-   "n": 8
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "nc_scca_countable_income",
-   "n": 8
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "nc_scca_maximum_payment",
-   "n": 8
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "social_security_disability",
-   "n": 8
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "basic_standard_deduction",
-   "n": 8
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "pre_subsidy_electricity_expense",
-   "n": 7
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "wy_power_eligibility",
-   "n": 7
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_annual_income",
-   "n": 6
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_extremely_low_income_limit",
-   "n": 6
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_low_income_limit",
-   "n": 6
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_very_low_income_limit",
-   "n": 6
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "7"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ami",
-   "n": 6
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_annual_income",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ma_state_supplement",
-   "n": 5
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ma_tafdc",
-   "n": 5
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "survivor_benefits",
-   "n": 5
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "current_pregnancy_month",
-   "n": 4
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "heat_expense_included_in_rent",
-   "n": 4
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "medical_out_of_pocket_expenses",
-   "n": 4
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "meets_snap_work_requirements_person",
-   "n": 4
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_gross_rent",
-   "n": 3
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_hap",
-   "n": 3
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_max_subsidy",
-   "n": 3
-  },
-  {
-   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "hud_ttp",
-   "n": 3
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "marital_unit_id",
-   "n": 3
+   "entity_type": "marital_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "bedrooms",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_extremely_low_income_limit",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_extremely_low_income_limit",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_gross_rent",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_hap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_low_income_limit",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_low_income_limit",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_max_subsidy",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_ttp",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_very_low_income_limit",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "hud_very_low_income_limit",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "in_la",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "meets_snap_work_requirements_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "3"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "pha_payment_standard",
-   "n": 3
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
-   "variable_name": "bedrooms",
-   "n": 3
+   "variable_name": "survivor_benefits",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "applicable_ssi",
-   "n": 2
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ca_withheld_income_tax",
-   "n": 2
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "county_fips",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "current_pregnancy_month",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "current_pregnancy_month",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_benefits",
-   "n": 2
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_market_income",
-   "n": 2
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_refundable_tax_credits",
-   "n": 2
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_state_income_tax",
-   "n": 2
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_tax",
-   "n": 2
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "household_tax_before_refundable_credits",
-   "n": 2
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "il_eitc",
-   "n": 2
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "il_tanf",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "il_tanf_countable_gross_earned_income",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "il_tanf_countable_unearned_income",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_incapable_of_self_care",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "is_in_work_program",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ks_tanf_is_assistance_unit_member",
-   "n": 2
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ma_eitc",
-   "n": 2
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ma_tcap_gross_earned_income",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "ma_tcap_gross_unearned_income",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "months_since_calworks_exit",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "nc_tanf",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "nc_tanf_countable_earned_income",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "nc_tanf_countable_gross_unearned_income",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "receives_housing_assistance",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "spm_unit_tenure_type",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "survivor_benefits",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "use_reported_ssi",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "was_calworks_recipient",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "was_in_foster_care",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "wa_tanf",
-   "n": 2
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "codex_probe_20260513_variable_tracking",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "1"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "educational_assistance",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "financial_assistance",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
    "variable_name": "hud_fair_market_rent",
-   "n": 1
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "1"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "1"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "1"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "1"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "medical_out_of_pocket_expenses",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "1"
+  },
+  {
+   "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
+   "variable_name": "meets_snap_work_requirements_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "1"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "age",
-   "n": 4322
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7741"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "basic_standard_deduction",
-   "n": 4279
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4288"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "employment_income",
-   "n": 4279
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4288"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "is_medicaid_eligible",
-   "n": 4279
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4288"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "snap",
-   "n": 4279
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4288"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "snap_assets",
-   "n": 4279
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4288"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "snap_excess_shelter_expense_deduction",
-   "n": 4279
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4288"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "variable_name": "state_code_str",
-   "n": 4279
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4285"
   },
   {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "aca_ptc",
-   "n": 6308
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "age",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "76"
   },
   {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_calworks_child_care",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_calworks_child_care_eligible",
-   "n": 6308
+   "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
+   "variable_name": "state_code_str",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_calworks_child_care_time_category",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_care",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_care_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_cdcc",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_eitc",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_eitc_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_fera",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_fera_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_foster_youth_tax_credit",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_income_tax_before_credits",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_income_tax_before_refundable_credits",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_la_ez_save",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_la_ez_save_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_renter_credit",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_state_supplement",
-   "n": 6308
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_state_supplement_eligible_person",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_tanf",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_tanf_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_tanf_region1",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_yctc",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "cdcc",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ctc",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "eitc",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "eitc_eligible",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "immigration_status_str",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "income_tax",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "income_tax_before_credits",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "income_tax_before_refundable_credits",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "income_tax_capped_non_refundable_credits",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "income_tax_non_refundable_credits",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "income_tax_refundable_credits",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "in_la",
-   "n": 6308
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "is_aca_eshi_eligible",
-   "n": 6308
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "is_aca_ptc_eligible",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "is_disabled",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "is_lifeline_eligible",
-   "n": 6308
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "is_medicaid_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "is_pregnant",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "is_snap_eligible",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "is_ssi_aged",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "is_ssi_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "la_general_relief",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "la_general_relief_eligible",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "lifeline",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "lives_in_vehicle",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "living_arrangements_allow_for_food_preparation",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "medicaid",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "phone_cost",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "premium_tax_credit",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "refundable_ctc",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "snap",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ssi",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "state_code_str",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "tax_unit_is_joint",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "wic",
-   "n": 6308
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "zip_code",
-   "n": 6308
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12593"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "age",
-   "n": 6294
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_ala_general_assistance",
-   "n": 6280
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12579"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_ala_general_assistance_eligible_person",
-   "n": 6280
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12561"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_ala_general_assistance_income_eligible",
-   "n": 6280
+   "variable_name": "ca_la_ez_save",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "6310"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_calworks_stage_2",
-   "n": 6280
+   "variable_name": "ca_la_ez_save_eligible",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "6310"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_calworks_stage_2_eligible",
-   "n": 6280
+   "variable_name": "aca_ptc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_calworks_stage_3",
-   "n": 6280
+   "variable_name": "ca_calworks_child_care",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_calworks_stage_3_eligible",
-   "n": 6280
+   "variable_name": "ca_calworks_child_care_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_capp",
-   "n": 6280
+   "variable_name": "ca_care",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_capp_eligible",
-   "n": 6280
+   "variable_name": "ca_care_eligible",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_riv_general_relief",
-   "n": 6280
+   "variable_name": "ca_cdcc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_riv_general_relief_eligible",
-   "n": 6280
+   "variable_name": "ca_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_riv_share_eligible",
-   "n": 6280
+   "variable_name": "ca_eitc_eligible",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "ca_riv_share_payment",
-   "n": 6280
+   "variable_name": "ca_fera",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "health_insurance_premiums",
-   "n": 6280
+   "variable_name": "ca_fera_eligible",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "in_ala",
-   "n": 6280
+   "variable_name": "ca_foster_youth_tax_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "in_riv",
-   "n": 6280
+   "variable_name": "ca_income_tax_before_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "months_since_calworks_exit",
-   "n": 6280
+   "variable_name": "ca_income_tax_before_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_renter_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_state_supplement",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf_region1",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_yctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "cdcc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "eitc_eligible",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_before_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_before_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_capped_non_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_non_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_la",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_lifeline_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_pregnant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_snap_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "la_general_relief",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "la_general_relief_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "lifeline",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "lives_in_vehicle",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "living_arrangements_allow_for_food_preparation",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "phone_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "premium_tax_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "refundable_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "state_code_str",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "tax_unit_is_joint",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "zip_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6308"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "receives_medicaid",
-   "n": 6280
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "tenant_pays_utilities",
-   "n": 6280
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "was_calworks_recipient",
-   "n": 6280
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance_income_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_2",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_2_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_3",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_3_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_capp",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_capp_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_general_relief",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_general_relief_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_share_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_share_payment",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "health_insurance_premiums",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_ala",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_riv",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6280"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "household_vehicles_value",
-   "n": 6226
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "rent",
-   "n": 4524
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "employment_income",
-   "n": 4140
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6226"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "weekly_hours_worked_before_lsr",
-   "n": 3875
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6058"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "rent",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4524"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "employment_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4421"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "meets_snap_work_requirements_person",
-   "n": 2535
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4406"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "months_since_calworks_exit",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "3844"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "heating_cooling_expense",
-   "n": 2461
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2461"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "months_since_calworks_exit",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2438"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "pre_subsidy_electricity_expense",
-   "n": 2068
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2068"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "household_vehicles_owned",
-   "n": 1821
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "other_medical_expenses",
-   "n": 1015
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "meets_ssi_disability_criteria",
-   "n": 974
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "is_snap_work_program_participant",
-   "n": 943
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1821"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_calworks_child_care_full_time",
-   "n": 783
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1230"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "other_medical_expenses",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1015"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "976"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_snap_work_program_participant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "926"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
-   "n": 783
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "783"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_riv_general_relief_meets_work_requirements",
-   "n": 446
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "446"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "was_in_foster_care",
-   "n": 403
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "403"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "social_security_retirement",
-   "n": 289
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "328"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "is_homeless",
-   "n": 226
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "226"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "meets_snap_work_requirements_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "194"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "social_security_disability",
-   "n": 147
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "147"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "bedrooms",
-   "n": 104
+   "variable_name": "meets_snap_work_requirements_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "114"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "pre_subsidy_rent",
-   "n": 104
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "104"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "self_employment_income",
-   "n": 100
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "104"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "bedrooms",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "104"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "unemployment_compensation",
-   "n": 92
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "92"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "receives_housing_assistance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "62"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "housing_assistance",
-   "n": 62
-  },
-  {
-   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
-   "variable_name": "receives_housing_assistance",
-   "n": 62
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "62"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "child_support_received",
-   "n": 55
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "55"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_state_disability_insurance",
-   "n": 54
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "54"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_capi_eligible_person",
-   "n": 28
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "32"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "meets_snap_work_requirements_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "20"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_snap_work_program_participant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "19"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "mortgage_payments",
-   "n": 16
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "medical_out_of_pocket_expenses",
-   "n": 14
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "14"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "alimony_income",
-   "n": 12
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_marin_general_relief",
-   "n": 4
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "ca_marin_general_relief_eligible",
-   "n": 4
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "variable_name": "in_marin",
-   "n": 4
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "meets_snap_work_requirements_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "mixed",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_lifeline_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_medicaid_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_pregnant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_snap_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_ssi_aged",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_ssi_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "la_general_relief",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "la_general_relief_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "lifeline",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "lives_in_vehicle",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "living_arrangements_allow_for_food_preparation",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "phone_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "premium_tax_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "receives_medicaid",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "refundable_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "state_code_str",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "tax_unit_is_joint",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "tenant_pays_utilities",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "was_calworks_recipient",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "weekly_hours_worked_before_lsr",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "wic",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "zip_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "aca_ptc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "age",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance_eligible_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_ala_general_assistance_income_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_child_care",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_child_care_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_child_care_time_category",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_2",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_2_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_3",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_calworks_stage_3_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_capp",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_capp_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_care",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_care_eligible",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_cc_general_assistance",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_cc_general_assistance_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_cdcc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_eitc_eligible",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_fera",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_fera_eligible",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_foster_youth_tax_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_income_tax_before_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_income_tax_before_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_renter_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_general_relief",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_general_relief_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_share_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_riv_share_payment",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_state_supplement",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_state_supplement_eligible_person",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_tanf_region1",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ca_yctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "cdcc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "eitc_eligible",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "health_insurance_premiums",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "household_vehicles_value",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "immigration_status_str",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_before_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_before_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_capped_non_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_non_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "income_tax_refundable_credits",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_ala",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_cc",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_la",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "in_riv",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_aca_eshi_eligible",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "is_aca_ptc_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
+   "variable_name": "employment_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
    "variable_name": "age",
-   "n": 4
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
    "variable_name": "ca_income_tax",
-   "n": 4
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
    "variable_name": "employment_income",
-   "n": 4
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
    "variable_name": "income_tax",
-   "n": 4
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "F4JmqoRvPgw0rEZdbC5g4IlLVYQW37Yf",
    "variable_name": "state_name",
-   "n": 4
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "google-oauth2|111840584585669746335",
    "variable_name": "age",
-   "n": 24
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "48"
   },
   {
    "client_id": "google-oauth2|111840584585669746335",
    "variable_name": "state_code_str",
-   "n": 24
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "24"
   },
   {
    "client_id": "google-oauth2|111840584585669746335",
    "variable_name": "employment_income",
-   "n": 16
-  },
-  {
-   "client_id": "google-oauth2|111840584585669746335",
-   "variable_name": "income_tax",
-   "n": 12
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "20"
   },
   {
    "client_id": "google-oauth2|111840584585669746335",
    "variable_name": "is_medicaid_eligible",
-   "n": 12
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12"
   },
   {
    "client_id": "google-oauth2|111840584585669746335",
    "variable_name": "snap",
-   "n": 12
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12"
   },
   {
    "client_id": "google-oauth2|111840584585669746335",
    "variable_name": "eitc",
-   "n": 8
-  },
-  {
-   "client_id": "google-oauth2|111840584585669746335",
-   "variable_name": "basic_standard_deduction",
-   "n": 4
-  },
-  {
-   "client_id": "google-oauth2|111840584585669746335",
-   "variable_name": "ctc",
-   "n": 4
-  },
-  {
-   "client_id": "google-oauth2|111840584585669746335",
-   "variable_name": "pension_income",
-   "n": 4
-  },
-  {
-   "client_id": "google-oauth2|111840584585669746335",
-   "variable_name": "self_employment_income",
-   "n": 4
-  },
-  {
-   "client_id": "google-oauth2|111840584585669746335",
-   "variable_name": "snap_assets",
-   "n": 4
-  },
-  {
-   "client_id": "google-oauth2|111840584585669746335",
-   "variable_name": "snap_excess_shelter_expense_deduction",
-   "n": 4
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "google-oauth2|111840584585669746335",
    "variable_name": "social_security",
-   "n": 4
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "basic_standard_deduction",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "pension_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "self_employment_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "snap_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "google-oauth2|111840584585669746335",
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
    "variable_name": "age",
-   "n": 60
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "120"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
    "variable_name": "state_code_str",
-   "n": 60
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "60"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
    "variable_name": "employment_income",
-   "n": 40
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "income_tax",
-   "n": 30
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "50"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
    "variable_name": "is_medicaid_eligible",
-   "n": 30
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "40"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
    "variable_name": "snap",
-   "n": 30
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "eitc",
-   "n": 20
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "basic_standard_deduction",
-   "n": 10
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "ctc",
-   "n": 10
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "pension_income",
-   "n": 10
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "self_employment_income",
-   "n": 10
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "snap_assets",
-   "n": 10
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "snap_excess_shelter_expense_deduction",
-   "n": 10
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "social_security",
-   "n": 10
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "child1",
-   "n": 4
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "family",
-   "n": 4
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
    "variable_name": "head",
-   "n": 4
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "24"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "household",
-   "n": 4
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "20"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "marital_unit",
-   "n": 4
-  },
-  {
-   "client_id": "google-oauth2|116242521439357911562",
-   "variable_name": "spm_unit",
-   "n": 4
+   "variable_name": "social_security",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "20"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",
    "variable_name": "tax_unit",
-   "n": 4
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "20"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "child1",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "16"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "basic_standard_deduction",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "pension_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "self_employment_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "snap_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "snap_excess_shelter_expense_deduction",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "10"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "household",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "8"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "family",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "4"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "marital_unit",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "4"
+  },
+  {
+   "client_id": "google-oauth2|116242521439357911562",
+   "variable_name": "spm_unit",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "unknown",
+   "availability_status": "unsupported",
+   "n": "4"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "age",
-   "n": 52
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "100"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "state_code_str",
-   "n": 52
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "52"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "employment_income",
-   "n": 34
-  },
-  {
-   "client_id": "google-oauth2|118409323882000545756",
-   "variable_name": "snap",
-   "n": 28
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "42"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "is_medicaid_eligible",
-   "n": 26
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "34"
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "28"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "income_tax",
-   "n": 24
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "24"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "eitc",
-   "n": 16
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16"
+  },
+  {
+   "client_id": "google-oauth2|118409323882000545756",
+   "variable_name": "social_security",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "basic_standard_deduction",
-   "n": 8
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "ctc",
-   "n": 8
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "pension_income",
-   "n": 8
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "self_employment_income",
-   "n": 8
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "snap_assets",
-   "n": 8
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "snap_excess_shelter_expense_deduction",
-   "n": 8
-  },
-  {
-   "client_id": "google-oauth2|118409323882000545756",
-   "variable_name": "social_security",
-   "n": 8
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "employment_income_2",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "2"
   },
   {
    "client_id": "google-oauth2|118409323882000545756",
    "variable_name": "is_medicaid_eligible_2",
-   "n": 2
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "2"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "age",
-   "n": 299
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "789"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "employment_income",
-   "n": 299
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "789"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "state_name",
-   "n": 299
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "242"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "weekly_hours_worked",
-   "n": 231
+   "variable_name": "is_full_time_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "242"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_incapable_of_self_care",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "242"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_pregnant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "242"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "is_wic_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "242"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "wic",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "242"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "adjusted_gross_income",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "cdcc",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "county_fips",
-   "n": 183
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "ctc",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "eitc",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "filing_status",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "income_tax",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "income_tax_before_credits",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_cdcc",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_code",
-   "n": 183
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_code_str",
-   "n": 183
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_ctc",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_eitc",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_fips",
-   "n": 183
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_income_tax",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "state_income_tax_before_refundable_credits",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "state_name",
+   "entity_type": "household",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "tax_unit_childcare_expenses",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "tax_unit_is_joint",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "tax_unit_married",
-   "n": 183
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "zip_code",
-   "n": 183
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "183"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "is_disabled",
-   "n": 116
+   "variable_name": "weekly_hours_worked",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "none",
+   "availability_status": "supported",
+   "n": "123"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "is_full_time_student",
-   "n": 116
-  },
-  {
-   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "is_incapable_of_self_care",
-   "n": 116
-  },
-  {
-   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "is_pregnant",
-   "n": 116
+   "variable_name": "weekly_hours_worked",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "119"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "is_snap_eligible",
-   "n": 116
-  },
-  {
-   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "is_wic_eligible",
-   "n": 116
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "116"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "snap",
-   "n": 116
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "116"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "wic",
-   "n": 116
+   "variable_name": "state_name",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "116"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "is_breastfeeding",
-   "n": 26
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "26"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "is_female",
-   "n": 26
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "26"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "is_parent",
-   "n": 26
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "26"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "is_homeless",
-   "n": 12
-  },
-  {
-   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
-   "variable_name": "child_support_received",
-   "n": 5
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12"
   },
   {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "variable_name": "self_employment_income",
-   "n": 3
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
+  },
+  {
+   "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
+   "variable_name": "child_support_received",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "5"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ssi",
-   "n": 351
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_disabled",
-   "n": 343
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "has_heating_cooling_expense",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "has_phone_expense",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "heating_cooling_expense",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "homeowners_association_fees",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "homeowners_insurance",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "housing_cost",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_blind",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_pregnant",
-   "n": 339
+   "variable_name": "age",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1446"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_tax_unit_dependent",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1310"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_tax_unit_head",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_tax_unit_spouse",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "lifeline",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "medicaid",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "medicaid_category",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "phone_expense",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "real_estate_taxes",
-   "n": 339
+   "variable_name": "employment_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1293"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "rental_income",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "school_meal_countable_income",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "school_meal_daily_subsidy",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "school_meal_tier",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1293"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "self_employment_income",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "snap",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "snap_assets",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "snap_earned_income",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "snap_emergency_allotment",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "snap_unearned_income",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1293"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "social_security",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ssi_countable_resources",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ssi_earned_income",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ssi_reported",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ssi_unearned_income",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "state_code",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1293"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "taxable_ira_distributions",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1293"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "taxable_pension_income",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1293"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "unemployment_compensation",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1293"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "water_expense",
-   "n": 339
+   "variable_name": "is_tax_unit_spouse",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1286"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "wic",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "wic_category",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "age",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "broadband_cost",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "childcare_expenses",
-   "n": 339
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "983"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "child_support_expense",
-   "n": 339
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "795"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ctc_value",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "current_pregnancies",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "eitc",
-   "n": 339
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "employment_income",
-   "n": 339
+   "variable_name": "real_estate_taxes",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "795"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_snap_ineligible_student",
-   "n": 338
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "794"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "other_medical_expenses",
-   "n": 292
+   "variable_name": "is_pregnant",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "784"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "zip_code",
-   "n": 262
+   "variable_name": "is_blind",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "760"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "aca_ptc",
-   "n": 262
+   "variable_name": "is_tax_unit_head",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "760"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "commodity_supplemental_food_program",
-   "n": 256
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_full_time_college_student",
-   "n": 210
+   "variable_name": "ssi_countable_resources",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "760"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "long_term_capital_gains",
-   "n": 181
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "714"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "spm_unit_assets",
-   "n": 179
+   "variable_name": "other_medical_expenses",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "710"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
-   "n": 179
+   "variable_name": "state_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "710"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "weekly_hours_worked_before_lsr",
-   "n": 179
+   "variable_name": "current_pregnancies",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_optional_senior_or_disabled_for_medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "medicaid",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "medicaid_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi_earned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi_reported",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi_unearned_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "wic",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "wic_category",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "643"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "628"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "capital_gains",
-   "n": 158
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "579"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "county_str",
-   "n": 133
+   "variable_name": "commodity_supplemental_food_program",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "521"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "spm_unit_cash_assets",
-   "n": 132
+   "variable_name": "is_full_time_college_student",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "488"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "head_start",
-   "n": 131
+   "variable_name": "childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "early_head_start",
-   "n": 131
+   "variable_name": "has_heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "miscellaneous_income",
-   "n": 130
+   "variable_name": "has_phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "heat_expense_included_in_rent",
-   "n": 129
+   "variable_name": "heating_cooling_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_ccdf_eligible",
-   "n": 129
+   "variable_name": "homeowners_association_fees",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_ccdf_reason_for_care_eligible",
-   "n": 129
+   "variable_name": "homeowners_insurance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "is_in_public_housing",
-   "n": 129
+   "variable_name": "housing_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_child_and_family_credit",
-   "n": 129
+   "variable_name": "phone_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_eaedc",
-   "n": 129
+   "variable_name": "snap_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_eaedc_living_arrangement",
-   "n": 129
+   "variable_name": "snap_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_eaedc_non_financial_eligible",
-   "n": 129
+   "variable_name": "snap_emergency_allotment",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_eitc",
-   "n": 129
+   "variable_name": "snap_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_liheap",
-   "n": 129
+   "variable_name": "water_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "421"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_mbta_enrolled_in_applicable_programs",
-   "n": 129
+   "variable_name": "weekly_hours_worked_before_lsr",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "413"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
-   "n": 129
+   "variable_name": "ctc_value",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "351"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_mbta_senior_charlie_card_eligible",
-   "n": 129
+   "variable_name": "eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "351"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_mbta_tap_charlie_card_eligible",
-   "n": 129
+   "variable_name": "broadband_cost",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "339"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_state_supplement",
-   "n": 129
+   "variable_name": "lifeline",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "339"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "ma_tafdc",
-   "n": 129
+   "variable_name": "school_meal_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "339"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "school_meal_daily_subsidy",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "339"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "school_meal_tier",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "339"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "337"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "ma_tcap_gross_earned_income",
-   "n": 129
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "296"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "ma_tcap_gross_unearned_income",
-   "n": 129
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "296"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "receives_housing_assistance",
-   "n": 129
+   "variable_name": "early_head_start",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "280"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "head_start",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "280"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "miscellaneous_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "273"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "chip_category",
-   "n": 129
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "electricity_expense",
-   "n": 127
+   "variable_name": "is_ccdf_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "is_ccdf_reason_for_care_eligible",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_enrolled_in_applicable_programs",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_income_eligible_reduced_fare_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_senior_charlie_card_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_mbta_tap_charlie_card_eligible",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_state_supplement",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "272"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "aca_ptc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "268"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "heating_expense_person",
-   "n": 127
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "268"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "nc_scca_countable_income",
-   "n": 82
+   "variable_name": "zip_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "262"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "nc_scca_maximum_payment",
-   "n": 82
+   "variable_name": "is_disabled",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "249"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "nc_tanf",
-   "n": 82
+   "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "203"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "nc_tanf_countable_earned_income",
-   "n": 82
+   "variable_name": "spm_unit_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "179"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "nc_tanf_countable_gross_unearned_income",
-   "n": 82
+   "variable_name": "is_in_public_housing",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "153"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "county_str",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "133"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "co_chp_eligible",
-   "n": 77
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "co_ctc",
-   "n": 77
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "co_eitc",
-   "n": 77
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "132"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "co_family_affordability_credit",
-   "n": 77
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "132"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "co_oap",
-   "n": 77
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "132"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "co_state_supplement",
-   "n": 77
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "132"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "co_tanf",
-   "n": 77
+   "variable_name": "spm_unit_cash_assets",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "132"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "co_tanf_countable_gross_earned_income",
-   "n": 77
+   "variable_name": "heat_expense_included_in_rent",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "co_tanf_countable_gross_unearned_income",
-   "n": 77
+   "variable_name": "ma_child_and_family_credit",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eaedc",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eaedc_living_arrangement",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eaedc_non_financial_eligible",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_liheap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ma_tafdc",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "receives_housing_assistance",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "129"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "electricity_expense",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "127"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "alimony_income",
-   "n": 51
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "118"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "childcare_attending_days_per_month",
-   "n": 50
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "117"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "chip",
-   "n": 50
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "117"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_veteran",
-   "n": 50
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "tx_ccs",
-   "n": 50
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "117"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "tx_dart_benefit_person",
-   "n": 50
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "117"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "tx_harris_rides_eligible",
-   "n": 50
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "tx_tanf",
-   "n": 50
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "117"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "medical_out_of_pocket_expenses",
-   "n": 47
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "85"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_ctc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_eitc",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "83"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_scca_countable_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "82"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_scca_maximum_payment",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "82"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "82"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_tanf_countable_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "82"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "nc_tanf_countable_gross_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "82"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "77"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_tanf_countable_gross_earned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "77"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "co_tanf_countable_gross_unearned_income",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "77"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "tx_fpp_benefit",
-   "n": 26
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "60"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tx_ccs",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "50"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tx_tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "50"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "ma_tafdc_pregnancy_eligible",
-   "n": 13
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "26"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "15"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "current_pregnancy_month",
-   "n": 8
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_medicare_eligible",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "medicare_quarters_of_coverage",
-   "n": 3
-  },
-  {
-   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "meets_ssi_disability_criteria",
-   "n": 3
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "msp",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "msp_category",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "msp_eligible",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "social_security_disability",
-   "n": 3
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_medicaid_eligible",
-   "n": 2
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
-   "variable_name": "tanf",
-   "n": 2
+   "variable_name": "meets_ssi_disability_criteria",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "was_in_foster_care",
-   "n": 2
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "8"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "current_pregnancy_month",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "month",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "mixed",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
+   "variable_name": "tanf",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "has_bcc_qualifying_coverage",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_aabd_person",
-   "n": 1
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_bcc_eligible",
-   "n": 1
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_ctc",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_eitc",
-   "n": 1
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_fpp_eligible",
-   "n": 1
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_hbwd_eligible",
-   "n": 1
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_hbwd_person",
-   "n": 1
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_liheap_income_eligible",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_mpe_eligible",
-   "n": 1
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_tanf",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_tanf_countable_gross_earned_income",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "il_tanf_countable_unearned_income",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_federal_work_study_participant",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_female",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_part_time_college_student",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "is_snap_higher_ed_student",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "mortgage_payments",
-   "n": 1
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "receives_medicaid",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "rent",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
    "variable_name": "workers_compensation",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "age",
-   "n": 794
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "employment_income",
-   "n": 792
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "state_code",
-   "n": 792
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "income_tax",
-   "n": 791
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "adjusted_gross_income",
-   "n": 779
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "filing_status",
-   "n": 779
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "is_tax_unit_head",
-   "n": 776
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "state_income_tax",
-   "n": 776
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "is_tax_unit_spouse",
-   "n": 682
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "additional_medicare_tax",
-   "n": 630
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "alternative_minimum_tax",
-   "n": 630
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "local_income_tax",
-   "n": 630
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1485"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "marginal_tax_rate",
-   "n": 630
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "net_investment_income_tax",
-   "n": 630
-  },
-  {
-   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
-   "variable_name": "qualified_business_income_deduction",
-   "n": 630
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1175"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "self_employment_tax",
-   "n": 630
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1175"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "employment_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "947"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "state_code",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "801"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "800"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "adjusted_gross_income",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "788"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "filing_status",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "788"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "is_tax_unit_head",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "785"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "state_income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "785"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "is_tax_unit_spouse",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "682"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "additional_medicare_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "639"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "alternative_minimum_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "639"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "local_income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "639"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "net_investment_income_tax",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "639"
+  },
+  {
+   "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
+   "variable_name": "qualified_business_income_deduction",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "639"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "standard_deduction",
-   "n": 630
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "639"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "taxable_income_deductions",
-   "n": 606
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "615"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "tax_unit_taxable_social_security",
-   "n": 600
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "609"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "taxable_ira_distributions",
-   "n": 347
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "351"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "taxable_interest_income",
-   "n": 150
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "150"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "social_security",
-   "n": 58
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "58"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "long_term_capital_gains",
-   "n": 13
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "qualified_dividend_income",
-   "n": 12
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "12"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "taxable_roth_conversions",
-   "n": 7
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "unsupported",
+   "n": "7"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "taxable_income",
-   "n": 3
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "traditional_ira_contributions",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "variable_name": "traditional_ira_contributions_desired",
-   "n": 3
-  },
-  {
-   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
-   "variable_name": "adjusted_gross_income",
-   "n": 33
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "age",
-   "n": 33
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "mixed",
+   "availability_status": "supported",
+   "n": "68"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "eitc",
-   "n": 33
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "33"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "filing_status",
-   "n": 33
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "33"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "income_tax",
-   "n": 33
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "33"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "state_income_tax",
-   "n": 33
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "33"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "state_name",
-   "n": 33
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "33"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "employment_income",
-   "n": 29
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30"
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "adjusted_gross_income",
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "29"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "charitable_cash_donations",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "deductible_mortgage_interest",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "health_savings_account_payroll_contributions",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "long_term_capital_gains",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "non_qualified_dividend_income",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "real_estate_taxes",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "taxable_interest_income",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "traditional_ira_contributions",
-   "n": 27
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "27"
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "age",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "19"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "standard_deduction",
-   "n": 6
+   "entity_type": "tax_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6"
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "adjusted_gross_income",
+   "entity_type": "tax_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
+   "variable_name": "social_security",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "short_term_capital_gains",
-   "n": 2
-  },
-  {
-   "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
-   "variable_name": "social_security",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "wCW62HfHGoMsKnIwfNgx3IYvkjnchazk",
    "variable_name": "unemployment_compensation",
-   "n": 2
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "weekly_hours_worked",
-   "n": 1409
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "age",
-   "n": 852
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "employment_income",
-   "n": 852
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_disabled",
-   "n": 852
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_full_time_student",
-   "n": 852
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_incapable_of_self_care",
-   "n": 852
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_pregnant",
-   "n": 852
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "is_snap_eligible",
-   "n": 852
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_wic_eligible",
-   "n": 852
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "snap",
-   "n": 852
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "state_name",
-   "n": 852
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "wic",
-   "n": 852
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2025"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "weekly_hours_worked",
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "none",
+   "availability_status": "supported",
+   "n": "1114"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "weekly_hours_worked",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "911"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "state_name",
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "854"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "is_snap_eligible",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "854"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "848"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "rent",
-   "n": 270
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "270"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "pre_subsidy_electricity_expense",
-   "n": 224
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "225"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "phone_expense",
-   "n": 212
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "213"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "spm_unit_pre_subsidy_childcare_expenses",
-   "n": 134
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "135"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "health_insurance_premiums",
-   "n": 121
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "135"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "water_expense",
-   "n": 109
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "110"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "gas_expense",
-   "n": 93
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "93"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "mortgage_payments",
-   "n": 85
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "86"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_homeless",
-   "n": 77
+   "entity_type": "household",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "77"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "medical_out_of_pocket_expenses",
-   "n": 71
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "deprecated_allowlisted",
+   "n": "75"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_breastfeeding",
-   "n": 55
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "55"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_female",
-   "n": 55
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "55"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_parent",
-   "n": 55
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "55"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "trash_expense",
-   "n": 46
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "46"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "heating_cooling_expense",
-   "n": 37
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "37"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "self_employment_income",
-   "n": 28
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "30"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "sewage_expense",
-   "n": 28
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "28"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "other_medical_expenses",
-   "n": 23
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "23"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "real_estate_taxes",
-   "n": 16
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "16"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "child_support_received",
-   "n": 13
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "homeowners_association_fees",
-   "n": 13
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "13"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "child_support_expense",
-   "n": 11
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "miscellaneous_income",
-   "n": 9
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "social_security",
-   "n": 7
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "ssi",
-   "n": 6
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "disability_benefits",
-   "n": 4
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "general_assistance",
-   "n": 4
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "11"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "is_wic_at_nutritional_risk",
-   "n": 3
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "medicaid_enrolled",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "meets_wic_categorical_eligibility",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "meets_wic_income_test",
-   "n": 3
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "pension_income",
-   "n": 3
-  },
-  {
-   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "retirement_distributions",
-   "n": 3
+   "variable_name": "miscellaneous_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "wic_category",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "wic_category_str",
-   "n": 3
+   "entity_type": "person",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "9"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
-   "variable_name": "alimony_income",
-   "n": 2
+   "variable_name": "social_security",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "7"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "snap",
+   "entity_type": "spm_unit",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "ssi",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "medicaid_enrolled",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "6"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "disability_benefits",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "general_assistance",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "pension_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "4"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "meets_wic_income_test",
+   "entity_type": "spm_unit",
+   "source": "requested_output",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "retirement_distributions",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "3"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "rental_income",
-   "n": 2
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
+  },
+  {
+   "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
+   "variable_name": "alimony_income",
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "2"
   },
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "variable_name": "gi_cash_assistance",
-   "n": 1
+   "entity_type": "person",
+   "source": "household_input",
+   "period_granularity": "year",
+   "availability_status": "supported",
+   "n": "1"
   }
  ],
  "endpoints": [
   {
    "client_id": "2bvOcXtHvebOexszcAdzCSIj7G29Cu5I",
    "endpoint": "calculate",
-   "n": 35081,
-   "last_seen": "2026-07-02 13:05:39"
+   "n": 35099,
+   "last_seen": "2026-07-02 15:00:42"
   },
   {
    "client_id": "1AR7c1FQlZOH72DDHkvvdYTSw2Eybto3",
    "endpoint": "calculate",
-   "n": 13878,
-   "last_seen": "2026-07-01 17:25:00"
+   "n": 13881,
+   "last_seen": "2026-07-02 14:24:16"
   },
   {
    "client_id": "eKpF8YnfwJFQVpU0TOQo8CEz70MDKn9Q",
    "endpoint": "calculate",
-   "n": 12458,
-   "last_seen": "2026-07-01 22:46:47"
+   "n": 12283,
+   "last_seen": "2026-07-02 14:38:33"
   },
   {
    "client_id": "DQ9PLUoU6MHtfr5fQOmY0FpTj63HmQ5Y",
    "endpoint": "calculate",
-   "n": 9368,
-   "last_seen": "2026-07-02 11:12:37"
+   "n": 9367,
+   "last_seen": "2026-07-02 14:50:24"
   },
   {
    "client_id": "CxWDaxfiziFbdnjW5T0ZPthShPgyj8A9",
@@ -5827,14 +11440,14 @@
   {
    "client_id": "WyWSiIJEOhQsWbRpiXOPqn5CcOQ2XEQu",
    "endpoint": "calculate",
-   "n": 1216,
-   "last_seen": "2026-07-02 10:44:15"
+   "n": 1218,
+   "last_seen": "2026-07-02 14:29:09"
   },
   {
    "client_id": "STaztFgtPFXkOuhFtNjPAv4jDhJfTiHq",
    "endpoint": "calculate",
-   "n": 922,
-   "last_seen": "2026-07-02 00:56:24"
+   "n": 931,
+   "last_seen": "2026-07-02 14:08:46"
   },
   {
    "client_id": "qSH0K7upvN2jfsDxLZyLashJrl6pZ1k8",
@@ -5843,16 +11456,16 @@
    "last_seen": "2026-07-01 08:20:33"
   },
   {
-   "client_id": "gs6efNb3RxhUFQgwS9OvTpJP0trZJiKz",
-   "endpoint": "calculate",
-   "n": 542,
-   "last_seen": "2026-05-08 18:17:36"
-  },
-  {
    "client_id": "NaQpYc3eu1ike6BYxjcaQ1xPclFgd9zr",
    "endpoint": "calculate",
-   "n": 447,
+   "n": 445,
    "last_seen": "2026-07-02 09:13:02"
+  },
+  {
+   "client_id": "gs6efNb3RxhUFQgwS9OvTpJP0trZJiKz",
+   "endpoint": "calculate",
+   "n": 429,
+   "last_seen": "2026-05-08 18:17:36"
   },
   {
    "client_id": "google-oauth2|116242521439357911562",

--- a/tools/parity/inventory.py
+++ b/tools/parity/inventory.py
@@ -1,0 +1,156 @@
+"""Phase-0 migration inventory: who uses the household API, and how.
+
+Read-only queries against the production user-analytics database (Cloud SQL,
+credentials from Secret Manager, IAM via application-default credentials).
+Produces the per-client compatibility matrix that drives the API v2 migration:
+which clients are active, what countries/versions/endpoints they use, and
+which variables they send/request — i.e. what the v2 endpoint must support
+before each client can move.
+
+    uv run python tools/parity/inventory.py [--days 90]
+
+Prints a report and writes tools/parity/inventory-report.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pymysql
+from google.cloud.sql.connector import Connector
+
+HERE = Path(__file__).parent
+PROJECT = "policyengine-household-api"
+
+
+def secret(name: str) -> str:
+    return subprocess.run(
+        ["gcloud", "secrets", "versions", "access", "latest", f"--secret={name}", f"--project={PROJECT}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def q(cur, sql: str, params: tuple = ()) -> list[dict]:
+    cur.execute(sql, params)
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--days", type=int, default=90)
+    ap.add_argument("--secret-prefix", default="household-api-production-")
+    args = ap.parse_args()
+
+    pfx = args.secret_prefix
+    def psecret(n):
+        try:
+            return secret(pfx + n)
+        except Exception:
+            return secret(n)
+    import os
+    conn_name = os.environ.get("ANALYTICS_CONN") or psecret("USER_ANALYTICS_DB_CONNECTION_NAME")
+    connector = Connector()
+    conn = connector.connect(
+        conn_name,
+        "pymysql",
+        user=psecret("USER_ANALYTICS_DB_USERNAME"),
+        password=psecret("USER_ANALYTICS_DB_PASSWORD"),
+        db=None,
+    )
+    cur = conn.cursor()
+    dbs = [r[0] for r in (cur.execute("SHOW DATABASES") or 1) and cur.fetchall()]
+    db = next((d for d in dbs if "analytic" in d.lower()), None) or next((d for d in dbs if d not in ("information_schema","mysql","performance_schema","sys")), None)
+    print(f"databases: {dbs} -> using {db}")
+    cur.execute(f"USE `{db}`")
+
+    report: dict = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "window_days": args.days,
+    }
+
+    # What tables exist (schema drifted across alembic revisions — be flexible)
+    tables = [list(r.values())[0] for r in q(cur, "SHOW TABLES")]
+    report["tables"] = tables
+    print(f"tables: {tables}\n")
+
+    since = f"created_at >= NOW() - INTERVAL {args.days} DAY"
+    visits_since = f"datetime >= NOW() - INTERVAL {args.days} DAY"
+
+    if "calculate_requests" in tables:
+        report["clients"] = q(cur, f"""
+            SELECT client_id,
+                   COUNT(*) AS requests,
+                   COUNT(DISTINCT country_id) AS countries,
+                   GROUP_CONCAT(DISTINCT country_id) AS country_list,
+                   GROUP_CONCAT(DISTINCT resolved_channel) AS channels,
+                   GROUP_CONCAT(DISTINCT requested_version) AS requested_versions,
+                   SUM(response_status_code >= 400) AS error_responses,
+                   MIN(created_at) AS first_seen,
+                   MAX(created_at) AS last_seen
+            FROM calculate_requests
+            WHERE {since}
+            GROUP BY client_id
+            ORDER BY requests DESC
+        """)
+        report["daily_volume"] = q(cur, f"""
+            SELECT DATE(created_at) AS day, COUNT(*) AS requests,
+                   COUNT(DISTINCT client_id) AS active_clients
+            FROM calculate_requests
+            WHERE {since}
+            GROUP BY DATE(created_at) ORDER BY day DESC LIMIT 14
+        """)
+        report["errors_by_client"] = q(cur, f"""
+            SELECT client_id, response_status_code, COUNT(*) AS n
+            FROM calculate_requests
+            WHERE {since} AND response_status_code >= 400
+            GROUP BY client_id, response_status_code ORDER BY n DESC LIMIT 20
+        """)
+        # UK usage specifically (prod UK calc is currently broken — issue #1601)
+        report["uk_usage"] = q(cur, f"""
+            SELECT client_id, COUNT(*) AS requests, MAX(created_at) AS last_seen,
+                   GROUP_CONCAT(DISTINCT response_status_code) AS statuses
+            FROM calculate_requests
+            WHERE {since} AND country_id = 'uk'
+            GROUP BY client_id
+        """)
+
+    if "calculate_request_variables" in tables:
+        report["variables_by_client"] = q(cur, f"""
+            SELECT client_id, variable_name, COUNT(*) AS n
+            FROM calculate_request_variables
+            WHERE {since}
+            GROUP BY client_id, variable_name
+            ORDER BY client_id, n DESC
+        """)
+
+    if "visits" in tables:
+        report["endpoints"] = q(cur, f"""
+            SELECT client_id, endpoint, COUNT(*) AS n, MAX(datetime) AS last_seen
+            FROM visits
+            WHERE {visits_since}
+            GROUP BY client_id, endpoint ORDER BY n DESC LIMIT 40
+        """)
+
+    cur.close(); conn.close(); connector.close()
+
+    out = HERE / "inventory-report.json"
+    out.write_text(json.dumps(report, indent=1, default=str))
+
+    # Console summary
+    print(f"=== Active clients (last {args.days}d) ===")
+    for c in report.get("clients", []):
+        print(f"  {(c['client_id'] or '(anonymous/demo)')[:24]:26} {c['requests']:>7} req  countries={c['country_list']}  channels={c['channels']}  errors={c['error_responses']}  last={c['last_seen']}")
+    print(f"\n=== UK usage (prod UK is broken — who's affected?) ===")
+    for c in report.get("uk_usage", []) or [{"client_id": "(none)", "requests": 0, "last_seen": "-", "statuses": "-"}]:
+        print(f"  {(c['client_id'] or '(anonymous/demo)')[:24]:26} {c['requests']:>7} req  statuses={c['statuses']}  last={c['last_seen']}")
+    print(f"\nFull report: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/parity/inventory.py
+++ b/tools/parity/inventory.py
@@ -121,10 +121,13 @@ def main() -> int:
 
     if "calculate_request_variables" in tables:
         report["variables_by_client"] = q(cur, f"""
-            SELECT client_id, variable_name, COUNT(*) AS n
+            SELECT client_id, variable_name, entity_type, source,
+                   period_granularity, availability_status,
+                   SUM(occurrence_count) AS n
             FROM calculate_request_variables
             WHERE {since}
-            GROUP BY client_id, variable_name
+            GROUP BY client_id, variable_name, entity_type, source,
+                     period_granularity, availability_status
             ORDER BY client_id, n DESC
         """)
 

--- a/tools/parity/parity.py
+++ b/tools/parity/parity.py
@@ -136,6 +136,13 @@ def build_corpus() -> dict[str, dict]:
             payload = data if "household" in data else {"household": data}
             corpus[f"us-legacy-{name.split('_')[1]}"] = {"country": country, "payload": payload}
 
+    # Per-client cases generated from the analytics inventory, if present.
+    cases_dir = HERE / "cases"
+    if cases_dir.exists():
+        for f in sorted(cases_dir.glob("*.json")):
+            data = json.loads(f.read_text())
+            corpus[f.stem] = {"country": data["country"], "payload": data["payload"]}
+
     return corpus
 
 

--- a/tools/parity/parity.py
+++ b/tools/parity/parity.py
@@ -84,6 +84,49 @@ def build_corpus() -> dict[str, dict]:
         },
     }
 
+    # Periphery cases — exercise the validation/warnings layer, not just math.
+    corpus["us-warn-partial-month"] = {
+        "country": "us",
+        "payload": {
+            "household": {
+                "people": {"adult": {"age": {"2026": 35}, "employment_income": {"2026-01": 2500}}},
+                "tax_units": {"tu": {"members": ["adult"], "income_tax": {"2026": None}}},
+                "spm_units": {"spm": {"members": ["adult"]}},
+                "families": {"fam": {"members": ["adult"]}},
+                "marital_units": {"mu": {"members": ["adult"]}},
+                "households": {"hh": {"members": ["adult"], "state_name": {"2026": "CA"}}},
+            }
+        },
+    }
+    corpus["us-warn-deprecated-input"] = {
+        "country": "us",
+        "payload": {
+            "household": {
+                "people": {"adult": {"age": {"2026": 40}, "employment_income": {"2026": 50000},
+                                      "medical_out_of_pocket_expenses": {"2026": 1200}}},
+                "tax_units": {"tu": {"members": ["adult"], "income_tax": {"2026": None}}},
+                "spm_units": {"spm": {"members": ["adult"]}},
+                "families": {"fam": {"members": ["adult"]}},
+                "marital_units": {"mu": {"members": ["adult"]}},
+                "households": {"hh": {"members": ["adult"], "state_name": {"2026": "NY"}}},
+            }
+        },
+    }
+    corpus["us-axes-sweep"] = {
+        "country": "us",
+        "payload": {
+            "household": {
+                "people": {"adult": {"age": {"2026": 30}, "employment_income": {"2026": None}}},
+                "tax_units": {"tu": {"members": ["adult"], "income_tax": {"2026": None}}},
+                "spm_units": {"spm": {"members": ["adult"]}},
+                "families": {"fam": {"members": ["adult"]}},
+                "marital_units": {"mu": {"members": ["adult"]}},
+                "households": {"hh": {"members": ["adult"], "state_name": {"2026": "TX"}}},
+                "axes": [[{"name": "employment_income", "count": 5, "min": 0, "max": 100000, "period": "2026"}]],
+            }
+        },
+    }
+
     # Legacy JSON payloads kept in the repo, if present.
     legacy = REPO_ROOT / "tests" / "to_refactor" / "python" / "data"
     for name, country in [("calculate_us_1_data.json", "us"), ("calculate_us_2_data.json", "us")]:

--- a/tools/parity/parity.py
+++ b/tools/parity/parity.py
@@ -136,6 +136,20 @@ def build_corpus() -> dict[str, dict]:
             payload = data if "household" in data else {"household": data}
             corpus[f"us-legacy-{name.split('_')[1]}"] = {"country": country, "payload": payload}
 
+    corpus["us-err-unknown-variable"] = {
+        "country": "us",
+        "payload": {
+            "household": {
+                "people": {"adult": {"age": {"2026": 35}, "definitely_not_a_variable": {"2026": 1}}},
+                "tax_units": {"tu": {"members": ["adult"], "income_tax": {"2026": None}}},
+                "spm_units": {"spm": {"members": ["adult"]}},
+                "families": {"fam": {"members": ["adult"]}},
+                "marital_units": {"mu": {"members": ["adult"]}},
+                "households": {"hh": {"members": ["adult"], "state_name": {"2026": "CA"}}},
+            }
+        },
+    }
+
     # Per-client cases generated from the analytics inventory, if present.
     cases_dir = HERE / "cases"
     if cases_dir.exists():
@@ -248,6 +262,18 @@ def cmd_diff(base_url: str, only: str | None) -> int:
             continue
         total += 1
         status, body = post(base_url, snap["country"], snap["request"])
+        expected_status = snap.get("expected_status", 200)
+        if expected_status != 200:
+            # Error-contract case: status + error body must match the golden.
+            ediffs = deep_diff(snap["response"], strip_ignored(body))
+            if status == expected_status and not ediffs:
+                passed += 1
+                print(f"✓ {snap['case']}: ERROR-PARITY (HTTP {status})")
+            else:
+                print(f"✗ {snap['case']}: HTTP {status} (want {expected_status}), {len(ediffs)} body diffs")
+                for d in ediffs[:6]:
+                    print(f"    {d}")
+            continue
         if status != 200:
             print(f"✗ {snap['case']}: HTTP {status} — {json.dumps(body)[:160]}")
             continue

--- a/tools/parity/parity.py
+++ b/tools/parity/parity.py
@@ -1,0 +1,244 @@
+"""Golden parity harness for the household API migration.
+
+Captures golden response snapshots from a reference deployment (the live
+household API) and diffs any candidate endpoint (e.g. the API v2 household
+service) against them, with numeric tolerance. The corpus is seeded from the
+real partner payloads in tests/data/customer_households plus synthetic basics.
+
+Usage (from repo root):
+
+    # 1. Freeze goldens against a reference API (local: `make debug` first)
+    uv run python tools/parity/parity.py capture --base-url http://localhost:5000
+
+    # 2. Diff a candidate implementation against the goldens
+    uv run python tools/parity/parity.py diff --base-url http://localhost:8000
+
+Goldens land in tools/parity/golden/<case>.json with the reference's model
+versions recorded; diffs compare `result` deeply (floats: abs 0.01 or rel
+1e-6), treat `warnings` as sets, and report model-version drift separately
+(a version mismatch explains numeric drift and is flagged, not failed).
+
+Zero third-party deps (stdlib only) so it runs in any environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).parent
+GOLDEN_DIR = HERE / "golden"
+REPO_ROOT = HERE.parent.parent
+
+ABS_TOL = 0.01  # money-scale absolute tolerance
+REL_TOL = 1e-6
+
+# Response keys that are run-specific, not contractual.
+IGNORED_KEYS = {"computation_tree_uuid"}
+
+
+def build_corpus() -> dict[str, dict]:
+    """Corpus cases: name -> {country, payload}. Seeded from real partner
+    households (imported from the test data) plus synthetic basics."""
+    sys.path.insert(0, str(REPO_ROOT))
+    from tests.data.customer_households import (  # noqa: E402
+        amplifi_household,
+        amplifi_household_2025,
+        impactica_household,
+        my_friend_ben_household,
+    )
+
+    corpus: dict[str, dict] = {
+        "us-my-friend-ben": {"country": "us", "payload": {"household": my_friend_ben_household}},
+        "us-amplifi": {"country": "us", "payload": {"household": amplifi_household}},
+        "us-amplifi-2025": {"country": "us", "payload": {"household": amplifi_household_2025}},
+        "us-impactica": {"country": "us", "payload": {"household": impactica_household}},
+        # Synthetic basics — trivially readable cases that catch gross breakage.
+        "us-single-adult": {
+            "country": "us",
+            "payload": {
+                "household": {
+                    "people": {"adult": {"age": {"2026": 35}, "employment_income": {"2026": 30000}}},
+                    "tax_units": {"tu": {"members": ["adult"], "income_tax": {"2026": None}}},
+                    "spm_units": {"spm": {"members": ["adult"], "snap": {"2026": None}}},
+                    "families": {"fam": {"members": ["adult"]}},
+                    "marital_units": {"mu": {"members": ["adult"]}},
+                    "households": {"hh": {"members": ["adult"], "state_name": {"2026": "CA"}}},
+                }
+            },
+        },
+        "uk-single-adult": {
+            "country": "uk",
+            "payload": {
+                "household": {
+                    "people": {"adult": {"age": {"2026": 35}, "employment_income": {"2026": 25000}}},
+                    "benunits": {"bu": {"members": ["adult"], "universal_credit": {"2026": None}}},
+                    "households": {"hh": {"members": ["adult"], "income_tax": {"2026": None}}},
+                }
+            },
+        },
+    }
+
+    # Legacy JSON payloads kept in the repo, if present.
+    legacy = REPO_ROOT / "tests" / "to_refactor" / "python" / "data"
+    for name, country in [("calculate_us_1_data.json", "us"), ("calculate_us_2_data.json", "us")]:
+        f = legacy / name
+        if f.exists():
+            data = json.loads(f.read_text())
+            payload = data if "household" in data else {"household": data}
+            corpus[f"us-legacy-{name.split('_')[1]}"] = {"country": country, "payload": payload}
+
+    return corpus
+
+
+def post(base_url: str, country: str, payload: dict, timeout: int = 120, endpoint: str = "calculate") -> tuple[int, dict]:
+    url = f"{base_url.rstrip('/')}/{country}/{endpoint}"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as res:
+            return res.status, json.loads(res.read().decode())
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode())
+        except Exception:
+            return e.code, {"error": str(e)}
+
+
+def strip_ignored(obj):
+    if isinstance(obj, dict):
+        return {k: strip_ignored(v) for k, v in obj.items() if k not in IGNORED_KEYS}
+    if isinstance(obj, list):
+        return [strip_ignored(v) for v in obj]
+    return obj
+
+
+def numbers_equal(a: float, b: float) -> bool:
+    if a == b:
+        return True
+    return abs(a - b) <= max(ABS_TOL, REL_TOL * max(abs(a), abs(b)))
+
+
+def deep_diff(golden, candidate, path="") -> list[str]:
+    """Structural + numeric diff; returns human-readable difference lines."""
+    diffs: list[str] = []
+    if isinstance(golden, dict) and isinstance(candidate, dict):
+        for k in sorted(set(golden) | set(candidate)):
+            p = f"{path}.{k}" if path else k
+            if k not in golden:
+                diffs.append(f"+ {p} (candidate-only): {json.dumps(candidate[k])[:80]}")
+            elif k not in candidate:
+                diffs.append(f"- {p} (missing in candidate): {json.dumps(golden[k])[:80]}")
+            else:
+                diffs.extend(deep_diff(golden[k], candidate[k], p))
+    elif isinstance(golden, list) and isinstance(candidate, list):
+        if len(golden) != len(candidate):
+            diffs.append(f"~ {path}: list length {len(golden)} vs {len(candidate)}")
+        for i, (g, c) in enumerate(zip(golden, candidate)):
+            diffs.extend(deep_diff(g, c, f"{path}[{i}]"))
+    elif isinstance(golden, bool) or isinstance(candidate, bool):
+        if golden != candidate:
+            diffs.append(f"~ {path}: {golden} vs {candidate}")
+    elif isinstance(golden, (int, float)) and isinstance(candidate, (int, float)):
+        if not numbers_equal(float(golden), float(candidate)):
+            diffs.append(f"~ {path}: {golden} vs {candidate}")
+    elif golden != candidate:
+        diffs.append(f"~ {path}: {json.dumps(golden)[:60]} vs {json.dumps(candidate)[:60]}")
+    return diffs
+
+
+def cmd_capture(base_url: str, only: str | None, endpoint: str = "calculate", sleep_between: float = 0) -> int:
+    import time
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    corpus = build_corpus()
+    failures = 0
+    for name, case in corpus.items():
+        if only and only not in name:
+            continue
+        if sleep_between:
+            time.sleep(sleep_between)
+        status, body = post(base_url, case["country"], case["payload"], endpoint=endpoint)
+        if status != 200 or body.get("status") != "ok":
+            print(f"✗ {name}: HTTP {status} — {json.dumps(body)[:160]}")
+            failures += 1
+            continue
+        snapshot = {
+            "case": name,
+            "country": case["country"],
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+            "reference_base_url": base_url,
+            "model_versions": body.get("policyengine_bundle") or body.get("model_version"),
+            "request": case["payload"],
+            "response": strip_ignored(body),
+        }
+        (GOLDEN_DIR / f"{name}.json").write_text(json.dumps(snapshot, indent=1, sort_keys=True))
+        print(f"✓ {name}: golden captured ({len(json.dumps(body))} bytes)")
+    print(f"\n{len(list(GOLDEN_DIR.glob('*.json')))} goldens in {GOLDEN_DIR}")
+    return 1 if failures else 0
+
+
+def cmd_diff(base_url: str, only: str | None) -> int:
+    goldens = sorted(GOLDEN_DIR.glob("*.json"))
+    if not goldens:
+        print("No goldens — run capture first.")
+        return 2
+    total = passed = 0
+    for f in goldens:
+        snap = json.loads(f.read_text())
+        if only and only not in snap["case"]:
+            continue
+        total += 1
+        status, body = post(base_url, snap["country"], snap["request"])
+        if status != 200:
+            print(f"✗ {snap['case']}: HTTP {status} — {json.dumps(body)[:160]}")
+            continue
+
+        golden_versions = snap.get("model_versions")
+        cand_versions = body.get("policyengine_bundle") or body.get("model_version")
+        version_note = "" if golden_versions == cand_versions else "  [MODEL VERSION DRIFT]"
+
+        diffs = deep_diff(snap["response"].get("result"), strip_ignored(body).get("result"))
+        g_warn = set(map(json.dumps, snap["response"].get("warnings") or []))
+        c_warn = set(map(json.dumps, body.get("warnings") or []))
+        if g_warn != c_warn:
+            diffs.append(f"~ warnings: {len(g_warn)} golden vs {len(c_warn)} candidate")
+
+        if not diffs:
+            passed += 1
+            print(f"✓ {snap['case']}: PARITY{version_note}")
+        else:
+            print(f"✗ {snap['case']}: {len(diffs)} differences{version_note}")
+            for d in diffs[:12]:
+                print(f"    {d}")
+            if len(diffs) > 12:
+                print(f"    … {len(diffs) - 12} more")
+    print(f"\n{passed}/{total} cases at parity")
+    return 0 if passed == total else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    for name in ("capture", "diff"):
+        p = sub.add_parser(name)
+        p.add_argument("--base-url", required=True)
+        p.add_argument("--only", help="substring filter on case names")
+        p.add_argument("--endpoint", default="calculate", help="calculate | calculate_demo")
+        p.add_argument("--sleep-between", type=float, default=0, help="seconds between requests (demo is rate-limited 1/10s)")
+    args = ap.parse_args()
+    if args.cmd == "capture":
+        return cmd_capture(args.base_url, args.only, args.endpoint, args.sleep_between)
+    return cmd_diff(args.base_url, args.only)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Tooling for the api-v2 migration (experiment; see plan discussion).

- **tools/parity/parity.py** — freezes golden response snapshots from a reference deployment and diffs any candidate endpoint with numeric tolerance. Corpus = the real partner payloads (MyFriendBen, Amplifi ×2, Impactica) + synthetics. Goldens in-tree were captured from production via calculate_demo. Found #1601 (prod UK 500) on first run.
- **tools/parity/inventory.py** — read-only Phase-0 client matrix from the prod user-analytics Cloud SQL DB: volumes, countries, channels, error rates, per-client variables. Headline: 100% of 90-day traffic is US; `frontier` channel is actively used.

First cross-implementation diff against the resurrected v2 household endpoint: **5/5 parity** on all partner payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)