### PR TITLE
Fix UK /calculate crashing on the policyengine-uk wrapper Simulation

### DIFF
--- a/changelog.d/policy-period-key-validation.changed.md
+++ b/changelog.d/policy-period-key-validation.changed.md
@@ -1,6 +1,7 @@
-`/calculate` now validates policy period keys up front: every key must be
-two dot-separated instants (`"2026-01-01.2026-12-31"`). Malformed keys
+`/calculate` now validates policy period keys explicitly: every key must
+be two dot-separated instants (`"2026-01-01.2026-12-31"`). Malformed keys
 return a descriptive 500 — the status the endpoint has always produced
 for bad policy input — instead of crashing mid-calculation (core path) or
-silently applying the change to a single day (UK wrapper path). Issue
-#1628 tracks moving this to a 400.
+silently applying the change to a single day (UK wrapper path). The check
+runs after household validation, preserving the endpoint's historical
+error precedence. Issue #1628 tracks moving this to a 400.

--- a/changelog.d/policy-period-key-validation.changed.md
+++ b/changelog.d/policy-period-key-validation.changed.md
@@ -1,0 +1,6 @@
+`/calculate` now validates policy period keys up front: every key must be
+two dot-separated instants (`"2026-01-01.2026-12-31"`). Malformed keys
+return a descriptive 500 — the status the endpoint has always produced
+for bad policy input — instead of crashing mid-calculation (core path) or
+silently applying the change to a single day (UK wrapper path). Issue
+#1628 tracks moving this to a 400.

--- a/changelog.d/reform-value-casting.fixed.md
+++ b/changelog.d/reform-value-casting.fixed.md
@@ -1,0 +1,9 @@
+Reform values in `/calculate` policy dicts are now cast explicitly to the
+parameter's type. Boolean parameters: string `"false"` previously applied
+as `True` (a Python truthiness accident) and now applies as `False`;
+accepted forms are true/false, `"true"`/`"false"`, `"1"`/`"0"`, and
+numbers, while ambiguous strings (e.g. `"2"`, `"1.0"`) and `null` — which
+previously coerced silently — now return a descriptive error. The
+parameter's type is now read from its most recent non-null value instead
+of its oldest, so parameters introduced with null placeholders no longer
+crash valid reforms.

--- a/changelog.d/reform-value-casting.fixed.md
+++ b/changelog.d/reform-value-casting.fixed.md
@@ -1,9 +1,10 @@
 Reform values in `/calculate` policy dicts are now cast explicitly to the
 parameter's type. Boolean parameters: string `"false"` previously applied
 as `True` (a Python truthiness accident) and now applies as `False`;
-accepted forms are true/false, `"true"`/`"false"`, `"1"`/`"0"`, and
-numbers, while ambiguous strings (e.g. `"2"`, `"1.0"`) and `null` — which
-previously coerced silently — now return a descriptive error. The
+accepted forms are true/false, `"true"`/`"false"`, `"1"`/`"0"`, and the
+numbers 0/1, while ambiguous strings (e.g. `"2"`, `"1.0"`), numbers other
+than 0/1, and `null` — which previously coerced silently — now return a
+descriptive error. The
 parameter's type is now read from its most recent non-null value instead
 of its oldest, so parameters introduced with null placeholders no longer
 crash valid reforms.

--- a/changelog.d/uk-calculate-wrapper-simulation.fixed.md
+++ b/changelog.d/uk-calculate-wrapper-simulation.fixed.md
@@ -1,6 +1,7 @@
 UK `/calculate` requests no longer fail with a 500. policyengine-uk 2.43+
 replaced its core `Simulation` subclass with a wrapper that builds its own
-tax-benefit system and takes reforms as a constructor argument;
-`PolicyEngineCountry.calculate` now detects which shape the country package
-exposes and constructs the simulation accordingly, including decoding the
-wrapper's string-array enum results.
+tax-benefit system and takes reforms through a `Scenario`;
+`PolicyEngineCountry` now routes UK calculations through a dedicated
+wrapper-style builder (applying reforms before construction so
+structural-trigger parameters take effect) while other countries keep the
+core path, and decodes the wrapper's string-array enum results.

--- a/changelog.d/uk-calculate-wrapper-simulation.fixed.md
+++ b/changelog.d/uk-calculate-wrapper-simulation.fixed.md
@@ -1,0 +1,6 @@
+UK `/calculate` requests no longer fail with a 500. policyengine-uk 2.43+
+replaced its core `Simulation` subclass with a wrapper that builds its own
+tax-benefit system and takes reforms as a constructor argument;
+`PolicyEngineCountry.calculate` now detects which shape the country package
+exposes and constructs the simulation accordingly, including decoding the
+wrapper's string-array enum results.

--- a/libs/household-api/policyengine_household_api/country.py
+++ b/libs/household-api/policyengine_household_api/country.py
@@ -1,5 +1,4 @@
 import importlib
-import inspect
 from flask import Response
 import json
 from policyengine_core.taxbenefitsystems import TaxBenefitSystem
@@ -471,24 +470,15 @@ class PolicyEngineCountry:
             self.country_package.CountryTaxBenefitSystem()
         )
         # policyengine-uk >= 2.43 replaced its core Simulation subclass
-        # with a wrapper that builds its own tax-benefit system and no
-        # longer accepts one from outside (its signature is scenario /
-        # situation / dataset / trace / reform). Detect which shape this
-        # package exposes so calculate() can construct the simulation the
-        # right way; checking the signature rather than the country id
-        # keeps this working when other packages make the same move.
-        # A ``**kwargs``-forwarding __init__ (policyengine-us) passes
-        # everything through to core's Simulation, which does accept
-        # ``tax_benefit_system``, so it counts as core-style.
-        simulation_params = inspect.signature(
-            self.country_package.Simulation.__init__
-        ).parameters
-        self._simulation_accepts_system = (
-            "tax_benefit_system" in simulation_params
-            or any(
-                parameter.kind is inspect.Parameter.VAR_KEYWORD
-                for parameter in simulation_params.values()
-            )
+        # with a wrapper that builds its own tax-benefit system, takes
+        # reforms as a constructor argument, and no longer accepts a
+        # system from outside. Route by country id here, once, so every
+        # UK-specific accommodation lives in the UK builder and all other
+        # countries share the standard core path.
+        self._build_simulation = (
+            self._build_simulation_uk
+            if country_id == "uk"
+            else self._build_simulation_standard
         )
         self.policyengine_bundle = self.build_policyengine_bundle()
         self.build_metadata()
@@ -795,13 +785,71 @@ class PolicyEngineCountry:
             }
         return cast
 
+    def _build_simulation_standard(
+        self,
+        normalized_household: dict,
+        reform: Union[dict, None],
+    ):
+        """Build a core-style Simulation (US, CA, NG, IL).
+
+        Reforms are applied by mutating a clone of the shared system
+        before construction, so the shared instance stays pristine for
+        concurrent requests.
+        """
+        system = self.tax_benefit_system
+        if reform:
+            system = self.tax_benefit_system.clone()
+            for parameter_name, changes in reform.items():
+                parameter = get_parameter(system.parameters, parameter_name)
+                for time_period, value in changes.items():
+                    start_instant, end_instant = time_period.split(".")
+                    parameter.update(
+                        start=instant(start_instant),
+                        stop=instant(end_instant),
+                        value=value,
+                    )
+        simulation = self.country_package.Simulation(
+            tax_benefit_system=system,
+            situation=normalized_household,
+        )
+        return system, simulation
+
+    def _build_simulation_uk(
+        self,
+        normalized_household: dict,
+        reform: Union[dict, None],
+    ):
+        """Build a policyengine-uk wrapper-style Simulation.
+
+        The wrapper constructs its own tax-benefit system internally, so
+        reforms go in through its Scenario mechanism rather than a mutated
+        clone. ``applied_before_data_load`` must be True: the wrapper
+        creates structural reforms from parameter values during
+        construction, so parameter changes applied afterwards (the
+        default for ``Simulation(reform=...)``) never activate the
+        structural reforms they gate. Note the wrapper samples those
+        trigger parameters at its ``default_input_period``, so a reform
+        must cover that instant — not just the calculation period — to
+        activate a structural reform.
+        """
+        scenario = None
+        if reform:
+            scenario = self.country_package.Scenario.from_reform(reform)
+            scenario.applied_before_data_load = True
+        simulation = self.country_package.Simulation(
+            scenario=scenario,
+            situation=normalized_household,
+        )
+        # The shared system serves variable metadata in the response
+        # loop; the wrapper's internal system is the one calculated on.
+        return self.tax_benefit_system, simulation
+
     def calculate(
         self,
         household: dict,
         reform: Union[dict, None] = None,
     ):
         reform = self._cast_reform_values(reform)
-        system = self.tax_benefit_system
 
         # Hand a normalized copy to the engine so YEAR-keyed inputs on
         # MONTH-defined variables behave like the hosted v1 API instead of
@@ -809,35 +857,14 @@ class PolicyEngineCountry:
         # internally so the original `household` is intact and the response
         # can echo back the partner's keys. It reads only variable
         # metadata, which a parametric reform never changes, so the shared
-        # system serves both paths here.
-        normalized_household = _normalize_period_keys(household, system)
+        # system serves both builders here.
+        normalized_household = _normalize_period_keys(
+            household, self.tax_benefit_system
+        )
 
-        if self._simulation_accepts_system:
-            if reform:
-                system = self.tax_benefit_system.clone()
-                for parameter_name, changes in reform.items():
-                    parameter = get_parameter(
-                        system.parameters, parameter_name
-                    )
-                    for time_period, value in changes.items():
-                        start_instant, end_instant = time_period.split(".")
-                        parameter.update(
-                            start=instant(start_instant),
-                            stop=instant(end_instant),
-                            value=value,
-                        )
-            simulation = self.country_package.Simulation(
-                tax_benefit_system=system,
-                situation=normalized_household,
-            )
-        else:
-            # The wrapper-style Simulation applies parametric reforms
-            # itself (via Scenario.from_reform) to its own internal
-            # system; the shared instance stays unmodified.
-            simulation = self.country_package.Simulation(
-                situation=normalized_household,
-                reform=reform,
-            )
+        system, simulation = self._build_simulation(
+            normalized_household, reform
+        )
 
         # Independent clone for the response-building loop below, which
         # mutates `household` to fill in computed values. Not related to

