### PR TITLE
Send explicit hours in SNAP parity test fixture

### DIFF
--- a/changelog.d/1654.fixed.md
+++ b/changelog.d/1654.fixed.md
@@ -1,0 +1,1 @@
+Send explicit `weekly_hours_worked_before_lsr` in the SNAP parity test fixture so it keeps modelling an eligible adult after policyengine-us dropped the 40-hour default.

--- a/tests/unit/test_normalize_period_keys.py
+++ b/tests/unit/test_normalize_period_keys.py
@@ -532,7 +532,16 @@ def _wa_household(income_map, output_key):
     """Build a single-person WA SNAP household with a configurable
     ``snap_gross_income`` input map + ``snap`` output request."""
     return {
-        "people": {"person_1": {"age": {"2026": 34}, "rent": {"2026": 10800}}},
+        "people": {
+            "person_1": {
+                "age": {"2026": 34},
+                "rent": {"2026": 10800},
+                # As of policyengine-us 1.815.1, weekly_hours_worked_before_lsr
+                # no longer defaults to 40; send it so this adult passes the
+                # ABAWD test and the v1-parity numbers below still hold.
+                "weekly_hours_worked_before_lsr": {"2026": 40},
+            }
+        },
         "tax_units": {"tax_unit_1": {"members": ["person_1"]}},
         "spm_units": {
             "spm_unit_1": {


### PR DESCRIPTION
Fixes #1654

## Summary

`TestSnapInputOutputMatrix` builds a single 34-year-old childless adult in WA without hours. policyengine-us 1.794.3+ (arriving in #1653 as 1.815.1) drops the 40-hour default on `weekly_hours_worked_before_lsr`, so that adult now fails the ABAWD test and `snap` returns $298 / $0 instead of the pinned v1-parity amounts — 4 of 9 parametrized rows fail on #1653.

This sends `weekly_hours_worked_before_lsr: 40` in the fixture so it keeps modelling an eligible adult. The pinned expected values are unchanged.

## Why a separate PR

The fixture change is independent of the version bump: with explicit hours the class passes on both 1.794.2 (`main`) and 1.815.1. Landing it on `main` first means the weekly bot branch — which is regenerated each week — doesn't need to carry a hand-applied fix. #1653 should merge `main` after this lands.

## Test plan

- [x] `make format-check` — 197 files already formatted
- [x] `uv run pytest tests/unit/test_normalize_period_keys.py -k TestSnapInputOutputMatrix` on 1.794.2 — 11 passed
- [x] Same class verified against 1.815.0 in a scratch venv — explicit 40 hours reproduces $3,607.57 exactly
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)