### PR TITLE
Bound Modal dispatch calls with configured deadlines in the Cloud Run gateway

### DIFF
--- a/changelog.d/1633.fixed.md
+++ b/changelog.d/1633.fixed.md
@@ -1,0 +1,1 @@
+Bound the Cloud Run gateway's Modal dispatch, probe, and canary calls with their configured deadlines so a hung Modal control-plane call frees its executor thread instead of permanently leaking a dispatch slot until the pool saturates.

--- a/libs/household-common/policyengine_household_common/worker_dispatch.py
+++ b/libs/household-common/policyengine_household_common/worker_dispatch.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Coroutine
+import threading
 from typing import Any
 
 from policyengine_household_common.observability.segments import SegmentName
@@ -15,6 +18,52 @@ HOP_BY_HOP_RESPONSE_HEADERS = {
     "content-length",
     "transfer-encoding",
 }
+
+
+class _ModalAsyncRunner:
+    """Run timed Modal calls on one lazily created process-local event loop."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+
+    def run(self, coroutine: Coroutine[Any, Any, Any]) -> Any:
+        loop = self._get_loop()
+        try:
+            future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+        except BaseException:
+            coroutine.close()
+            raise
+        return future.result()
+
+    def _get_loop(self) -> asyncio.AbstractEventLoop:
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                assert self._loop is not None
+                return self._loop
+
+            loop = asyncio.new_event_loop()
+            started = threading.Event()
+
+            def run_loop() -> None:
+                asyncio.set_event_loop(loop)
+                started.set()
+                loop.run_forever()
+
+            thread = threading.Thread(
+                target=run_loop,
+                name="household-modal-async",
+                daemon=True,
+            )
+            self._loop = loop
+            self._thread = thread
+            thread.start()
+            started.wait()
+            return loop
+
+
+_MODAL_ASYNC_RUNNER = _ModalAsyncRunner()
 
 
 def dispatch_to_flask_app(
@@ -70,9 +119,9 @@ def call_modal_worker_dispatch(
     top-level ``handle_household_request`` function; fall back to that shape
     when the class is not present.
 
-    ``timeout_seconds`` bounds the wait for the dispatch result; without it
-    Modal waits indefinitely, including for an input queued behind a
-    container that never finishes booting.
+    ``timeout_seconds`` bounds both the control-plane dispatch and the wait
+    for its result; without it Modal waits indefinitely, including for an
+    input queued behind a container that never finishes booting.
     """
     import modal
 
@@ -113,6 +162,45 @@ def _dispatch_result(
     payload: dict[str, Any],
     timeout_seconds: float | None,
 ) -> dict[str, Any]:
+    return call_modal_function(
+        method,
+        payload,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def call_modal_function(
+    function: Any,
+    *args: Any,
+    timeout_seconds: float | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Invoke a Modal function with a deadline covering dispatch and result.
+
+    Modal's synchronous ``spawn()`` performs the initial control-plane RPC
+    before returning a function-call handle, so applying a timeout only to
+    ``handle.get()`` still allows ``spawn()`` itself to hang indefinitely.
+    Run both async phases in one timeout context so cancellation also reaches
+    a black-holed dispatch RPC.
+    """
     if timeout_seconds is None:
-        return method.remote(payload)
-    return method.spawn(payload).get(timeout=timeout_seconds)
+        return function.remote(*args, **kwargs)
+    return _MODAL_ASYNC_RUNNER.run(
+        _call_modal_function_with_timeout(
+            function,
+            args,
+            kwargs,
+            timeout_seconds,
+        )
+    )
+
+
+async def _call_modal_function_with_timeout(
+    function: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    timeout_seconds: float,
+) -> Any:
+    async with asyncio.timeout(timeout_seconds):
+        function_call = await function.spawn.aio(*args, **kwargs)
+        return await function_call.get.aio(timeout=timeout_seconds)

--- a/projects/cloud-run-failover-api/policyengine_household_failover/cloud_run_gateway.py
+++ b/projects/cloud-run-failover-api/policyengine_household_failover/cloud_run_gateway.py
@@ -60,6 +60,7 @@ from policyengine_household_common.gateway import (
 )
 from policyengine_household_common.version_routing import VersionRoutingError
 from policyengine_household_common.worker_dispatch import (
+    call_modal_function,
     call_modal_worker_dispatch,
 )
 
@@ -607,10 +608,10 @@ def probe_modal_canary(*, timeout_seconds: float | None = None) -> None:
                 function_name,
             )
         with segment(SegmentName.MODAL_REMOTE_EXECUTION, backend="modal"):
-            if timeout_seconds is None:
-                result = canary_function.remote()
-            else:
-                result = canary_function.spawn().get(timeout=timeout_seconds)
+            result = call_modal_function(
+                canary_function,
+                timeout_seconds=timeout_seconds,
+            )
     except Exception as exc:
         raise ModalBackendUnavailable(str(exc)) from exc
     if not isinstance(result, dict) or result.get("ok") is not True:

--- a/projects/cloud-run-failover-api/policyengine_household_failover/cloud_run_gateway.py
+++ b/projects/cloud-run-failover-api/policyengine_household_failover/cloud_run_gateway.py
@@ -379,9 +379,6 @@ def create_gateway_app(
     # ``request.get_data()`` on a small gateway container.
     app.config["MAX_CONTENT_LENGTH"] = max_content_length_bytes()
     load_manifest = manifest_loader or GcsFailoverManifestLoader()
-    call_modal = modal_request or call_modal_worker
-    probe_modal = modal_health_probe or probe_modal_worker
-    probe_canary = modal_canary_probe or probe_modal_canary
     call_fallback = fallback_request or call_cloud_run_worker
     check_modal_status = modal_status_checker or fetch_modal_status
     warm_fallback = fallback_warmup or warm_cloud_run_worker
@@ -413,6 +410,30 @@ def create_gateway_app(
             legacy_timeout_seconds=modal_timeout_seconds,
         )
     )
+
+    # The resolved deadlines must reach the Modal SDK calls themselves, not
+    # just the executor-side result wait: a dispatch without its own deadline
+    # blocks an executor thread forever when the control-plane connection
+    # black-holes, and each hung call permanently leaks one of the
+    # MODAL_EXECUTOR_MAX_WORKERS slots until the pool saturates (#1633).
+    def _call_modal_with_deadline(
+        app_name: str, payload: dict[str, Any]
+    ) -> Response:
+        return call_modal_worker(
+            app_name,
+            payload,
+            timeout_seconds=request_timeout,
+        )
+
+    def _probe_modal_with_deadline(app_name: str) -> None:
+        probe_modal_worker(app_name, timeout_seconds=probe_timeout)
+
+    def _probe_canary_with_deadline() -> None:
+        probe_modal_canary(timeout_seconds=canary_timeout)
+
+    call_modal = modal_request or _call_modal_with_deadline
+    probe_modal = modal_health_probe or _probe_modal_with_deadline
+    probe_canary = modal_canary_probe or _probe_canary_with_deadline
 
     @app.get("/liveness_check")
     def liveness_check() -> Response:
@@ -535,13 +556,26 @@ def create_gateway_app(
     return app
 
 
-def call_modal_worker(app_name: str, payload: dict[str, Any]) -> Response:
+def call_modal_worker(
+    app_name: str,
+    payload: dict[str, Any],
+    *,
+    timeout_seconds: float | None = None,
+) -> Response:
     return _response_from_dispatch_result(
-        _call_modal_worker_dispatch(app_name, payload)
+        _call_modal_worker_dispatch(
+            app_name,
+            payload,
+            timeout_seconds=timeout_seconds,
+        )
     )
 
 
-def probe_modal_worker(app_name: str) -> None:
+def probe_modal_worker(
+    app_name: str,
+    *,
+    timeout_seconds: float | None = None,
+) -> None:
     result = _call_modal_worker_dispatch(
         app_name,
         {
@@ -551,12 +585,13 @@ def probe_modal_worker(app_name: str) -> None:
             "headers": {},
             "body": b"",
         },
+        timeout_seconds=timeout_seconds,
     )
     if int(result["status_code"]) != 200:
         raise ModalBackendUnavailable("Modal worker liveness check failed")
 
 
-def probe_modal_canary() -> None:
+def probe_modal_canary(*, timeout_seconds: float | None = None) -> None:
     import modal
 
     app_name = os.getenv(MODAL_CANARY_APP_NAME_ENV, MODAL_CANARY_APP_NAME)
@@ -572,7 +607,10 @@ def probe_modal_canary() -> None:
                 function_name,
             )
         with segment(SegmentName.MODAL_REMOTE_EXECUTION, backend="modal"):
-            result = canary_function.remote()
+            if timeout_seconds is None:
+                result = canary_function.remote()
+            else:
+                result = canary_function.spawn().get(timeout=timeout_seconds)
     except Exception as exc:
         raise ModalBackendUnavailable(str(exc)) from exc
     if not isinstance(result, dict) or result.get("ok") is not True:
@@ -582,6 +620,8 @@ def probe_modal_canary() -> None:
 def _call_modal_worker_dispatch(
     app_name: str,
     payload: dict[str, Any],
+    *,
+    timeout_seconds: float | None = None,
 ) -> dict[str, Any]:
     environment = os.getenv(MODAL_ENVIRONMENT_ENV, "").strip()
     try:
@@ -589,6 +629,7 @@ def _call_modal_worker_dispatch(
             app_name,
             payload,
             environment_name=environment or None,
+            timeout_seconds=timeout_seconds,
         )
     except Exception as exc:
         raise ModalBackendUnavailable(str(exc)) from exc

--- a/tests/fixtures/modal_fakes.py
+++ b/tests/fixtures/modal_fakes.py
@@ -4,8 +4,8 @@ Production code imports ``modal`` lazily inside functions, so patching
 ``sys.modules["modal"]`` with :func:`install_fake_modal` makes those lazy
 imports resolve to the fake. The fake covers the worker-dispatch surface:
 ``modal.Cls.from_name`` / ``modal.Function.from_name`` lookups (including
-the pre-#1528 function-shaped fallback), ``.remote`` and
-``.spawn().get(timeout=...)`` invocation, and
+the pre-#1528 function-shaped fallback), synchronous ``.remote`` and async
+``.spawn.aio()`` / ``.get.aio(timeout=...)`` invocation, and
 ``modal.exception.NotFoundError``.
 """
 
@@ -57,22 +57,32 @@ class FakeWorkerDispatch:
 
 
 def install_fake_modal(monkeypatch, worker: FakeWorkerDispatch) -> None:
+    class _SyncAsyncCallable:
+        def __init__(self, callback):
+            self._callback = callback
+
+        def __call__(self, *args, **kwargs):
+            return self._callback(*args, **kwargs)
+
+        async def aio(self, *args, **kwargs):
+            return self._callback(*args, **kwargs)
+
     class _FakeFunctionCall:
         def __init__(self, payload):
-            self._payload = payload
-
-        def get(self, timeout=None):
-            return worker.dispatch(self._payload, timeout)
+            self.get = _SyncAsyncCallable(
+                lambda timeout=None: worker.dispatch(payload, timeout)
+            )
 
     class _FakeMethod:
-        def remote(self, payload):
-            return worker.dispatch(payload, None)
-
-        def spawn(self, payload):
-            return _FakeFunctionCall(payload)
+        def __init__(self):
+            self.remote = _SyncAsyncCallable(
+                lambda payload: worker.dispatch(payload, None)
+            )
+            self.spawn = _SyncAsyncCallable(_FakeFunctionCall)
 
     class _FakeInstance:
-        handle_household_request = _FakeMethod()
+        def __init__(self):
+            self.handle_household_request = _FakeMethod()
 
     class _FakeCls:
         @staticmethod

--- a/tests/unit/failover/test_cloud_run_gateway.py
+++ b/tests/unit/failover/test_cloud_run_gateway.py
@@ -20,6 +20,7 @@ from policyengine_household_failover.cloud_run_gateway import (
     _modal_canary_confirms_outage,
     _run_modal_operation,
     call_cloud_run_worker,
+    call_modal_worker,
     create_gateway_app,
     modal_status_summary,
     probe_modal_canary,
@@ -717,6 +718,93 @@ def test_probe_modal_canary_uses_configured_modal_app(monkeypatch):
         "object_name": "custom_ping",
         "kwargs": {"environment_name": "testing"},
     }
+
+
+def _install_fake_modal_with_spawn(monkeypatch, captured, *, result):
+    class NotFoundError(Exception):
+        pass
+
+    def _spawn_handle():
+        return types.SimpleNamespace(
+            get=lambda timeout=None: (
+                captured.__setitem__("timeout", timeout) or result
+            )
+        )
+
+    class FakeModalCls:
+        @staticmethod
+        def from_name(app_name, object_name, **kwargs):
+            class FakeWorkerClass:
+                def __call__(self):
+                    return types.SimpleNamespace(
+                        handle_household_request=types.SimpleNamespace(
+                            spawn=lambda payload: _spawn_handle()
+                        )
+                    )
+
+            return FakeWorkerClass()
+
+    class FakeModalFunction:
+        @staticmethod
+        def from_name(app_name, object_name, **kwargs):
+            return types.SimpleNamespace(spawn=lambda: _spawn_handle())
+
+    monkeypatch.setenv("MODAL_ENVIRONMENT", "testing")
+    monkeypatch.setitem(
+        sys.modules,
+        "modal",
+        types.SimpleNamespace(
+            Cls=FakeModalCls,
+            Function=FakeModalFunction,
+            exception=types.SimpleNamespace(NotFoundError=NotFoundError),
+        ),
+    )
+
+
+def test_call_modal_worker_bounds_dispatch_with_timeout(monkeypatch):
+    captured = {}
+    _install_fake_modal_with_spawn(
+        monkeypatch,
+        captured,
+        result={"status_code": 200, "body": b"OK", "headers": []},
+    )
+
+    response = call_modal_worker(
+        "modal-current",
+        {
+            "method": "GET",
+            "path": "/liveness_check",
+            "query_string": "",
+            "headers": {},
+            "body": b"",
+        },
+        timeout_seconds=7.5,
+    )
+
+    assert response.status_code == 200
+    assert captured["timeout"] == 7.5
+
+
+def test_probe_modal_worker_bounds_dispatch_with_timeout(monkeypatch):
+    captured = {}
+    _install_fake_modal_with_spawn(
+        monkeypatch,
+        captured,
+        result={"status_code": 200, "body": b"OK", "headers": []},
+    )
+
+    probe_modal_worker("modal-current", timeout_seconds=2.5)
+
+    assert captured["timeout"] == 2.5
+
+
+def test_probe_modal_canary_bounds_dispatch_with_timeout(monkeypatch):
+    captured = {}
+    _install_fake_modal_with_spawn(monkeypatch, captured, result={"ok": True})
+
+    probe_modal_canary(timeout_seconds=3.0)
+
+    assert captured["timeout"] == 3.0
 
 
 def test_unknown_exact_package_version_returns_unprocessable_entity():

--- a/tests/unit/failover/test_cloud_run_gateway.py
+++ b/tests/unit/failover/test_cloud_run_gateway.py
@@ -1,3 +1,4 @@
+import asyncio
 import concurrent.futures
 import json
 import sys
@@ -720,14 +721,52 @@ def test_probe_modal_canary_uses_configured_modal_app(monkeypatch):
     }
 
 
-def _install_fake_modal_with_spawn(monkeypatch, captured, *, result):
+def _install_fake_modal_with_spawn(
+    monkeypatch,
+    captured,
+    *,
+    result,
+    hang_spawn=False,
+):
     class NotFoundError(Exception):
         pass
 
+    class SyncAsyncCallable:
+        def __init__(self, sync_callback, async_callback=None):
+            self._sync_callback = sync_callback
+            self._async_callback = async_callback
+
+        def __call__(self, *args, **kwargs):
+            return self._sync_callback(*args, **kwargs)
+
+        async def aio(self, *args, **kwargs):
+            if self._async_callback is not None:
+                return await self._async_callback(*args, **kwargs)
+            return self._sync_callback(*args, **kwargs)
+
     def _spawn_handle():
         return types.SimpleNamespace(
-            get=lambda timeout=None: (
-                captured.__setitem__("timeout", timeout) or result
+            get=SyncAsyncCallable(
+                lambda timeout=None: (
+                    captured.__setitem__("timeout", timeout) or result
+                )
+            )
+        )
+
+    async def _spawn_async(*_args):
+        captured["spawn_started"] = True
+        if hang_spawn:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                captured["spawn_cancelled"] = True
+        return _spawn_handle()
+
+    def _modal_method():
+        return types.SimpleNamespace(
+            spawn=SyncAsyncCallable(
+                lambda *_args: _spawn_handle(),
+                _spawn_async,
             )
         )
 
@@ -737,9 +776,7 @@ def _install_fake_modal_with_spawn(monkeypatch, captured, *, result):
             class FakeWorkerClass:
                 def __call__(self):
                     return types.SimpleNamespace(
-                        handle_household_request=types.SimpleNamespace(
-                            spawn=lambda payload: _spawn_handle()
-                        )
+                        handle_household_request=_modal_method()
                     )
 
             return FakeWorkerClass()
@@ -747,7 +784,7 @@ def _install_fake_modal_with_spawn(monkeypatch, captured, *, result):
     class FakeModalFunction:
         @staticmethod
         def from_name(app_name, object_name, **kwargs):
-            return types.SimpleNamespace(spawn=lambda: _spawn_handle())
+            return _modal_method()
 
     monkeypatch.setenv("MODAL_ENVIRONMENT", "testing")
     monkeypatch.setitem(
@@ -805,6 +842,45 @@ def test_probe_modal_canary_bounds_dispatch_with_timeout(monkeypatch):
     probe_modal_canary(timeout_seconds=3.0)
 
     assert captured["timeout"] == 3.0
+
+
+def test_call_modal_worker_cancels_hung_spawn_and_releases_executor_slot(
+    monkeypatch,
+):
+    captured = {}
+    _install_fake_modal_with_spawn(
+        monkeypatch,
+        captured,
+        result={"status_code": 200, "body": b"OK", "headers": []},
+        hang_spawn=True,
+    )
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    semaphore = threading.BoundedSemaphore(1)
+
+    try:
+        with pytest.raises(ModalBackendUnavailable):
+            _run_modal_operation(
+                lambda: call_modal_worker(
+                    "modal-current",
+                    {
+                        "method": "GET",
+                        "path": "/liveness_check",
+                        "query_string": "",
+                        "headers": {},
+                        "body": b"",
+                    },
+                    timeout_seconds=0.01,
+                ),
+                timeout_seconds=0.5,
+                executor=executor,
+                semaphore=semaphore,
+            )
+
+        assert captured["spawn_started"] is True
+        assert captured["spawn_cancelled"] is True
+        assert semaphore.acquire(blocking=False) is True
+    finally:
+        executor.shutdown(wait=True)
 
 
 def test_unknown_exact_package_version_returns_unprocessable_entity():


### PR DESCRIPTION
Fixes #1633

## Summary

During the 2026-07-21 production outage, Modal control-plane dispatches from the gateway black-holed: each hung call blocked its executor thread past the 90s request timeout, `future.cancel()` could not stop the running thread, and the semaphore permit (released only on completion) never came back. 32 hung dispatches exhausted `MODAL_EXECUTOR_MAX_WORKERS` and the gateway then 503'd every request instantly (`modal_executor_saturated`) without attempting Modal. See #1633 for the full incident analysis.

This PR passes the gateway's already-resolved deadlines into the Modal SDK calls themselves, so a hung dispatch frees its thread when the deadline expires instead of leaking it until process restart:

- `call_modal_worker`, `probe_modal_worker`, and `_call_modal_worker_dispatch` accept `timeout_seconds` and forward it to `call_modal_worker_dispatch`, which already supports bounding via `spawn(payload).get(timeout=...)` (previously the gateway never passed it, so the dispatch used unbounded `.remote()`).
- `probe_modal_canary` accepts `timeout_seconds` and uses `spawn().get(timeout=...)` when set.
- `create_gateway_app` binds the resolved `request_timeout` / `probe_timeout` / `canary_timeout` into the default callables. Injected fakes (`modal_request=`, `modal_health_probe=`, `modal_canary_probe=`) are unaffected.

All new parameters are keyword-only with `None` defaults, preserving existing call sites and test fakes.

## Scope notes

- The inner deadline equals the outer `_run_modal_operation` wait, so client-facing 503 timing is unchanged; the fix is that the executor thread now also unblocks.
- A hang inside the Modal function *lookup* (before `spawn`) can still block a thread; the circuit-breaker and connection-recycling follow-ups in #1633 cover that residual risk.
- `libs/household-common/gateway.py` (the Modal-hosted gateway) still dispatches without a deadline; out of scope here, noted in #1633.

## Test plan

- [x] Three new unit tests assert the timeout reaches the Modal SDK call for dispatch, worker probe, and canary paths (`spawn().get(timeout=...)` fakes)
- [x] `make format-check` passes (193 files)
- [x] `make test` passes: 714 passed, 1 skipped
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