--- a/libs/household-api/policyengine_household_api/country.py
+++ b/libs/household-api/policyengine_household_api/country.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 from flask import Response
 import json
 from policyengine_core.taxbenefitsystems import TaxBenefitSystem
@@ -469,6 +470,19 @@ class PolicyEngineCountry:
         self.tax_benefit_system: TaxBenefitSystem = (
             self.country_package.CountryTaxBenefitSystem()
         )
+        # policyengine-uk >= 2.43 replaced its core Simulation subclass
+        # with a wrapper that builds its own tax-benefit system and no
+        # longer accepts one from outside (its signature is scenario /
+        # situation / dataset / trace / reform). Detect which shape this
+        # package exposes so calculate() can construct the simulation the
+        # right way; checking the signature rather than the country id
+        # keeps this working when other packages make the same move.
+        self._simulation_accepts_system = (
+            "tax_benefit_system"
+            in inspect.signature(
+                self.country_package.Simulation.__init__
+            ).parameters
+        )
         self.policyengine_bundle = self.build_policyengine_bundle()
         self.build_metadata()
 
@@ -732,32 +746,73 @@ class PolicyEngineCountry:
             data[entity.key] = entity_data
         return data
 
+    @staticmethod
+    def _cast_reform_value(parameter, value):
+        """Cast a reform value to the parameter's node type.
+
+        JSON payloads may carry numbers as strings and integers where the
+        parameter is a float; both casts predate the wrapper-simulation
+        path and stay identical across it.
+        """
+        node_type = type(parameter.values_list[-1].value)
+        if node_type is int:
+            node_type = float
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            pass
+        return node_type(value)
+
+    def _reform_dict_for_wrapper(
+        self, reform: Union[dict, None]
+    ) -> Union[dict, None]:
+        """Prepare a policy dict for a wrapper-style Simulation's `reform`.
+
+        The wrapper applies dict values raw (Scenario.from_reform does no
+        casting), so cast each value here the same way the injected-system
+        path does. Parameter paths are resolved against the shared system
+        purely to learn the node type; nothing is mutated.
+        """
+        if reform is None or len(reform) == 0:
+            return None
+
+        normalized: dict = {}
+        for parameter_name, changes in reform.items():
+            parameter = get_parameter(
+                self.tax_benefit_system.parameters, parameter_name
+            )
+            normalized[parameter_name] = {
+                time_period: self._cast_reform_value(parameter, value)
+                for time_period, value in changes.items()
+            }
+        return normalized
+
     def calculate(
         self,
         household: dict,
         reform: Union[dict, None] = None,
     ):
-        if reform is not None and len(reform.keys()) > 0:
-            system = self.tax_benefit_system.clone()
-            for parameter_name in reform:
-                for time_period, value in reform[parameter_name].items():
-                    start_instant, end_instant = time_period.split(".")
-                    parameter = get_parameter(
-                        system.parameters, parameter_name
-                    )
-                    node_type = type(parameter.values_list[-1].value)
-                    if node_type is int:
-                        node_type = float
-                    try:
-                        value = float(value)
-                    except (TypeError, ValueError):
-                        pass
-                    parameter.update(
-                        start=instant(start_instant),
-                        stop=instant(end_instant),
-                        value=node_type(value),
-                    )
+        if self._simulation_accepts_system:
+            if reform is not None and len(reform.keys()) > 0:
+                system = self.tax_benefit_system.clone()
+                for parameter_name in reform:
+                    for time_period, value in reform[parameter_name].items():
+                        start_instant, end_instant = time_period.split(".")
+                        parameter = get_parameter(
+                            system.parameters, parameter_name
+                        )
+                        parameter.update(
+                            start=instant(start_instant),
+                            stop=instant(end_instant),
+                            value=self._cast_reform_value(parameter, value),
+                        )
+            else:
+                system = self.tax_benefit_system
         else:
+            # The wrapper-style Simulation applies parametric reforms
+            # itself (via Scenario.from_reform), so the shared system
+            # instance is only used for variable metadata below and must
+            # stay unmodified.
             system = self.tax_benefit_system
 
         # Hand a normalized copy to the engine so YEAR-keyed inputs on
@@ -767,10 +822,16 @@ class PolicyEngineCountry:
         # can echo back the partner's keys.
         normalized_household = _normalize_period_keys(household, system)
 
-        simulation = self.country_package.Simulation(
-            tax_benefit_system=system,
-            situation=normalized_household,
-        )
+        if self._simulation_accepts_system:
+            simulation = self.country_package.Simulation(
+                tax_benefit_system=system,
+                situation=normalized_household,
+            )
+        else:
+            simulation = self.country_package.Simulation(
+                situation=normalized_household,
+                reform=self._reform_dict_for_wrapper(reform),
+            )
 
         # Independent clone for the response-building loop below, which
         # mutates `household` to fill in computed values. Not related to
@@ -812,7 +873,13 @@ class PolicyEngineCountry:
                 else:
                     entity_index = population.get_index(entity_id)
                     if variable.value_type == Enum:
-                        entity_result = result.decode()[entity_index].name
+                        # Wrapper-style Simulations decode enum results to
+                        # plain string arrays before returning; core-style
+                        # ones return an EnumArray.
+                        if hasattr(result, "decode"):
+                            entity_result = result.decode()[entity_index].name
+                        else:
+                            entity_result = str(result[entity_index])
                     elif variable.value_type is float:
                         entity_result = float(str(result[entity_index]))
                         # Convert infinities to JSON infinities

--- a/libs/household-api/policyengine_household_api/country.py
+++ b/libs/household-api/policyengine_household_api/country.py
@@ -13,7 +13,7 @@ from policyengine_core.parameters import (
     ParameterScaleBracket,
 )
 from policyengine_core.parameters import get_parameter
-from policyengine_core.model_api import Reform, Enum
+from policyengine_core.model_api import Enum
 from policyengine_core.periods import instant, period as parse_period
 import copy
 import dpath
@@ -477,11 +477,18 @@ class PolicyEngineCountry:
         # package exposes so calculate() can construct the simulation the
         # right way; checking the signature rather than the country id
         # keeps this working when other packages make the same move.
+        # A ``**kwargs``-forwarding __init__ (policyengine-us) passes
+        # everything through to core's Simulation, which does accept
+        # ``tax_benefit_system``, so it counts as core-style.
+        simulation_params = inspect.signature(
+            self.country_package.Simulation.__init__
+        ).parameters
         self._simulation_accepts_system = (
-            "tax_benefit_system"
-            in inspect.signature(
-                self.country_package.Simulation.__init__
-            ).parameters
+            "tax_benefit_system" in simulation_params
+            or any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in simulation_params.values()
+            )
         )
         self.policyengine_bundle = self.build_policyengine_bundle()
         self.build_metadata()
@@ -751,8 +758,7 @@ class PolicyEngineCountry:
         """Cast a reform value to the parameter's node type.
 
         JSON payloads may carry numbers as strings and integers where the
-        parameter is a float; both casts predate the wrapper-simulation
-        path and stay identical across it.
+        parameter is a float.
         """
         node_type = type(parameter.values_list[-1].value)
         if node_type is int:
@@ -763,74 +769,74 @@ class PolicyEngineCountry:
             pass
         return node_type(value)
 
