### PR TITLE
Keep analytics writer import chain free of heavy modules

### DIFF
--- a/changelog.d/1603.fixed.md
+++ b/changelog.d/1603.fixed.md
@@ -1,0 +1,1 @@
+Keep the analytics writer import chain free of numpy and country model packages so the slim Cloud Run analytics writer image boots.

--- a/policyengine_household_api/utils/__init__.py
+++ b/policyengine_household_api/utils/__init__.py
@@ -1,13 +1,17 @@
+"""Utility helpers for the Household API.
+
+Keep this package import lightweight: the Cloud Run analytics writer imports
+`policyengine_household_api.utils.config_loader`, which executes this module
+first. Heavy submodules (`json` pulls numpy) must be imported directly, e.g.
+`from policyengine_household_api.utils.json import get_safe_json`.
+"""
+
 from . import config_loader
-from .json import *
-from .validate_country import *
 from .config_loader import ConfigLoader, get_config, get_config_value
-from .validate_country import validate_country
 
 __all__ = [
     "config_loader",
     "ConfigLoader",
     "get_config",
     "get_config_value",
-    "validate_country",
 ]

--- a/tests/unit/failover/test_cloud_run_analytics_writer.py
+++ b/tests/unit/failover/test_cloud_run_analytics_writer.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 import logging
+import subprocess
+import sys
 from unittest.mock import MagicMock
 
 from policyengine_household_api.analytics.events import CalculateAnalyticsEvent
@@ -101,3 +103,34 @@ def test_analytics_writer_db_failure_returns_500_for_cloud_tasks_retry(
     assert response.status_code == 500
     assert response.get_json()["code"] == "analytics_write_failed"
     assert "Failed to persist calculate analytics event" in caplog.text
+
+
+def test_analytics_writer_import_chain_stays_slim():
+    """The writer image installs only the analytics-writer dependency group.
+
+    Importing the writer must not pull modules excluded from that group
+    (numpy via utils.json, country model packages via calculation code), or
+    the deployed writer crash-loops at gunicorn worker boot.
+    """
+    heavy_modules = (
+        "numpy",
+        "policyengine_core",
+        "policyengine_uk",
+        "policyengine_us",
+    )
+    probe = (
+        "import sys\n"
+        "import policyengine_household_api.failover."
+        "cloud_run_analytics_writer\n"
+        "import policyengine_household_api.analytics.persistence\n"
+        f"heavy = [m for m in {heavy_modules!r} if m in sys.modules]\n"
+        "assert not heavy, f'writer import pulled heavy modules: {heavy}'\n"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Fixes #1603

## Summary

- Slim `policyengine_household_api/utils/__init__.py` to re-export only `config_loader` symbols. The eager `from .json import *` pulled numpy into the import chain of `utils.config_loader`, which the Cloud Run analytics writer imports; the slim `analytics-writer` dependency group intentionally excludes numpy, so the deployed writer crash-looped at gunicorn worker boot and returned 503 to every Cloud Tasks dispatch.
- All consumers of `utils.json` and `utils.validate_country` already import from the submodules directly (#1580 migrated the last root-level importers), so no call sites change.
- Add a regression test that imports the writer entry modules in a subprocess and asserts numpy and country model packages stay out of `sys.modules`.

## Context

Deploy run 28673382864 (the #1580 release): all four `Integration tests against Modal staging` matrix jobs failed on `test_calculate_request_records_complete_analytics_metadata` because no analytics row ever appeared. Worker enqueue and Cloud Tasks dispatch worked; the writer was the broken hop:

```
File "/app/policyengine_household_api/data/analytics_setup.py", line 10, in <module>
    from policyengine_household_api.utils.config_loader import get_config_value
File "/app/policyengine_household_api/utils/__init__.py", line 2, in <module>
    from .json import *
File "/app/policyengine_household_api/utils/json.py", line 3, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```

The revision still passed deployment because Cloud Run's default TCP startup probe succeeds once the gunicorn master binds the port, before the worker crashes. Hardening the writer deploy to fail loudly on boot errors (HTTP startup probe or gunicorn preload) is left as a follow-up; see #1603.

## Validation

- Recreated the writer's exact slim dependency set locally (`uv sync --frozen --no-install-project --only-group analytics-writer`): reproduced the boot crash on current `main`, and with this fix the writer imports, serves `/liveness_check` 200, and accepts a valid write event.
- `ruff format --check .` clean.
- Full unit lane: 621 passed (including the new regression test).
- Auth integration lane: 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)