### PR TITLE
Reduce Modal worker concurrency to 2/1

### DIFF
--- a/changelog.d/1644.changed.md
+++ b/changelog.d/1644.changed.md
@@ -1,0 +1,1 @@
+Reduce Modal worker input concurrency so simultaneous household calculations spread across more containers and have lower tail latency under load.

--- a/projects/modal-api/policyengine_household_modal/worker_app.py
+++ b/projects/modal-api/policyengine_household_modal/worker_app.py
@@ -57,7 +57,7 @@ def worker_function_options(
         # Reserve a 1-core CPU floor. Modal guarantees only 0.125 cores by
         # default (the rest is best-effort burst), so a container running
         # several heavy household calculates concurrently (input concurrency up
-        # to 3) starves and exceeds the execution budget -> the gateway returns
+        # to 2) starves and exceeds the execution budget -> the gateway returns
         # 503 backend_unavailable. This surfaced on the Amplifi household
         # against Cloud Run staging, which keeps no warm workers. 1.0 is a
         # cost-balanced floor vs the 2.0 dropped in #1610; raise toward 2.0 if
@@ -79,7 +79,7 @@ def worker_function_options(
 
 
 def worker_concurrency_options() -> dict[str, int]:
-    return {"max_inputs": 3, "target_inputs": 2}
+    return {"max_inputs": 2, "target_inputs": 1}
 
 
 def reset_post_snapshot_process_state(flask_app) -> None:

--- a/tests/unit/modal_release/test_worker_app.py
+++ b/tests/unit/modal_release/test_worker_app.py
@@ -130,15 +130,15 @@ def test_worker_concurrency_options_set_max_inputs(worker_app):
     """Heavy customer calculates cost 12-50 CPU-seconds each; a low input
     concurrency cap bounds in-container contention and limits the
     collateral of Modal's cancel-shuts-down-the-container semantics
-    (issue #1609)."""
-    assert worker_app.worker_concurrency_options()["max_inputs"] == 3
+    (issue #1644)."""
+    assert worker_app.worker_concurrency_options()["max_inputs"] == 2
 
 
 def test_worker_concurrency_options_set_target_inputs(worker_app):
     """A low autoscale target adds capacity before containers saturate,
     so simultaneous heavy requests spread across containers instead of
-    piling onto one (issue #1609)."""
-    assert worker_app.worker_concurrency_options()["target_inputs"] == 2
+    piling onto one (issue #1644)."""
+    assert worker_app.worker_concurrency_options()["target_inputs"] == 1
 
 
 def test_worker_function_options_reserve_cpu(worker_app):


### PR DESCRIPTION
Fixes #1644

## Modal Version Release

No release configuration block is needed. This is a code-only worker configuration change and does not change the current/frontier manifest or country-package versions.

## Summary

- reduce Modal worker concurrency from `max_inputs=3, target_inputs=2` to `max_inputs=2, target_inputs=1`
- update focused unit expectations and the concurrency rationale
- add a Towncrier changelog fragment

Each worker reserves one CPU. Allowing up to three simultaneous calculations on that CPU creates contention during concurrent traffic, while a target of two delays scale-out. The lower limits make Modal spread concurrent calculations across more containers.

In the isolated A/B benchmark, the 25-request burst improved from 13.47s to 8.09s at p95 and from 16.80s to 9.30s at max latency. Throughput increased from 2.27 to 3.43 requests/second. The tradeoff is greater container use and therefore potentially higher dynamic Modal cost during concurrent load.

## Testing

- `make format-check`
- `uv run pytest tests/unit/modal_release/test_worker_app.py -q` — 17 passed
- `make test` — 713 passed and 1 skipped; three environment-sensitive tests failed under sandboxed localhost/network permissions
- reran those three tests with normal host permissions — 3 passed
- `uv run towncrier build --draft --version 0.0.0`
- `make test-with-auth` not run locally because the required Auth0 variables are unavailable; rely on PR CI for that lane