-    def _reform_dict_for_wrapper(
+    def _cast_reform_values(
         self, reform: Union[dict, None]
     ) -> Union[dict, None]:
-        """Prepare a policy dict for a wrapper-style Simulation's `reform`.
+        """Resolve and cast every value in a policy dict.
 
-        The wrapper applies dict values raw (Scenario.from_reform does no
-        casting), so cast each value here the same way the injected-system
-        path does. Parameter paths are resolved against the shared system
-        purely to learn the node type; nothing is mutated.
+        Both simulation paths consume the result: the injected-system
+        path applies it to a cloned system, and the wrapper path hands
+        it to the Simulation's `reform` argument (Scenario.from_reform
+        does no casting of its own). Parameter paths are resolved against
+        the shared system purely to learn each node type; nothing is
+        mutated.
         """
-        if reform is None or len(reform) == 0:
+        if not reform:
             return None
 
-        normalized: dict = {}
+        cast: dict = {}
         for parameter_name, changes in reform.items():
             parameter = get_parameter(
                 self.tax_benefit_system.parameters, parameter_name
             )
-            normalized[parameter_name] = {
+            cast[parameter_name] = {
                 time_period: self._cast_reform_value(parameter, value)
                 for time_period, value in changes.items()
             }
-        return normalized
+        return cast
 
     def calculate(
         self,
         household: dict,
         reform: Union[dict, None] = None,
     ):
-        if self._simulation_accepts_system:
-            if reform is not None and len(reform.keys()) > 0:
-                system = self.tax_benefit_system.clone()
-                for parameter_name in reform:
-                    for time_period, value in reform[parameter_name].items():
-                        start_instant, end_instant = time_period.split(".")
-                        parameter = get_parameter(
-                            system.parameters, parameter_name
-                        )
-                        parameter.update(
-                            start=instant(start_instant),
-                            stop=instant(end_instant),
-                            value=self._cast_reform_value(parameter, value),
-                        )
-            else:
-                system = self.tax_benefit_system
-        else:
-            # The wrapper-style Simulation applies parametric reforms
-            # itself (via Scenario.from_reform), so the shared system
-            # instance is only used for variable metadata below and must
-            # stay unmodified.
-            system = self.tax_benefit_system
+        reform = self._cast_reform_values(reform)
+        system = self.tax_benefit_system
 
         # Hand a normalized copy to the engine so YEAR-keyed inputs on
         # MONTH-defined variables behave like the hosted v1 API instead of
         # being silently dropped (issue #1489). The normalizer deep-copies
         # internally so the original `household` is intact and the response
-        # can echo back the partner's keys.
+        # can echo back the partner's keys. It reads only variable
+        # metadata, which a parametric reform never changes, so the shared
+        # system serves both paths here.
         normalized_household = _normalize_period_keys(household, system)
 
         if self._simulation_accepts_system:
+            if reform:
+                system = self.tax_benefit_system.clone()
+                for parameter_name, changes in reform.items():
+                    parameter = get_parameter(
+                        system.parameters, parameter_name
+                    )
+                    for time_period, value in changes.items():
+                        start_instant, end_instant = time_period.split(".")
+                        parameter.update(
+                            start=instant(start_instant),
+                            stop=instant(end_instant),
+                            value=value,
+                        )
             simulation = self.country_package.Simulation(
                 tax_benefit_system=system,
                 situation=normalized_household,
             )
         else:
+            # The wrapper-style Simulation applies parametric reforms
+            # itself (via Scenario.from_reform) to its own internal
+            # system; the shared instance stays unmodified.
             simulation = self.country_package.Simulation(
                 situation=normalized_household,
-                reform=self._reform_dict_for_wrapper(reform),
+                reform=reform,
             )
 
         # Independent clone for the response-building loop below, which
@@ -907,47 +913,6 @@ class PolicyEngineCountry:
                     )
 
         return household
-
-
-def create_policy_reform(policy_data: dict) -> dict:
-    """
-    Create a policy reform.
-
-    Args:
-        policy_data (dict): The policy data.
-
-    Returns:
-        dict: The reform.
-    """
-
-    def modify_parameters(parameters: ParameterNode) -> ParameterNode:
-        for path, values in policy_data.items():
-            node = parameters
-            for step in path.split("."):
-                if "[" in step:
-                    step, index = step.split("[")
-                    index = int(index[:-1])
-                    node = node.children[step].brackets[index]
-                else:
-                    node = node.children[step]
-            for period, value in values.items():
-                start, end = period.split(".")
-                node_type = type(node.values_list[-1].value)
-                if node_type is int:
-                    node_type = float  # '0' is of type int by default, but usually we want to cast to float.
-                node.update(
-                    start=instant(start),
-                    stop=instant(end),
-                    value=node_type(value),
-                )
-
-        return parameters
-
-    class reform(Reform):
-        def apply(self):
-            self.modify_parameters(modify_parameters)
-
-    return reform
 
 
 def get_requested_computations(household: dict):

--- a/libs/household-api/policyengine_household_api/country.py
+++ b/libs/household-api/policyengine_household_api/country.py
@@ -461,6 +461,52 @@ def _broadcast_year_value(period_map: dict, year: str, value) -> None:
             period_map[month_key] = value
 
 
+def validate_policy_periods(policy_json: Union[dict, None]) -> None:
+    """Reject policy period keys that aren't ``start.stop`` instant pairs.
+
+    Every period key in a policy dict must be two dot-separated instants
+    (``"2026-01-01.2026-12-31"``), the grammar the core simulation path
+    has always enforced. Without this check, looser grammars reach the
+    engine and either crash mid-calculation or — on the UK path, whose
+    Scenario mechanism accepts bare instants — silently apply the change
+    to a single day, returning near-baseline numbers with a 200.
+
+    This lives here, next to the code that consumes the grammar, and runs
+    on every ``calculate()`` regardless of caller; the calculate endpoint
+    also calls it up front for a cleaner error message. Raises
+    ``ValueError`` with a user-safe message on failure.
+    """
+    if policy_json is None:
+        return
+    if not isinstance(policy_json, dict):
+        raise ValueError("'policy' must be a JSON object")
+
+    for parameter_name, changes in policy_json.items():
+        if not isinstance(changes, dict):
+            raise ValueError(
+                f"'policy.{parameter_name}' must be a JSON object keyed "
+                'by "start.stop" period strings'
+            )
+        for time_period in changes:
+            parts = str(time_period).split(".")
+            if len(parts) != 2 or not all(
+                _is_valid_instant(part) for part in parts
+            ):
+                raise ValueError(
+                    f"Invalid policy period key `{time_period}` for "
+                    f"`{parameter_name}`. Expected two dot-separated "
+                    'instants, e.g. "2026-01-01.2026-12-31".'
+                )
+
+
+def _is_valid_instant(candidate: str) -> bool:
+    try:
+        instant(candidate)
+    except ValueError:
+        return False
+    return True
+
+
 def _cast_bool(value) -> bool:
     """Interpret a JSON-borne reform value as a boolean.
 
@@ -803,17 +849,23 @@ class PolicyEngineCountry:
     def _cast_reform_values(
         self, reform: Union[dict, None]
     ) -> Union[dict, None]:
-        """Resolve and cast every value in a policy dict.
+        """Validate a policy dict's period keys and cast every value.
 
-        Both simulation paths consume the result: the injected-system
-        path applies it to a cloned system, and the wrapper path hands
-        it to the Simulation's `reform` argument (Scenario.from_reform
-        does no casting of its own). Parameter paths are resolved against
-        the shared system purely to learn each node type; nothing is
-        mutated.
+        Both simulation builders consume the result: the standard builder
+        applies it to a cloned system, and the UK builder routes it
+        through a Scenario (which does no casting of its own). Parameter
+        paths are resolved against the shared system purely to learn each
+        node type; nothing is mutated.
+
+        Raises ``ValueError`` for malformed period keys or uncastable
+        values; through the calculate endpoint that surfaces as a 500,
+        the status this API has always used for bad policy input
+        (issue #1628 tracks moving it to 400).
         """
         if not reform:
             return None
+
+        validate_policy_periods(reform)
 
         cast: dict = {}
         for parameter_name, changes in reform.items():

--- a/libs/household-api/policyengine_household_api/country.py
+++ b/libs/household-api/policyengine_household_api/country.py
@@ -461,6 +461,28 @@ def _broadcast_year_value(period_map: dict, year: str, value) -> None:
             period_map[month_key] = value
 
 
+def _cast_bool(value) -> bool:
+    """Interpret a JSON-borne reform value as a boolean.
+
+    ``bool("false")`` is True in Python, so string forms need an explicit
+    mapping rather than a bare cast.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "1"):
+            return True
+        if lowered in ("false", "0"):
+            return False
+    raise ValueError(
+        f"Cannot interpret {value!r} as a boolean parameter value; "
+        'use true/false (or "true"/"false").'
+    )
+
+
 class PolicyEngineCountry:
     def __init__(self, country_package_name: str, country_id: str):
         self.country_package_name = country_package_name
@@ -471,15 +493,18 @@ class PolicyEngineCountry:
         )
         # policyengine-uk >= 2.43 replaced its core Simulation subclass
         # with a wrapper that builds its own tax-benefit system, takes
-        # reforms as a constructor argument, and no longer accepts a
-        # system from outside. Route by country id here, once, so every
-        # UK-specific accommodation lives in the UK builder and all other
-        # countries share the standard core path.
-        self._build_simulation = (
-            self._build_simulation_uk
-            if country_id == "uk"
-            else self._build_simulation_standard
-        )
+        # reforms as a constructor argument, and decodes enum results to
+        # plain string arrays. Route by country id here, once, so every
+        # UK-specific accommodation lives in a UK strategy function and
+        # all other countries share the standard core path.
+        if country_id == "uk":
+            self._build_simulation = self._build_simulation_uk
+            self._axes_result_values = self._axes_result_values_uk
+            self._enum_result_name = self._enum_result_name_uk
+        else:
+            self._build_simulation = self._build_simulation_standard
+            self._axes_result_values = self._axes_result_values_standard
+            self._enum_result_name = self._enum_result_name_standard
         self.policyengine_bundle = self.build_policyengine_bundle()
         self.build_metadata()
 
@@ -745,18 +770,34 @@ class PolicyEngineCountry:
 
     @staticmethod
     def _cast_reform_value(parameter, value):
-        """Cast a reform value to the parameter's node type.
+        """Cast a reform value to the parameter's value type.
 
-        JSON payloads may carry numbers as strings and integers where the
-        parameter is a float.
+        JSON payloads carry numbers as strings and integers where the
+        parameter is a float; core's parameter interpolation needs the
+        stored type to be consistent, so coerce explicitly per type. The
+        reference type comes from the parameter's most recent non-null
+        value (``values_list`` is ordered newest-first; null placeholders
+        carry no type information).
+
+        Raises ``ValueError`` when the value cannot be interpreted as the
+        parameter's type.
         """
-        node_type = type(parameter.values_list[-1].value)
-        if node_type is int:
-            node_type = float
-        try:
-            value = float(value)
-        except (TypeError, ValueError):
-            pass
+        node_type = next(
+            (
+                type(known.value)
+                for known in parameter.values_list
+                if known.value is not None
+            ),
+            float,
+        )
+        if node_type is bool:
+            return _cast_bool(value)
+        if node_type in (int, float):
+            # Ints are stored as floats: reform values may be fractional
+            # and interpolation expects one numeric type.
+            return float(value)
+        # Core restricts parameter values to float/int/bool/None/list;
+        # lists (and any future type) coerce through their constructor.
         return node_type(value)
 
     def _cast_reform_values(
@@ -844,6 +885,52 @@ class PolicyEngineCountry:
         # loop; the wrapper's internal system is the one calculated on.
         return self.tax_benefit_system, simulation
 
+    def _axes_result_values_standard(
+        self, result, count_entities: int, entity_index: int, variable
+    ) -> list:
+        """Reshape an axes-scan result into this entity's value list.
+
+        Core-style results cast cleanly to float — including EnumArray,
+        which yields the enum's numeric indices (documented behavior the
+        US API has always exposed).
+        """
+        values = (
+            result.astype(float)
+            .reshape((-1, count_entities))
+            .T[entity_index]
+            .tolist()
+        )
+        if any(math.isinf(value) for value in values):
+            raise ValueError("Infinite value")
+        return values
+
+    def _axes_result_values_uk(
+        self, result, count_entities: int, entity_index: int, variable
+    ) -> list:
+        """UK axes results: enums arrive as decoded string arrays.
+
+        The wrapper Simulation decodes enum results before returning, so
+        the standard float cast would raise and the axes error handler
+        would silently null the slot; return the names instead.
+        """
+        if variable.value_type == Enum:
+            return (
+                result.reshape((-1, count_entities)).T[entity_index].tolist()
+            )
+        return self._axes_result_values_standard(
+            result, count_entities, entity_index, variable
+        )
+
+    @staticmethod
+    def _enum_result_name_standard(result, entity_index: int) -> str:
+        return result.decode()[entity_index].name
+
+    @staticmethod
+    def _enum_result_name_uk(result, entity_index: int) -> str:
+        # The wrapper's calculate() has already decoded enum results to
+        # plain string arrays.
+        return str(result[entity_index])
+
     def calculate(
         self,
         household: dict,
@@ -890,29 +977,17 @@ class PolicyEngineCountry:
                         if _entity_id == entity_id:
                             break
                         entity_index += 1
-                    result = (
-                        result.astype(float)
-                        .reshape((-1, count_entities))
-                        .T[entity_index]
-                        .tolist()
+                    household[entity_plural][entity_id][variable_name][
+                        period
+                    ] = self._axes_result_values(
+                        result, count_entities, entity_index, variable
                     )
-                    # If the result contains infinities, throw an error
-                    if any([math.isinf(value) for value in result]):
-                        raise ValueError("Infinite value")
-                    else:
-                        household[entity_plural][entity_id][variable_name][
-                            period
-                        ] = result
                 else:
                     entity_index = population.get_index(entity_id)
                     if variable.value_type == Enum:
-                        # Wrapper-style Simulations decode enum results to
-                        # plain string arrays before returning; core-style
-                        # ones return an EnumArray.
-                        if hasattr(result, "decode"):
-                            entity_result = result.decode()[entity_index].name
-                        else:
-                            entity_result = str(result[entity_index])
+                        entity_result = self._enum_result_name(
+                            result, entity_index
+                        )
                     elif variable.value_type is float:
                         entity_result = float(str(result[entity_index]))
                         # Convert infinities to JSON infinities

--- a/libs/household-api/policyengine_household_api/country.py
+++ b/libs/household-api/policyengine_household_api/country.py
@@ -473,8 +473,9 @@ def validate_policy_periods(policy_json: Union[dict, None]) -> None:
 
     This lives here, next to the code that consumes the grammar, and runs
     on every ``calculate()`` regardless of caller; the calculate endpoint
-    also calls it up front for a cleaner error message. Raises
-    ``ValueError`` with a user-safe message on failure.
+    also calls it directly — after all household validation, matching the
+    endpoint's historical error precedence — so clients get the message
+    unwrapped. Raises ``ValueError`` with a user-safe message on failure.
     """
     if policy_json is None:
         return
@@ -510,12 +511,13 @@ def _is_valid_instant(candidate: str) -> bool:
 def _cast_bool(value) -> bool:
     """Interpret a JSON-borne reform value as a boolean.
 
-    ``bool("false")`` is True in Python, so string forms need an explicit
-    mapping rather than a bare cast.
+    ``bool("false")`` is True in Python and ``bool(2)`` hides client
+    mistakes, so only unambiguous forms are accepted: booleans, the
+    numbers 0 and 1, and the strings "true"/"false"/"1"/"0".
     """
     if isinstance(value, bool):
         return value
-    if isinstance(value, (int, float)):
+    if isinstance(value, (int, float)) and value in (0, 1):
         return bool(value)
     if isinstance(value, str):
         lowered = value.strip().lower()

--- a/libs/household-api/policyengine_household_api/endpoints/household.py
+++ b/libs/household-api/policyengine_household_api/endpoints/household.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from flask import Response, request
+from policyengine_core.periods import instant
 from policyengine_observability import record_error
 from policyengine_observability import segment
 from policyengine_observability import set_attribute
@@ -61,6 +62,49 @@ def _validate_household_payload(country_id: str, household_json: dict) -> None:
         schema_cls.model_validate(household_for_schema)
     except ValidationError as e:
         raise ValueError(f"Invalid household payload: {e}")
+
+
+def _validate_policy_periods(policy_json: dict) -> None:
+    """Reject policy period keys that aren't ``start.stop`` instant pairs.
+
+    Every period key in a policy dict must be two dot-separated instants
+    (``"2026-01-01.2026-12-31"``), the grammar the core simulation path
+    has always enforced. Without this check, looser grammars reach the
+    engine and either crash mid-calculation or — on the UK path, whose
+    Scenario mechanism accepts bare instants — silently apply the change
+    to a single day, returning near-baseline numbers with a 200.
+
+    Raises ``ValueError`` with a user-safe message on failure.
+    """
+    if policy_json is None:
+        return
+    if not isinstance(policy_json, dict):
+        raise ValueError("'policy' must be a JSON object")
+
+    for parameter_name, changes in policy_json.items():
+        if not isinstance(changes, dict):
+            raise ValueError(
+                f"'policy.{parameter_name}' must be a JSON object keyed "
+                'by "start.stop" period strings'
+            )
+        for time_period in changes:
+            parts = str(time_period).split(".")
+            if len(parts) != 2 or not all(
+                _is_valid_instant(part) for part in parts
+            ):
+                raise ValueError(
+                    f"Invalid policy period key `{time_period}` for "
+                    f"`{parameter_name}`. Expected two dot-separated "
+                    'instants, e.g. "2026-01-01.2026-12-31".'
+                )
+
+
+def _is_valid_instant(candidate: str) -> bool:
+    try:
+        instant(candidate)
+    except ValueError:
+        return False
+    return True
 
 
 def _validate_axes(household_json: dict) -> None:
@@ -156,6 +200,20 @@ def get_calculate(country_id: str, add_missing: bool = False) -> Response:
         return _json_response(
             {"status": "error", "message": str(e)},
             status=400,
+        )
+
+    # A malformed policy is a client error and should be a 400, but the
+    # endpoint has always surfaced bad policy input as a 500 (it used to
+    # crash in the engine), so we keep that status for compatibility.
+    # Issue #1628 tracks moving this to 400 and documenting the grammar.
+    try:
+        with segment(SegmentName.PAYLOAD_VALIDATION):
+            _validate_policy_periods(policy_json)
+    except ValueError as e:
+        record_error(e, handled=True, status_code=500, include_stack=False)
+        return _json_response(
+            {"status": "error", "message": str(e)},
+            status=500,
         )
 
     with segment(SegmentName.VARIABLE_VALIDATION):

--- a/libs/household-api/policyengine_household_api/endpoints/household.py
+++ b/libs/household-api/policyengine_household_api/endpoints/household.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from flask import Response, request
-from policyengine_core.periods import instant
 from policyengine_observability import record_error
 from policyengine_observability import segment
 from policyengine_observability import set_attribute
@@ -11,6 +10,7 @@ from policyengine_household_api.country import (
     detect_period_warnings,
     validate_period_budgets,
     validate_period_keys,
+    validate_policy_periods,
 )
 from policyengine_household_common.models.household import (
     HouseholdModelGeneric,
@@ -62,49 +62,6 @@ def _validate_household_payload(country_id: str, household_json: dict) -> None:
         schema_cls.model_validate(household_for_schema)
     except ValidationError as e:
         raise ValueError(f"Invalid household payload: {e}")
-
-
-def _validate_policy_periods(policy_json: dict) -> None:
-    """Reject policy period keys that aren't ``start.stop`` instant pairs.
-
-    Every period key in a policy dict must be two dot-separated instants
-    (``"2026-01-01.2026-12-31"``), the grammar the core simulation path
-    has always enforced. Without this check, looser grammars reach the
-    engine and either crash mid-calculation or — on the UK path, whose
-    Scenario mechanism accepts bare instants — silently apply the change
-    to a single day, returning near-baseline numbers with a 200.
-
-    Raises ``ValueError`` with a user-safe message on failure.
-    """
-    if policy_json is None:
-        return
-    if not isinstance(policy_json, dict):
-        raise ValueError("'policy' must be a JSON object")
-
-    for parameter_name, changes in policy_json.items():
-        if not isinstance(changes, dict):
-            raise ValueError(
-                f"'policy.{parameter_name}' must be a JSON object keyed "
-                'by "start.stop" period strings'
-            )
-        for time_period in changes:
-            parts = str(time_period).split(".")
-            if len(parts) != 2 or not all(
-                _is_valid_instant(part) for part in parts
-            ):
-                raise ValueError(
-                    f"Invalid policy period key `{time_period}` for "
-                    f"`{parameter_name}`. Expected two dot-separated "
-                    'instants, e.g. "2026-01-01.2026-12-31".'
-                )
-
-
-def _is_valid_instant(candidate: str) -> bool:
-    try:
-        instant(candidate)
-    except ValueError:
-        return False
-    return True
 
 
 def _validate_axes(household_json: dict) -> None:
@@ -202,20 +159,6 @@ def get_calculate(country_id: str, add_missing: bool = False) -> Response:
             status=400,
         )
 
-    # A malformed policy is a client error and should be a 400, but the
-    # endpoint has always surfaced bad policy input as a 500 (it used to
-    # crash in the engine), so we keep that status for compatibility.
-    # Issue #1628 tracks moving this to 400 and documenting the grammar.
-    try:
-        with segment(SegmentName.PAYLOAD_VALIDATION):
-            _validate_policy_periods(policy_json)
-    except ValueError as e:
-        record_error(e, handled=True, status_code=500, include_stack=False)
-        return _json_response(
-            {"status": "error", "message": str(e)},
-            status=500,
-        )
-
     with segment(SegmentName.VARIABLE_VALIDATION):
         variable_errors = validate_household_variables(
             household=household_json,
@@ -275,6 +218,25 @@ def get_calculate(country_id: str, add_missing: bool = False) -> Response:
             country.tax_benefit_system,
         )
     set_attribute("period_warning_count", len(period_warnings))
+
+    # A malformed policy is a client error and should be a 400, but the
+    # endpoint has always surfaced bad policy input as a 500 (it used to
+    # crash in the engine), so we keep that status for compatibility —
+    # and check it last, after all household validation, matching the
+    # error precedence clients saw when the crash happened inside
+    # calculate. Issue #1628 tracks moving this to 400 and documenting
+    # the grammar. calculate() itself re-validates via
+    # _cast_reform_values, so callers that bypass this endpoint get the
+    # same guard.
+    try:
+        with segment(SegmentName.PAYLOAD_VALIDATION):
+            validate_policy_periods(policy_json)
+    except ValueError as e:
+        record_error(e, handled=True, status_code=500, include_stack=False)
+        return _json_response(
+            {"status": "error", "message": str(e)},
+            status=500,
+        )
 
     try:
         result: dict

--- a/libs/household-api/policyengine_household_api/openapi_spec.yaml
+++ b/libs/household-api/policyengine_household_api/openapi_spec.yaml
@@ -1158,9 +1158,9 @@ components:
             {"2026-01-01.2026-12-31": 15000}}. Each period key must be two
             dot-separated instants (start.stop). Values are cast to the
             parameter's type; boolean parameters accept true/false,
-            "true"/"false", "1"/"0", or numbers. Malformed period keys or
-            values return a 500 with a descriptive message (moving to 400
-            is tracked in issue #1628).
+            "true"/"false", "1"/"0", or the numbers 0/1. Malformed period
+            keys or values return a 500 with a descriptive message
+            (moving to 400 is tracked in issue #1628).
           additionalProperties: true
         version:
           type: string

--- a/libs/household-api/policyengine_household_api/openapi_spec.yaml
+++ b/libs/household-api/policyengine_household_api/openapi_spec.yaml
@@ -1159,8 +1159,7 @@ components:
             dot-separated instants (start.stop). Values are cast to the
             parameter's type; boolean parameters accept true/false,
             "true"/"false", "1"/"0", or the numbers 0/1. Malformed period
-            keys or values return a 500 with a descriptive message
-            (moving to 400 is tracked in issue #1628).
+            keys or values return a 500 with a descriptive message.
           additionalProperties: true
         version:
           type: string

--- a/libs/household-api/policyengine_household_api/openapi_spec.yaml
+++ b/libs/household-api/policyengine_household_api/openapi_spec.yaml
@@ -1151,7 +1151,16 @@ components:
           $ref: "#/components/schemas/Household"
         policy:
           type: object
-          description: Optional policy reform object passed through to the country model.
+          description: >-
+            Optional policy reform object mapping parameter paths to
+            period-keyed values, e.g.
+            {"gov.hmrc.income_tax.allowances.personal_allowance.amount":
+            {"2026-01-01.2026-12-31": 15000}}. Each period key must be two
+            dot-separated instants (start.stop). Values are cast to the
+            parameter's type; boolean parameters accept true/false,
+            "true"/"false", "1"/"0", or numbers. Malformed period keys or
+            values return a 500 with a descriptive message (moving to 400
+            is tracked in issue #1628).
           additionalProperties: true
         version:
           type: string

--- a/tests/data/uk_households.py
+++ b/tests/data/uk_households.py
@@ -31,6 +31,25 @@ uk_household_requesting_universal_credit = {
     },
 }
 
+# Minimal case whose expected value is derivable by hand: a single
+# unemployed adult aged 25+ with no housing costs receives only the
+# Universal Credit standard allowance — no elements, no taper.
+uk_household_single_adult_no_income = {
+    "people": {
+        "adult": {
+            "age": {"2026": 30},
+            "employment_income": {"2026": 0},
+        }
+    },
+    "benunits": {
+        "benunit": {
+            "members": ["adult"],
+            "universal_credit": {"2026": None},
+        }
+    },
+    "households": {"household": {"members": ["adult"]}},
+}
+
 uk_household_requesting_enum_outputs = {
     "people": {"parent": {"age": {"2026": 30}}},
     "benunits": {"benunit": {"members": ["parent"]}},

--- a/tests/data/uk_households.py
+++ b/tests/data/uk_households.py
@@ -1,0 +1,87 @@
+"""UK household payloads shared by the unit and deployed test lanes.
+
+UK calculations broke silently when policyengine-uk 2.43 changed its
+Simulation constructor because no test lane sent a UK household through
+/calculate; these payloads exist so both lanes keep that path covered.
+"""
+
+uk_household_requesting_universal_credit = {
+    "people": {
+        "parent": {
+            "age": {"2026": 30},
+            "employment_income": {"2026": 15_000},
+        },
+        "child": {
+            "age": {"2026": 5},
+        },
+    },
+    "benunits": {
+        "benunit": {
+            "members": ["parent", "child"],
+            "universal_credit": {"2026": None},
+        }
+    },
+    "households": {
+        "household": {
+            "members": ["parent", "child"],
+            "region": {"2026": "LONDON"},
+            "tenure_type": {"2026": "RENT_PRIVATELY"},
+            "rent": {"2026": 15_600},
+        }
+    },
+}
+
+uk_household_requesting_enum_outputs = {
+    "people": {"parent": {"age": {"2026": 30}}},
+    "benunits": {"benunit": {"members": ["parent"]}},
+    "households": {
+        "household": {
+            "members": ["parent"],
+            "region": {"2026": "LONDON"},
+            "country": {"2026": None},
+        }
+    },
+}
+
+uk_household_requesting_income_tax = {
+    "people": {
+        "parent": {
+            "age": {"2026": 30},
+            "employment_income": {"2026": 15_000},
+            "income_tax": {"2026": None},
+        }
+    },
+    "benunits": {"benunit": {"members": ["parent"]}},
+    "households": {"household": {"members": ["parent"]}},
+}
+
+# The value is a string on purpose: the API casts reform values to the
+# parameter's node type, and that contract must hold on the wrapper
+# simulation path too.
+uk_personal_allowance_reform = {
+    "gov.hmrc.income_tax.allowances.personal_allowance.amount": {
+        "2026-01-01.2026-12-31": "15000",
+    }
+}
+
+uk_household_with_axes = {
+    "people": {"parent": {"age": {"2026": 30}}},
+    "benunits": {
+        "benunit": {
+            "members": ["parent"],
+            "universal_credit": {"2026": None},
+        }
+    },
+    "households": {"household": {"members": ["parent"]}},
+    "axes": [
+        [
+            {
+                "name": "employment_income",
+                "count": 3,
+                "min": 0,
+                "max": 30_000,
+                "period": "2026",
+            }
+        ]
+    ],
+}

--- a/tests/data/uk_households.py
+++ b/tests/data/uk_households.py
@@ -83,6 +83,41 @@ uk_personal_allowance_reform = {
     }
 }
 
+# A high earner fails the marriage allowance income condition under
+# current law; only the structural reform gated by the parameter below
+# removes that condition. Distinguishes "parameter changed" from
+# "structural reform actually applied".
+uk_household_married_requesting_marriage_allowance = {
+    "people": {
+        "earner": {
+            "age": {"2026": 40},
+            "employment_income": {"2026": 80_000},
+            "marriage_allowance": {"2026": None},
+        },
+        "partner": {
+            "age": {"2026": 40},
+            "employment_income": {"2026": 0},
+        },
+    },
+    "benunits": {
+        "benunit": {
+            "members": ["earner", "partner"],
+            "is_married": {"2026": True},
+        }
+    },
+    "households": {"household": {"members": ["earner", "partner"]}},
+}
+
+# The period must cover the wrapper's default input period (2025 as of
+# policyengine-uk 2.88): structural-trigger parameters are sampled at
+# that instant during Simulation construction, not at the calculation
+# period.
+uk_marriage_allowance_structural_reform = {
+    "gov.contrib.cps.marriage_tax_reforms.expanded_ma.remove_income_condition": {
+        "2025-01-01.2030-12-31": True,
+    }
+}
+
 uk_household_with_axes = {
     "people": {"parent": {"age": {"2026": 30}}},
     "benunits": {

--- a/tests/data/uk_households.py
+++ b/tests/data/uk_households.py
@@ -126,7 +126,11 @@ uk_household_with_axes = {
             "universal_credit": {"2026": None},
         }
     },
-    "households": {"household": {"members": ["parent"]}},
+    # `country` pins enum outputs under axes: the wrapper Simulation
+    # returns them as decoded string arrays.
+    "households": {
+        "household": {"members": ["parent"], "country": {"2026": None}}
+    },
     "axes": [
         [
             {

--- a/tests/deployed/conftest.py
+++ b/tests/deployed/conftest.py
@@ -131,7 +131,9 @@ def auth_token() -> str:
     return _get_required_env_var(AUTH_TOKEN_ENV_VAR)
 
 
-def _resolve_active_versions(base_url: str) -> dict[str, str]:
+def _resolve_active_versions(
+    base_url: str, country_id: str = "us"
+) -> dict[str, str]:
     """Ask the deployed gateway which model versions each channel serves.
 
     The gateway is often freshly deployed (cold) when the suite starts, and
@@ -144,7 +146,7 @@ def _resolve_active_versions(base_url: str) -> dict[str, str]:
             time.sleep(VERSION_RESOLUTION_BACKOFF_SECONDS)
         try:
             with request.urlopen(
-                f"{base_url}/versions/us",
+                f"{base_url}/versions/{country_id}",
                 timeout=VERSION_RESOLUTION_TIMEOUT_SECONDS,
             ) as response:
                 return json.loads(response.read().decode("utf-8"))
@@ -154,7 +156,7 @@ def _resolve_active_versions(base_url: str) -> dict[str, str]:
             last_error = repr(exc)
     raise RuntimeError(
         "Could not load active Modal channels from "
-        f"{base_url}/versions/us: {last_error}"
+        f"{base_url}/versions/{country_id}: {last_error}"
     )
 
 
@@ -167,6 +169,31 @@ def request_version(
     override = os.getenv(REQUEST_VERSION_ENV_VAR, "").strip()
     if override:
         return override
+    return _request_version_for_country(
+        base_url, expected_channel, route_mode, "us"
+    )
+
+
+@pytest.fixture(scope="session")
+def uk_request_version(
+    base_url: str,
+    expected_channel: str | None,
+    route_mode: str | None,
+) -> str | None:
+    # The REQUEST_VERSION_ENV_VAR override is an exact US package version,
+    # so it cannot apply to UK requests; UK tests resolve their own exact
+    # version from the gateway instead.
+    return _request_version_for_country(
+        base_url, expected_channel, route_mode, "uk"
+    )
+
+
+def _request_version_for_country(
+    base_url: str,
+    expected_channel: str | None,
+    route_mode: str | None,
+    country_id: str,
+) -> str | None:
     if not route_mode:
         return None
     if not expected_channel:
@@ -176,12 +203,13 @@ def request_version(
         )
 
     try:
-        versions = _resolve_active_versions(base_url)
+        versions = _resolve_active_versions(base_url, country_id)
     except RuntimeError as exc:
         pytest.fail(str(exc))
     if not versions.get(expected_channel):
         pytest.fail(
-            f"Deployed gateway does not expose `{expected_channel}` for US"
+            f"Deployed gateway does not expose `{expected_channel}` for "
+            f"{country_id.upper()}"
         )
 
     if route_mode == "channel":

--- a/tests/deployed/test_uk_calculate.py
+++ b/tests/deployed/test_uk_calculate.py
@@ -1,0 +1,56 @@
+"""Deployed smoke coverage for UK /calculate.
+
+policyengine-uk 2.43 changed its Simulation constructor and every UK
+calculation 500'd for months without any deployed test noticing; this
+module keeps a UK household flowing through each deployed route.
+"""
+
+from tests.data.uk_households import (
+    uk_household_requesting_universal_credit,
+)
+
+
+class TestUKCalculate:
+    def test_universal_credit_calculation(
+        self,
+        deployed_api,
+        auth_token,
+        uk_request_version,
+        expected_backend,
+    ):
+        request_body = {
+            "household": uk_household_requesting_universal_credit,
+        }
+        if uk_request_version:
+            request_body["version"] = uk_request_version
+
+        response = deployed_api.post(
+            "/uk/calculate",
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+            },
+            json_body=request_body,
+        )
+
+        assert response.status_code == 200
+        if expected_backend:
+            assert (
+                response.headers["X-PolicyEngine-Backend"] == expected_backend
+            )
+
+        result = response.json()
+        assert result["status"] == "ok"
+        assert result["message"] is None
+
+        household = result["result"]
+        universal_credit = household["benunits"]["benunit"][
+            "universal_credit"
+        ]["2026"]
+        assert isinstance(universal_credit, (int, float))
+        assert universal_credit > 0
+
+        # Inputs must be echoed back unchanged.
+        assert (
+            household["people"]["parent"]["employment_income"]["2026"]
+            == 15_000
+        )

--- a/tests/fixtures/country.py
+++ b/tests/fixtures/country.py
@@ -12,3 +12,24 @@ valid_household_requesting_ctc_calculation = {
 
 country_package_name_us = "policyengine_us"
 country_id_us = "us"
+
+us_household_requesting_income_tax = {
+    "people": {
+        "you": {
+            "age": {"2024": 40},
+            "employment_income": {"2024": 50_000},
+        }
+    },
+    "tax_units": {
+        "tax_unit": {"members": ["you"], "income_tax": {"2024": None}}
+    },
+    "families": {"family": {"members": ["you"]}},
+    "households": {"household": {"members": ["you"]}},
+    "spm_units": {"spm_unit": {"members": ["you"]}},
+}
+
+us_standard_deduction_reform = {
+    "gov.irs.deductions.standard.amount.SINGLE": {
+        "2024-01-01.2024-12-31": "30000",
+    }
+}

--- a/tests/fixtures/country.py
+++ b/tests/fixtures/country.py
@@ -33,3 +33,24 @@ us_standard_deduction_reform = {
         "2024-01-01.2024-12-31": "30000",
     }
 }
+
+us_household_with_axes = {
+    "people": {"you": {"age": {"2024": 40}}},
+    "tax_units": {
+        "tax_unit": {"members": ["you"], "income_tax": {"2024": None}}
+    },
+    "families": {"family": {"members": ["you"]}},
+    "households": {"household": {"members": ["you"]}},
+    "spm_units": {"spm_unit": {"members": ["you"]}},
+    "axes": [
+        [
+            {
+                "name": "employment_income",
+                "count": 3,
+                "min": 0,
+                "max": 100_000,
+                "period": "2024",
+            }
+        ]
+    ],
+}

--- a/tests/integration_with_auth/test_uk_calculate.py
+++ b/tests/integration_with_auth/test_uk_calculate.py
@@ -1,0 +1,54 @@
+"""Endpoint-integration coverage for UK /calculate.
+
+policyengine-uk 2.43 changed its Simulation constructor and every UK
+calculation 500'd for months without any test noticing; this module
+keeps a UK household flowing through the local Flask endpoint (with
+auth enabled) in ordinary PR CI.
+"""
+
+import json
+
+import pytest
+
+from policyengine_household_api.utils import get_config_value
+from tests.data.uk_households import uk_household_single_adult_no_income
+
+# A single unemployed adult aged 25+ with no housing costs receives only
+# the Universal Credit standard allowance, so the expected value is the
+# 12-month sum of gov.dwp.universal_credit.standard_allowance.amount
+# .SINGLE_OLD, including the Universal Credit Act 2025 uplift the model
+# applies from April 2026. Recompute when a policyengine-uk bump changes
+# UC uprating.
+EXPECTED_UNIVERSAL_CREDIT_2026 = 5_079.13
+
+
+class TestUKCalculate:
+    def test_universal_credit_standard_allowance_only(self, client):
+        response = client.post(
+            "/uk/calculate",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": (
+                    f"Bearer {get_config_value('auth.auth0.test_token')}"
+                ),
+            },
+            json={"household": uk_household_single_adult_no_income},
+        )
+
+        assert response.status_code == 200
+
+        result = json.loads(response.data)
+        assert result["status"] == "ok"
+        assert result["message"] is None
+
+        household = result["result"]
+        universal_credit = household["benunits"]["benunit"][
+            "universal_credit"
+        ]["2026"]
+        assert universal_credit == pytest.approx(
+            EXPECTED_UNIVERSAL_CREDIT_2026, abs=0.01
+        )
+
+        # Inputs must be echoed back unchanged.
+        assert household["people"]["adult"]["age"]["2026"] == 30
+        assert household["people"]["adult"]["employment_income"]["2026"] == 0

--- a/tests/unit/endpoints/test_household.py
+++ b/tests/unit/endpoints/test_household.py
@@ -580,7 +580,12 @@ class TestPolicyPeriodValidation:
         assert response.status_code == 500
         payload = json.loads(response.data)
         assert payload["status"] == "error"
-        assert "Invalid policy period key" in payload["message"]
+        # startswith pins the endpoint's own validation call: if a
+        # refactor drops it, the same error still arrives via
+        # calculate() but wrapped in an "Error calculating household
+        # under policy:" prefix, and this assertion catches the
+        # message-contract change.
+        assert payload["message"].startswith("Invalid policy period key")
 
     def test__given_invalid_variable_and_malformed_policy__variable_error_wins(
         self, client

--- a/tests/unit/endpoints/test_household.py
+++ b/tests/unit/endpoints/test_household.py
@@ -2,10 +2,8 @@ import json
 
 import pytest
 from policyengine_household_api.constants import COUNTRY_PACKAGE_VERSIONS
-from policyengine_household_api.endpoints.household import (
-    _validate_axes,
-    _validate_policy_periods,
-)
+from policyengine_household_api.country import validate_policy_periods
+from policyengine_household_api.endpoints.household import _validate_axes
 from policyengine_household_common.routing_metadata import (
     REQUESTED_VERSION_ENVIRON_KEY,
     RESOLVED_CHANNEL_ENVIRON_KEY,
@@ -544,7 +542,7 @@ class TestPolicyPeriodValidation:
         self, policy, message
     ):
         with pytest.raises(ValueError) as error:
-            _validate_policy_periods(policy)
+            validate_policy_periods(policy)
 
         assert message in str(error.value)
 
@@ -559,7 +557,7 @@ class TestPolicyPeriodValidation:
         ],
     )
     def test__given_valid_policy_periods__does_not_raise(self, policy):
-        _validate_policy_periods(policy)
+        validate_policy_periods(policy)
 
     def test__given_malformed_policy_period__endpoint_returns_500(
         self, client
@@ -583,3 +581,32 @@ class TestPolicyPeriodValidation:
         payload = json.loads(response.data)
         assert payload["status"] == "error"
         assert "Invalid policy period key" in payload["message"]
+
+    def test__given_invalid_variable_and_malformed_policy__variable_error_wins(
+        self, client
+    ):
+        # Error precedence must match main: household variable validation
+        # (400) fires before policy validation (500), because bad policy
+        # historically only crashed inside calculate, after all household
+        # validation.
+        household = {
+            **valid_household_requesting_ctc_calculation,
+            "people": {
+                "you": {
+                    "age": {"2024": 40},
+                    "not_a_real_variable": {"2024": 1},
+                }
+            },
+        }
+        response = client.post(
+            "/us/calculate",
+            json={
+                "household": household,
+                "policy": {"gov.some.parameter": {"2026": 1}},
+            },
+            headers=TestCalculateEndpoint.auth_headers,
+        )
+
+        assert response.status_code == 400
+        payload = json.loads(response.data)
+        assert payload["message"] == "Invalid household variables."

--- a/tests/unit/endpoints/test_household.py
+++ b/tests/unit/endpoints/test_household.py
@@ -2,7 +2,10 @@ import json
 
 import pytest
 from policyengine_household_api.constants import COUNTRY_PACKAGE_VERSIONS
-from policyengine_household_api.endpoints.household import _validate_axes
+from policyengine_household_api.endpoints.household import (
+    _validate_axes,
+    _validate_policy_periods,
+)
 from policyengine_household_common.routing_metadata import (
     REQUESTED_VERSION_ENVIRON_KEY,
     RESOLVED_CHANNEL_ENVIRON_KEY,
@@ -508,3 +511,75 @@ class TestAxesValidation:
     )
     def test__given_valid_axes__does_not_raise(self, household):
         _validate_axes(household)
+
+
+class TestPolicyPeriodValidation:
+    @pytest.mark.parametrize(
+        "policy,message",
+        [
+            ("not a dict", "'policy' must be a JSON object"),
+            (
+                {"gov.some.parameter": "not a dict"},
+                "'policy.gov.some.parameter' must be a JSON object",
+            ),
+            (
+                {"gov.some.parameter": {"2026-01-01": 1}},
+                "Invalid policy period key `2026-01-01`",
+            ),
+            (
+                {"gov.some.parameter": {"2026": 1}},
+                "Invalid policy period key `2026`",
+            ),
+            (
+                {"gov.some.parameter": {"a.b.c": 1}},
+                "Invalid policy period key `a.b.c`",
+            ),
+            (
+                {"gov.some.parameter": {"garbage.2026-12-31": 1}},
+                "Invalid policy period key `garbage.2026-12-31`",
+            ),
+        ],
+    )
+    def test__given_invalid_policy_periods__raises_value_error(
+        self, policy, message
+    ):
+        with pytest.raises(ValueError) as error:
+            _validate_policy_periods(policy)
+
+        assert message in str(error.value)
+
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            None,
+            {},
+            {"gov.some.parameter": {"2026-01-01.2026-12-31": 1}},
+            # Bare years are valid instants, so year.year pairs pass.
+            {"gov.some.parameter": {"2026.2027": 1}},
+        ],
+    )
+    def test__given_valid_policy_periods__does_not_raise(self, policy):
+        _validate_policy_periods(policy)
+
+    def test__given_malformed_policy_period__endpoint_returns_500(
+        self, client
+    ):
+        # 500 rather than 400 matches the endpoint's long-standing
+        # behavior for bad policy input; issue #1628 tracks moving to 400.
+        response = client.post(
+            "/us/calculate",
+            json={
+                "household": valid_household_requesting_ctc_calculation,
+                "policy": {
+                    "gov.irs.deductions.standard.amount.SINGLE": {
+                        "2026-01-01": 30_000,
+                    }
+                },
+            },
+            headers=TestCalculateEndpoint.auth_headers,
+        )
+
+        assert response.status_code == 500
+        payload = json.loads(response.data)
+        assert payload["status"] == "error"
+        assert "Invalid policy period key" in payload["message"]

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -4,6 +4,8 @@ from tests.fixtures.country import (
     valid_household_requesting_ctc_calculation,
     country_package_name_us,
     country_id_us,
+    us_household_requesting_income_tax,
+    us_standard_deduction_reform,
 )
 from tests.data.uk_households import (
     uk_household_requesting_universal_credit,
@@ -33,6 +35,29 @@ class TestCalculateReturnValue:
 
         assert isinstance(result, dict)
         assert "people" in result
+
+    def test_calculate_applies_parametric_reform(self):
+        # policyengine-us's Simulation.__init__ is (*args, **kwargs), so
+        # the core/wrapper detection must classify it as core-style; a
+        # misclassification sends the policy dict to core's `reform`
+        # argument (which expects a Reform class) and breaks every US
+        # reform request. The value is a string on purpose: the API casts
+        # reform values to the parameter's node type.
+        country = COUNTRIES["us"]
+
+        baseline = country.calculate(
+            household=us_household_requesting_income_tax,
+            reform=None,
+        )
+        reformed = country.calculate(
+            household=us_household_requesting_income_tax,
+            reform=us_standard_deduction_reform,
+        )
+
+        baseline_tax = baseline["tax_units"]["tax_unit"]["income_tax"]["2024"]
+        reformed_tax = reformed["tax_units"]["tax_unit"]["income_tax"]["2024"]
+        # Raising the standard deduction must reduce income tax.
+        assert reformed_tax < baseline_tax
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -221,6 +221,8 @@ class TestCastReformValue:
             ("0", False),
             (1, True),
             (0, False),
+            (1.0, True),
+            (0.0, False),
         ],
     )
     def test_boolean_values_cast_explicitly(self, value, expected):
@@ -236,12 +238,16 @@ class TestCastReformValue:
         [
             "garbage",
             # Deliberately rejected: the pre-rewrite casting accepted
-            # these by accident ("2" and "1.0" via float-then-bool, None
-            # coercing to False); they are ambiguous as booleans and now
-            # raise instead of silently coercing.
+            # these by accident (strings via float-then-bool, None
+            # coercing to False, any nonzero number via bool()); they
+            # are ambiguous as booleans and now raise instead of
+            # silently coercing. Only 0 and 1 are accepted as numbers.
             "2",
             "1.0",
             None,
+            2,
+            -3,
+            2.5,
         ],
     )
     def test_unrecognized_boolean_values_raise(self, value):

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -1,10 +1,13 @@
 import pytest
 
+from policyengine_core.parameters import Parameter
+
 from tests.fixtures.country import (
     valid_household_requesting_ctc_calculation,
     country_package_name_us,
     country_id_us,
     us_household_requesting_income_tax,
+    us_household_with_axes,
     us_standard_deduction_reform,
 )
 from tests.data.uk_households import (
@@ -59,6 +62,21 @@ class TestCalculateReturnValue:
         reformed_tax = reformed["tax_units"]["tax_unit"]["income_tax"]["2024"]
         # Raising the standard deduction must reduce income tax.
         assert reformed_tax < baseline_tax
+
+    def test_calculate_supports_axes(self):
+        # Pins the standard axes reshaping path shared by US/CA/NG/IL.
+        country = COUNTRIES["us"]
+
+        result = country.calculate(
+            household=us_household_with_axes,
+            reform=None,
+        )
+
+        income_tax = result["tax_units"]["tax_unit"]["income_tax"]["2024"]
+        assert isinstance(income_tax, list)
+        assert len(income_tax) == 3
+        # Income tax rises with swept employment income.
+        assert income_tax[-1] > income_tax[0]
 
 
 @pytest.fixture(scope="module")
@@ -154,6 +172,59 @@ class TestCalculateUK:
         assert len(universal_credit) == 3
         # Universal Credit tapers away as swept employment income rises.
         assert universal_credit[0] > universal_credit[-1]
+
+        # Enum outputs under axes come back as decoded names on the UK
+        # path (the standard path returns numeric enum indices).
+        country = result["households"]["household"]["country"]["2026"]
+        assert country == ["ENGLAND", "ENGLAND", "ENGLAND"]
+
+
+class TestCastReformValue:
+    @staticmethod
+    def _parameter(values: dict) -> Parameter:
+        return Parameter("test.parameter", data={"values": values})
+
+    def test_numeric_strings_cast_to_float(self):
+        parameter = self._parameter({"2020-01-01": 100})
+
+        cast = PolicyEngineCountry._cast_reform_value(parameter, "30000")
+
+        assert cast == 30_000.0
+        assert isinstance(cast, float)
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("false", False),
+            ("1", True),
+            ("0", False),
+            (1, True),
+            (0, False),
+        ],
+    )
+    def test_boolean_values_cast_explicitly(self, value, expected):
+        parameter = self._parameter({"2020-01-01": False})
+
+        assert (
+            PolicyEngineCountry._cast_reform_value(parameter, value)
+            is expected
+        )
+
+    def test_unrecognized_boolean_string_raises(self):
+        parameter = self._parameter({"2020-01-01": False})
+
+        with pytest.raises(ValueError, match="as a boolean"):
+            PolicyEngineCountry._cast_reform_value(parameter, "garbage")
+
+    def test_type_comes_from_most_recent_non_null_value(self):
+        # values_list is ordered newest-first; a null placeholder at
+        # either end carries no type information and must be skipped.
+        parameter = self._parameter({"2015-01-01": None, "2020-01-01": 0.25})
+
+        assert PolicyEngineCountry._cast_reform_value(parameter, "0.3") == 0.3
 
 
 class TestPolicyEngineBundle:

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -11,7 +11,9 @@ from tests.data.uk_households import (
     uk_household_requesting_universal_credit,
     uk_household_requesting_enum_outputs,
     uk_household_requesting_income_tax,
+    uk_household_married_requesting_marriage_allowance,
     uk_household_with_axes,
+    uk_marriage_allowance_structural_reform,
     uk_personal_allowance_reform,
 )
 from importlib.metadata import PackageNotFoundError
@@ -37,12 +39,11 @@ class TestCalculateReturnValue:
         assert "people" in result
 
     def test_calculate_applies_parametric_reform(self):
-        # policyengine-us's Simulation.__init__ is (*args, **kwargs), so
-        # the core/wrapper detection must classify it as core-style; a
-        # misclassification sends the policy dict to core's `reform`
-        # argument (which expects a Reform class) and breaks every US
-        # reform request. The value is a string on purpose: the API casts
-        # reform values to the parameter's node type.
+        # Pins the standard (core-style) builder's reform path: a routing
+        # mistake that sends the policy dict to the Simulation constructor
+        # (which expects a Reform class there) breaks every US reform
+        # request. The value is a string on purpose: the API casts reform
+        # values to the parameter's node type.
         country = COUNTRIES["us"]
 
         baseline = country.calculate(
@@ -114,6 +115,31 @@ class TestCalculateUK:
         # income must reduce their income tax to zero.
         assert baseline_tax > 0
         assert reformed_tax == 0
+
+    def test_calculate_applies_structural_trigger_reform(self, uk_country):
+        # The wrapper creates structural reforms from parameter values
+        # during construction, so the reform must be applied before that
+        # point (Scenario with applied_before_data_load=True). If it is
+        # applied late — the wrapper's default for `reform=` — the
+        # parameter changes but the structural reform never activates and
+        # this household gets baseline (zero) marriage allowance.
+        baseline = uk_country.calculate(
+            household=uk_household_married_requesting_marriage_allowance,
+            reform=None,
+        )
+        reformed = uk_country.calculate(
+            household=uk_household_married_requesting_marriage_allowance,
+            reform=uk_marriage_allowance_structural_reform,
+        )
+
+        baseline_ma = baseline["people"]["earner"]["marriage_allowance"][
+            "2026"
+        ]
+        reformed_ma = reformed["people"]["earner"]["marriage_allowance"][
+            "2026"
+        ]
+        assert baseline_ma == 0
+        assert reformed_ma > 0
 
     def test_calculate_supports_axes(self, uk_country):
         result = uk_country.calculate(

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -159,6 +159,24 @@ class TestCalculateUK:
         assert baseline_ma == 0
         assert reformed_ma > 0
 
+    def test_uk_package_exposes_scenario_interface(self, uk_country):
+        # _build_simulation_uk resolves Scenario per request; if a future
+        # policyengine-uk moves or renames it (or drops from_reform /
+        # applied_before_data_load), UK reform requests would 500 at
+        # runtime with a raw AttributeError — and the deployed smoke
+        # tests send no policy, so deploy gates wouldn't notice. Pin the
+        # interface here so a version bump fails in CI instead.
+        scenario_cls = uk_country.country_package.Scenario
+        scenario = scenario_cls.from_reform(
+            {
+                "gov.hmrc.income_tax.allowances.personal_allowance.amount": {
+                    "2026-01-01.2026-12-31": 15_000.0,
+                }
+            }
+        )
+        scenario.applied_before_data_load = True
+        assert scenario.applied_before_data_load is True
+
     def test_calculate_supports_axes(self, uk_country):
         result = uk_country.calculate(
             household=uk_household_with_axes,
@@ -213,11 +231,24 @@ class TestCastReformValue:
             is expected
         )
 
-    def test_unrecognized_boolean_string_raises(self):
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "garbage",
+            # Deliberately rejected: the pre-rewrite casting accepted
+            # these by accident ("2" and "1.0" via float-then-bool, None
+            # coercing to False); they are ambiguous as booleans and now
+            # raise instead of silently coercing.
+            "2",
+            "1.0",
+            None,
+        ],
+    )
+    def test_unrecognized_boolean_values_raise(self, value):
         parameter = self._parameter({"2020-01-01": False})
 
         with pytest.raises(ValueError, match="as a boolean"):
-            PolicyEngineCountry._cast_reform_value(parameter, "garbage")
+            PolicyEngineCountry._cast_reform_value(parameter, value)
 
     def test_type_comes_from_most_recent_non_null_value(self):
         # values_list is ordered newest-first; a null placeholder at

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -1,10 +1,22 @@
+import pytest
+
 from tests.fixtures.country import (
     valid_household_requesting_ctc_calculation,
     country_package_name_us,
     country_id_us,
 )
+from tests.data.uk_households import (
+    uk_household_requesting_universal_credit,
+    uk_household_requesting_enum_outputs,
+    uk_household_requesting_income_tax,
+    uk_household_with_axes,
+    uk_personal_allowance_reform,
+)
 from importlib.metadata import PackageNotFoundError
-from policyengine_household_api.country import PolicyEngineCountry
+from policyengine_household_api.country import (
+    COUNTRIES,
+    PolicyEngineCountry,
+)
 from policyengine_household_api.constants import COUNTRY_PACKAGE_VERSIONS
 
 
@@ -21,6 +33,76 @@ class TestCalculateReturnValue:
 
         assert isinstance(result, dict)
         assert "people" in result
+
+
+@pytest.fixture(scope="module")
+def uk_country():
+    # Reuse the instance the endpoints serve instead of building a second
+    # UK tax-benefit system; these tests exercise the same object.
+    return COUNTRIES["uk"]
+
+
+class TestCalculateUK:
+    """policyengine-uk >= 2.43 exposes a wrapper Simulation that no longer
+    accepts a tax_benefit_system argument; these tests pin the alternate
+    construction path in PolicyEngineCountry.calculate.
+    """
+
+    def test_calculate_returns_universal_credit(self, uk_country):
+        # Given a single parent with one child renting in London
+        result = uk_country.calculate(
+            household=uk_household_requesting_universal_credit,
+            reform=None,
+        )
+
+        universal_credit = result["benunits"]["benunit"]["universal_credit"][
+            "2026"
+        ]
+        assert isinstance(universal_credit, float)
+        assert universal_credit > 0
+
+    def test_calculate_decodes_enum_outputs(self, uk_country):
+        # Wrapper-style Simulations return enum results as plain string
+        # arrays rather than EnumArray; the response loop must serialize
+        # them to the enum's name either way.
+        result = uk_country.calculate(
+            household=uk_household_requesting_enum_outputs,
+            reform=None,
+        )
+
+        country = result["households"]["household"]["country"]["2026"]
+        assert country == "ENGLAND"
+
+    def test_calculate_applies_parametric_reform(self, uk_country):
+        baseline = uk_country.calculate(
+            household=uk_household_requesting_income_tax,
+            reform=None,
+        )
+        reformed = uk_country.calculate(
+            household=uk_household_requesting_income_tax,
+            reform=uk_personal_allowance_reform,
+        )
+
+        baseline_tax = baseline["people"]["parent"]["income_tax"]["2026"]
+        reformed_tax = reformed["people"]["parent"]["income_tax"]["2026"]
+        # Raising the personal allowance above this person's employment
+        # income must reduce their income tax to zero.
+        assert baseline_tax > 0
+        assert reformed_tax == 0
+
+    def test_calculate_supports_axes(self, uk_country):
+        result = uk_country.calculate(
+            household=uk_household_with_axes,
+            reform=None,
+        )
+
+        universal_credit = result["benunits"]["benunit"]["universal_credit"][
+            "2026"
+        ]
+        assert isinstance(universal_credit, list)
+        assert len(universal_credit) == 3
+        # Universal Credit tapers away as swept employment income rises.
+        assert universal_credit[0] > universal_credit[-1]
 
 
 class TestPolicyEngineBundle:


### PR DESCRIPTION
Fixes #1631

## What broke

policyengine-uk 2.43.0 replaced its core `Simulation` subclass with a wrapper whose constructor is `(scenario, situation, dataset, trace, reform)` and which builds its own tax-benefit system internally. `PolicyEngineCountry.calculate` still passed `tax_benefit_system=`, so every UK `/calculate` request has returned a 500 since the UK pin crossed that boundary (2.65.0, December 2025). No test lane sent a UK household through the endpoint, so nothing caught it.

## What this PR does

- **Routes simulation construction by country id**, chosen once in `PolicyEngineCountry.__init__`: UK calculations go through a wrapper-style builder; US/CA/NG/IL keep the injected-system path byte-for-byte. Enum serialization (scalar and under axes) is routed the same way, since the wrapper decodes enums to string arrays while core returns `EnumArray`s.
- **Applies UK reforms via `Scenario` with `applied_before_data_load=True`.** The wrapper's own `reform=` argument applies parameter changes only after it creates structural reforms from baseline parameters, so reforms on structural-trigger parameters (`gov.contrib.*`) changed the parameter but never activated the reform — HTTP 200 with baseline numbers. Upstream: PolicyEngine/policyengine-uk#1800.
- **Validates policy period keys** (`"start.stop"` instant pairs) as a single grammar owned by `country.py` and enforced on every `calculate()`; the endpoint maps failures to a descriptive 500 after all household validation, preserving historical error precedence. The UK wrapper otherwise silently applies bare-instant keys to a single day. Moving to 400 + docs: #1628.
- **Casts reform values explicitly to the parameter's type.** String `"false"` previously *enabled* boolean parameters (`bool("false")` is `True`); accepted boolean forms are now true/false, `"true"`/`"false"`, `"1"`/`"0"`, and the numbers 0/1, with ambiguous forms raising. The parameter's type is read from its most recent non-null value instead of its oldest.
- **Adds UK coverage to every test lane**: unit (UC calculation, enum decoding, parametric + structural-trigger reforms, axes, Scenario interface pin), endpoint-integration (pinned UC value of £5,079.13 for a standard-allowance-only claimant), and deployed smoke tests with per-country version resolution. Also pins the previously untested US reform and axes paths.
- Deletes the dead `create_policy_reform`, updates the OpenAPI `policy` description, and adds three changelog fragments.

## Verification

- Full `make test` (676+ tests), `make test-with-auth` (7), and `make format-check` all green locally through development; the final suite run at the branch tip covers the same slices that ran green per-commit.
- The fixed UK path returns Universal Credit values identical to running policyengine-uk 2.88.18 directly.
- Three multi-agent review rounds; all confirmed findings fixed or tracked (#1628, #1629, #1630, PolicyEngine/policyengine-uk#1800, PolicyEngine/policyengine-us#9053).

## Related

#1628 (400 migration), #1629 (UK app extrication), #1630 (drop CA/NG/IL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)